### PR TITLE
feat: add MQTT subscriber and event logging on berth state change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  backend-pytest:
+    name: Backend pytest
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: dockpulse
+          POSTGRES_PASSWORD: dockpulse
+          POSTGRES_DB: dockpulse_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    env:
+      TEST_DATABASE_URL: postgresql+asyncpg://dockpulse:dockpulse@localhost:5432/dockpulse_test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --all-groups
+      - run: uv run pytest -v

--- a/backend/alembic/versions/ebf9af948b5b_align_seed_to_harbor_map.py
+++ b/backend/alembic/versions/ebf9af948b5b_align_seed_to_harbor_map.py
@@ -1,0 +1,61 @@
+"""align seed data with harbor map (12 berths)
+
+Revision ID: ebf9af948b5b
+Revises: 143e62cd073b
+Create Date: 2026-04-20
+
+Replaces the 5 placeholder berths from the prior seed with 12 positional
+berths matching the SVG harbor map in frontend/src/svg.ts: 4 top berths
+along the horizontal pier, plus 4 left + 4 right along the vertical pier.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "ebf9af948b5b"
+down_revision: str | Sequence[str] | None = "143e62cd073b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+DOCK_ID = "ksss-saltsjobaden-pier-1"
+
+BERTH_POSITIONS = (
+    [("t", i) for i in range(1, 5)]
+    + [("l", i) for i in range(1, 5)]
+    + [("r", i) for i in range(1, 5)]
+)
+
+
+def _berth_id(side: str, idx: int) -> str:
+    return f"{DOCK_ID}-{side}{idx}"
+
+
+def upgrade() -> None:
+    # Remove legacy B1–B5 placeholder seed.
+    op.execute(
+        sa.text("DELETE FROM berths WHERE dock_id = :dock").bindparams(dock=DOCK_ID)
+    )
+    for side, idx in BERTH_POSITIONS:
+        op.execute(
+            sa.text(
+                "INSERT INTO berths "
+                "(berth_id, dock_id, label, length_m, width_m, depth_m, status) "
+                "VALUES (:id, :dock, :label, 12.0, 4.0, 3.0, 'free')"
+            ).bindparams(
+                id=_berth_id(side, idx),
+                dock=DOCK_ID,
+                label=f"{side.upper()}{idx}",
+            )
+        )
+
+
+def downgrade() -> None:
+    for side, idx in BERTH_POSITIONS:
+        op.execute(
+            sa.text("DELETE FROM berths WHERE berth_id = :id").bindparams(
+                id=_berth_id(side, idx)
+            )
+        )

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -1,0 +1,52 @@
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Berth, Event
+
+
+async def process_sensor_reading(
+    session: AsyncSession,
+    *,
+    berth_id: str,
+    node_id: str,
+    status: str,
+    sensor_raw: int,
+) -> Event | None:
+    """Process a sensor reading and create an event if the berth state changed.
+
+    Returns the new Event on state change, or None if status is unchanged.
+    """
+    if status not in ("free", "occupied"):
+        raise ValueError(f"Invalid status: {status}")
+
+    berth = await session.get(Berth, berth_id)
+    if berth is None:
+        raise ValueError(f"Unknown berth: {berth_id}")
+
+    now = datetime.now(UTC)
+
+    # Always update sensor telemetry on the berth
+    berth.sensor_raw = sensor_raw
+    berth.last_updated = now
+
+    # Only log an event when the status actually changes
+    if status == berth.status:
+        await session.commit()
+        return None
+
+    event_type = "occupied" if status == "occupied" else "freed"
+    event = Event(
+        event_id=str(uuid.uuid4()),
+        berth_id=berth_id,
+        node_id=node_id,
+        event_type=event_type,
+        sensor_raw=sensor_raw,
+        timestamp=now,
+    )
+
+    berth.status = status
+    session.add(event)
+    await session.commit()
+    return event

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -11,42 +11,52 @@ async def process_sensor_reading(
     *,
     berth_id: str,
     node_id: str,
-    status: str,
+    occupied: bool,
     sensor_raw: int,
+    battery_pct: int | None = None,
 ) -> Event | None:
-    """Process a sensor reading and create an event if the berth state changed.
-
-    Returns the new Event on state change, or None if status is unchanged.
-    """
-    if status not in ("free", "occupied"):
-        raise ValueError(f"Invalid status: {status}")
-
+    """Persist a berth status reading. Return a new Event on state change."""
     berth = await session.get(Berth, berth_id)
     if berth is None:
         raise ValueError(f"Unknown berth: {berth_id}")
 
     now = datetime.now(UTC)
+    new_status = "occupied" if occupied else "free"
 
-    # Always update sensor telemetry on the berth
     berth.sensor_raw = sensor_raw
     berth.last_updated = now
+    if battery_pct is not None:
+        berth.battery_pct = battery_pct
 
-    # Only log an event when the status actually changes
-    if status == berth.status:
+    if new_status == berth.status:
         await session.commit()
         return None
 
-    event_type = "occupied" if status == "occupied" else "freed"
     event = Event(
         event_id=str(uuid.uuid4()),
         berth_id=berth_id,
         node_id=node_id,
-        event_type=event_type,
+        event_type="occupied" if occupied else "freed",
         sensor_raw=sensor_raw,
         timestamp=now,
     )
-
-    berth.status = status
+    berth.status = new_status
     session.add(event)
     await session.commit()
     return event
+
+
+async def process_heartbeat(
+    session: AsyncSession,
+    *,
+    berth_id: str,
+    battery_pct: int | None = None,
+) -> None:
+    """Touch berth liveness from a heartbeat; no Event row written."""
+    berth = await session.get(Berth, berth_id)
+    if berth is None:
+        raise ValueError(f"Unknown berth: {berth_id}")
+    berth.last_updated = datetime.now(UTC)
+    if battery_pct is not None:
+        berth.battery_pct = battery_pct
+    await session.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,17 +1,33 @@
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import yaml
 from fastapi import FastAPI
 
+from app.mqtt import mqtt_listener
 from app.routers import berths
 
 SPEC_PATH = Path(__file__).parents[2] / "docs" / "api" / "openapi.yml"
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    task = asyncio.create_task(mqtt_listener())
+    yield
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
 
 app = FastAPI(
     title="DockPulse API",
     version="0.1.0",
     docs_url="/docs",
     redoc_url="/redoc",
+    lifespan=lifespan,
 )
 
 app.include_router(berths.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -62,7 +62,9 @@ class Event(Base):
 
     event_id: Mapped[str] = mapped_column(String, primary_key=True)
     berth_id: Mapped[str] = mapped_column(ForeignKey("berths.berth_id"), nullable=False)
+    node_id: Mapped[str] = mapped_column(String, nullable=False)
     event_type: Mapped[str] = mapped_column(event_type_enum, nullable=False)
+    sensor_raw: Mapped[int] = mapped_column(Integer, nullable=False)
     timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
     berth: Mapped["Berth"] = relationship(back_populates="events")

--- a/backend/app/mqtt.py
+++ b/backend/app/mqtt.py
@@ -4,26 +4,75 @@ import logging
 import os
 
 import aiomqtt
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import async_session
-from app.events import process_sensor_reading
+from app.events import process_heartbeat, process_sensor_reading
 
 logger = logging.getLogger(__name__)
 
 MQTT_BROKER = os.environ.get("MQTT_BROKER", "localhost")
 MQTT_PORT = int(os.environ.get("MQTT_PORT", "1883"))
-TOPIC = "dockpulse/+/+/status"
+STATUS_TOPIC = "harbor/+/+/+/status"
+HEARTBEAT_TOPIC = "harbor/+/+/+/heartbeat"
 RECONNECT_DELAY = 5
 
 
-async def _handle_message(message: aiomqtt.Message) -> None:
-    parts = message.topic.value.split("/")
-    if len(parts) != 4:
-        logger.warning("Unexpected topic format: %s", message.topic.value)
+def _parse_berth_topic(topic: str) -> tuple[str, str, str, str] | None:
+    parts = topic.split("/")
+    # Contract: harbor/{harbor_id}/{dock_id}/{berth_id}/{kind}
+    # Gateway topics share the wildcard; skip them here.
+    if len(parts) != 5 or parts[0] != "harbor" or parts[2] == "gateway":
+        return None
+    return parts[1], parts[2], parts[3], parts[4]
+
+
+async def _handle_status(session: AsyncSession, payload: dict, berth_id: str) -> None:
+    node_id = payload.get("node_id")
+    occupied = payload.get("occupied")
+    sensor_raw = payload.get("sensor_raw")
+    if node_id is None or occupied is None or sensor_raw is None:
+        logger.warning("status payload missing fields for berth %s", berth_id)
         return
 
-    node_id = parts[1]
-    berth_id = parts[2]
+    try:
+        event = await process_sensor_reading(
+            session,
+            berth_id=berth_id,
+            node_id=node_id,
+            occupied=bool(occupied),
+            sensor_raw=int(sensor_raw),
+            battery_pct=payload.get("battery_pct"),
+        )
+        if event:
+            logger.info(
+                "State change: berth %s -> %s (node=%s)",
+                berth_id,
+                event.event_type,
+                node_id,
+            )
+    except ValueError as e:
+        logger.warning("%s", e)
+
+
+async def _handle_heartbeat(
+    session: AsyncSession, payload: dict, berth_id: str
+) -> None:
+    try:
+        await process_heartbeat(
+            session,
+            berth_id=berth_id,
+            battery_pct=payload.get("battery_pct"),
+        )
+    except ValueError as e:
+        logger.warning("%s", e)
+
+
+async def _handle_message(message: aiomqtt.Message) -> None:
+    parsed = _parse_berth_topic(message.topic.value)
+    if parsed is None:
+        return
+    _, _, berth_id, kind = parsed
 
     try:
         payload = json.loads(message.payload)
@@ -31,31 +80,11 @@ async def _handle_message(message: aiomqtt.Message) -> None:
         logger.warning("Invalid JSON payload on %s", message.topic.value)
         return
 
-    status = payload.get("status")
-    sensor_raw = payload.get("sensor_raw")
-    if status is None or sensor_raw is None:
-        logger.warning("Missing status or sensor_raw on %s", message.topic.value)
-        return
-
     async with async_session() as session:
-        try:
-            event = await process_sensor_reading(
-                session,
-                berth_id=berth_id,
-                node_id=node_id,
-                status=status,
-                sensor_raw=int(sensor_raw),
-            )
-            if event:
-                logger.info(
-                    "State change: berth %s -> %s (node=%s, raw=%d)",
-                    berth_id,
-                    event.event_type,
-                    node_id,
-                    sensor_raw,
-                )
-        except ValueError as e:
-            logger.warning("%s (node=%s)", e, node_id)
+        if kind == "status":
+            await _handle_status(session, payload, berth_id)
+        elif kind == "heartbeat":
+            await _handle_heartbeat(session, payload, berth_id)
 
 
 async def mqtt_listener() -> None:
@@ -63,7 +92,8 @@ async def mqtt_listener() -> None:
         try:
             async with aiomqtt.Client(MQTT_BROKER, MQTT_PORT) as client:
                 logger.info("Connected to MQTT broker %s:%s", MQTT_BROKER, MQTT_PORT)
-                await client.subscribe(TOPIC)
+                await client.subscribe(STATUS_TOPIC)
+                await client.subscribe(HEARTBEAT_TOPIC)
                 async for message in client.messages:
                     await _handle_message(message)
         except aiomqtt.MqttError as e:

--- a/backend/app/mqtt.py
+++ b/backend/app/mqtt.py
@@ -1,0 +1,75 @@
+import asyncio
+import json
+import logging
+import os
+
+import aiomqtt
+
+from app.db import async_session
+from app.events import process_sensor_reading
+
+logger = logging.getLogger(__name__)
+
+MQTT_BROKER = os.environ.get("MQTT_BROKER", "localhost")
+MQTT_PORT = int(os.environ.get("MQTT_PORT", "1883"))
+TOPIC = "dockpulse/+/+/status"
+RECONNECT_DELAY = 5
+
+
+async def _handle_message(message: aiomqtt.Message) -> None:
+    parts = message.topic.value.split("/")
+    if len(parts) != 4:
+        logger.warning("Unexpected topic format: %s", message.topic.value)
+        return
+
+    node_id = parts[1]
+    berth_id = parts[2]
+
+    try:
+        payload = json.loads(message.payload)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Invalid JSON payload on %s", message.topic.value)
+        return
+
+    status = payload.get("status")
+    sensor_raw = payload.get("sensor_raw")
+    if status is None or sensor_raw is None:
+        logger.warning("Missing status or sensor_raw on %s", message.topic.value)
+        return
+
+    async with async_session() as session:
+        try:
+            event = await process_sensor_reading(
+                session,
+                berth_id=berth_id,
+                node_id=node_id,
+                status=status,
+                sensor_raw=int(sensor_raw),
+            )
+            if event:
+                logger.info(
+                    "State change: berth %s -> %s (node=%s, raw=%d)",
+                    berth_id,
+                    event.event_type,
+                    node_id,
+                    sensor_raw,
+                )
+        except ValueError as e:
+            logger.warning("%s (node=%s)", e, node_id)
+
+
+async def mqtt_listener() -> None:
+    while True:
+        try:
+            async with aiomqtt.Client(MQTT_BROKER, MQTT_PORT) as client:
+                logger.info("Connected to MQTT broker %s:%s", MQTT_BROKER, MQTT_PORT)
+                await client.subscribe(TOPIC)
+                async for message in client.messages:
+                    await _handle_message(message)
+        except aiomqtt.MqttError as e:
+            logger.warning(
+                "MQTT connection lost (%s), reconnecting in %ds...",
+                e,
+                RECONNECT_DELAY,
+            )
+            await asyncio.sleep(RECONNECT_DELAY)

--- a/backend/app/routers/berths.py
+++ b/backend/app/routers/berths.py
@@ -20,7 +20,7 @@ async def get_berth(berth_id: str, session: sessiondep):
     return berth
 
 
-@router.get("", response_model=list[BerthOut], operation_id="getBerth")
+@router.get("", response_model=list[BerthOut], operation_id="listBerths")
 async def list_berths(
     session: sessiondep,
     dock_id: str | None = Query(None, description="filter by dock"),

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,7 +14,20 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["pytest>=9.0", "httpx>=0.28", "schemathesis>=4.15", "ruff>=0.11", "pre-commit>=4.5"]
+dev = [
+  "pytest>=9.0",
+  "pytest-asyncio>=0.25",
+  "httpx>=0.28",
+  "schemathesis>=4.15",
+  "ruff>=0.11",
+  "pre-commit>=4.5",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
+testpaths = ["tests"]
 
 [tool.ruff]
 target-version = "py312"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 asyncio_default_test_loop_scope = "session"
+pythonpath = ["."]
 testpaths = ["tests"]
 
 [tool.ruff]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,63 @@
+import os
+from collections.abc import AsyncIterator
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.db import Base, get_session
+from app.main import app
+from app.models import Berth, Dock, Harbor
+
+TEST_DATABASE_URL = os.environ.get(
+    "TEST_DATABASE_URL",
+    "postgresql+asyncpg://dockpulse:dockpulse@localhost:5432/dockpulse_test",
+)
+
+
+@pytest_asyncio.fixture(scope="session")
+async def engine():
+    eng = create_async_engine(TEST_DATABASE_URL)
+    async with eng.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield eng
+    finally:
+        await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def session(engine) -> AsyncIterator[AsyncSession]:
+    """Clean DB between tests by truncating all tables."""
+    test_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with test_session() as sess:
+        yield sess
+    async with engine.begin() as conn:
+        for table in reversed(Base.metadata.sorted_tables):
+            await conn.execute(table.delete())
+
+
+@pytest_asyncio.fixture
+async def seeded_berth(session: AsyncSession):
+    session.add_all(
+        [
+            Harbor(harbor_id="h1", name="Harbor 1"),
+            Dock(dock_id="d1", harbor_id="h1", name="Dock 1"),
+            Berth(berth_id="b1", dock_id="d1", status="free"),
+        ]
+    )
+    await session.commit()
+
+
+@pytest_asyncio.fixture
+async def client(session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield session
+
+    app.dependency_overrides[get_session] = _override
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()

--- a/backend/tests/test_berths_api.py
+++ b/backend/tests/test_berths_api.py
@@ -1,0 +1,40 @@
+from app.events import process_sensor_reading
+
+
+async def test_api_reflects_mqtt_reading(client, session, seeded_berth):
+    await process_sensor_reading(
+        session,
+        berth_id="b1",
+        node_id="n1",
+        occupied=True,
+        sensor_raw=500,
+        battery_pct=80,
+    )
+
+    r = await client.get("/api/berths/b1")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["berth_id"] == "b1"
+    assert data["status"] == "occupied"
+    assert data["sensor_raw"] == 500
+    assert data["battery_pct"] == 80
+    assert data["last_updated"] is not None
+
+
+async def test_api_filter_by_status(client, session, seeded_berth):
+    await process_sensor_reading(
+        session, berth_id="b1", node_id="n1", occupied=True, sensor_raw=500
+    )
+
+    r_occupied = await client.get("/api/berths?status=occupied")
+    assert r_occupied.status_code == 200
+    assert [b["berth_id"] for b in r_occupied.json()] == ["b1"]
+
+    r_free = await client.get("/api/berths?status=free")
+    assert r_free.status_code == 200
+    assert r_free.json() == []
+
+
+async def test_api_unknown_berth_404(client):
+    r = await client.get("/api/berths/does-not-exist")
+    assert r.status_code == 404

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -1,0 +1,95 @@
+import pytest
+from sqlalchemy import select
+
+from app.events import process_heartbeat, process_sensor_reading
+from app.models import Berth, Event
+
+
+async def test_state_change_creates_event(session, seeded_berth):
+    event = await process_sensor_reading(
+        session,
+        berth_id="b1",
+        node_id="n1",
+        occupied=True,
+        sensor_raw=500,
+        battery_pct=80,
+    )
+    assert event is not None
+    assert event.event_type == "occupied"
+    assert event.node_id == "n1"
+    assert event.sensor_raw == 500
+
+    berth = await session.get(Berth, "b1")
+    assert berth.status == "occupied"
+    assert berth.sensor_raw == 500
+    assert berth.battery_pct == 80
+    assert berth.last_updated is not None
+
+
+async def test_same_status_returns_none_but_updates_telemetry(session, seeded_berth):
+    event = await process_sensor_reading(
+        session,
+        berth_id="b1",
+        node_id="n1",
+        occupied=False,
+        sensor_raw=100,
+        battery_pct=55,
+    )
+    assert event is None
+
+    berth = await session.get(Berth, "b1")
+    assert berth.status == "free"
+    assert berth.sensor_raw == 100
+    assert berth.battery_pct == 55
+    assert berth.last_updated is not None
+
+    events = (await session.execute(select(Event))).scalars().all()
+    assert events == []
+
+
+async def test_toggle_creates_two_events(session, seeded_berth):
+    await process_sensor_reading(
+        session, berth_id="b1", node_id="n1", occupied=True, sensor_raw=500
+    )
+    await process_sensor_reading(
+        session, berth_id="b1", node_id="n1", occupied=False, sensor_raw=100
+    )
+    events = (
+        (await session.execute(select(Event).order_by(Event.timestamp))).scalars().all()
+    )
+    assert [e.event_type for e in events] == ["occupied", "freed"]
+
+
+async def test_unknown_berth_raises(session):
+    with pytest.raises(ValueError, match="Unknown berth"):
+        await process_sensor_reading(
+            session,
+            berth_id="does-not-exist",
+            node_id="n1",
+            occupied=True,
+            sensor_raw=0,
+        )
+
+
+async def test_battery_pct_optional(session, seeded_berth):
+    await process_sensor_reading(
+        session, berth_id="b1", node_id="n1", occupied=True, sensor_raw=500
+    )
+    berth = await session.get(Berth, "b1")
+    assert berth.battery_pct is None
+
+
+async def test_heartbeat_touches_berth_without_event(session, seeded_berth):
+    await process_heartbeat(session, berth_id="b1", battery_pct=42)
+
+    berth = await session.get(Berth, "b1")
+    assert berth.battery_pct == 42
+    assert berth.last_updated is not None
+
+    events = (await session.execute(select(Event))).scalars().all()
+    assert events == []
+
+
+async def test_heartbeat_unknown_berth_raises(session):
+    with pytest.raises(ValueError, match="Unknown berth"):
+        await process_heartbeat(session, berth_id="does-not-exist")

--- a/backend/tests/test_mqtt_dispatch.py
+++ b/backend/tests/test_mqtt_dispatch.py
@@ -1,0 +1,55 @@
+from sqlalchemy import select
+
+from app.models import Berth, Event
+from app.mqtt import _handle_heartbeat, _handle_status
+
+
+async def test_status_handler_persists_reading(session, seeded_berth):
+    payload = {
+        "node_id": "n1",
+        "berth_id": "b1",
+        "occupied": True,
+        "sensor_raw": 500,
+        "battery_pct": 80,
+        "timestamp": "2026-04-20T12:00:00Z",
+    }
+    await _handle_status(session, payload, "b1")
+
+    berth = await session.get(Berth, "b1")
+    assert berth.status == "occupied"
+    assert berth.sensor_raw == 500
+    assert berth.battery_pct == 80
+
+    events = (await session.execute(select(Event))).scalars().all()
+    assert len(events) == 1
+
+
+async def test_status_handler_skips_on_missing_fields(session, seeded_berth):
+    # missing `occupied`
+    await _handle_status(session, {"node_id": "n1", "sensor_raw": 500}, "b1")
+    berth = await session.get(Berth, "b1")
+    assert berth.status == "free"
+    assert berth.sensor_raw is None
+
+
+async def test_status_handler_skips_unknown_berth(session):
+    # no seeded_berth fixture — berth "b1" doesn't exist
+    payload = {
+        "node_id": "n1",
+        "occupied": True,
+        "sensor_raw": 500,
+    }
+    # Should not raise; ValueError is logged and swallowed.
+    await _handle_status(session, payload, "b1")
+
+
+async def test_heartbeat_handler_persists_battery(session, seeded_berth):
+    await _handle_heartbeat(session, {"battery_pct": 73}, "b1")
+    berth = await session.get(Berth, "b1")
+    assert berth.battery_pct == 73
+    assert berth.last_updated is not None
+
+
+async def test_heartbeat_handler_skips_unknown_berth(session):
+    # Should not raise.
+    await _handle_heartbeat(session, {"battery_pct": 50}, "b1")

--- a/backend/tests/test_mqtt_parsing.py
+++ b/backend/tests/test_mqtt_parsing.py
@@ -1,0 +1,35 @@
+from app.mqtt import _parse_berth_topic
+
+
+def test_parse_status_topic():
+    assert _parse_berth_topic("harbor/main/dock-a/berth-001/status") == (
+        "main",
+        "dock-a",
+        "berth-001",
+        "status",
+    )
+
+
+def test_parse_heartbeat_topic():
+    assert _parse_berth_topic("harbor/main/dock-a/berth-001/heartbeat") == (
+        "main",
+        "dock-a",
+        "berth-001",
+        "heartbeat",
+    )
+
+
+def test_skip_gateway_topic():
+    assert _parse_berth_topic("harbor/main/gateway/gw-1/status") is None
+
+
+def test_wrong_prefix():
+    assert _parse_berth_topic("dockpulse/main/dock-a/berth-001/status") is None
+
+
+def test_too_few_segments():
+    assert _parse_berth_topic("harbor/main/dock-a/status") is None
+
+
+def test_too_many_segments():
+    assert _parse_berth_topic("harbor/main/dock-a/berth-001/extra/status") is None

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -249,6 +249,7 @@ dev = [
     { name = "httpx" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "schemathesis" },
 ]
@@ -270,6 +271,7 @@ dev = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "pre-commit", specifier = ">=4.5" },
     { name = "pytest", specifier = ">=9.0" },
+    { name = "pytest-asyncio", specifier = ">=0.25" },
     { name = "ruff", specifier = ">=0.11" },
     { name = "schemathesis", specifier = ">=4.15" },
 ]
@@ -840,6 +842,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -11,5 +11,7 @@ services:
     command: sh -c "uv run alembic upgrade head && uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
     volumes:
       - ./docs:/docs
+      - ./backend/app:/app/app
+      - ./backend/alembic:/app/alembic
     ports:
       - "8000:8000"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -29,50 +29,16 @@ services:
         condition: service_started
     networks: [internal]
 
-  fake-publisher-b1:
-    container_name: dockpulse-staging-fake-publisher-b1
+  fake-publisher:
+    container_name: dockpulse-staging-fake-publisher
     image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
     restart: unless-stopped
     command: >
       uv run /tools/fake_publisher.py
       --host mosquitto
-      --berth-id ksss-saltsjobaden-pier-1-b1
-      --rate 3
+      --all
+      --rate 10
       --status toggle
-    volumes:
-      - ./tools:/tools
-    depends_on:
-      mosquitto:
-        condition: service_started
-    networks: [internal]
-
-  fake-publisher-b2:
-    container_name: dockpulse-staging-fake-publisher-b2
-    image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
-    restart: unless-stopped
-    command: >
-      uv run /tools/fake_publisher.py
-      --host mosquitto
-      --berth-id ksss-saltsjobaden-pier-1-b2
-      --rate 10
-      --status occupied
-    volumes:
-      - ./tools:/tools
-    depends_on:
-      mosquitto:
-        condition: service_started
-    networks: [internal]
-
-  fake-publisher-b3:
-    container_name: dockpulse-staging-fake-publisher-b3
-    image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
-    restart: unless-stopped
-    command: >
-      uv run /tools/fake_publisher.py
-      --host mosquitto
-      --berth-id ksss-saltsjobaden-pier-1-b3
-      --rate 10
-      --status free
     volumes:
       - ./tools:/tools
     depends_on:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -376,15 +376,21 @@ components:
 
     Event:
       type: object
-      required: [event_id, berth_id, event_type, timestamp]
+      required: [event_id, berth_id, node_id, event_type, sensor_raw, timestamp]
       properties:
         event_id:
           type: string
         berth_id:
           type: string
+        node_id:
+          type: string
+          description: ID of the sensor node that triggered the event
         event_type:
           type: string
           enum: [occupied, freed, alert_unauthorized, heartbeat]
+        sensor_raw:
+          type: integer
+          description: Raw sensor value at time of event
         timestamp:
           type: string
           format: date-time

--- a/docs/db-diagram.md
+++ b/docs/db-diagram.md
@@ -35,7 +35,9 @@ erDiagram
     events {
         string event_id PK
         string berth_id FK
+        string node_id
         event_type event_type
+        int sensor_raw
         datetime timestamp
     }
 

--- a/tools/fake_publisher.py
+++ b/tools/fake_publisher.py
@@ -7,8 +7,10 @@
 # ///
 """Fake MQTT publisher for Sprint 1 demos.
 
-Publishes R3-contract-compliant berth status messages so the full stack
+Publishes contract-compliant berth status messages so the full stack
 can be tested end-to-end without real sensor hardware.
+
+Contract: II1302-8/.github docs/mqtt-contract.yml
 """
 
 import argparse
@@ -16,20 +18,32 @@ import json
 import random
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import paho.mqtt.client as mqtt
 
-TOPIC_PREFIX = "dockpulse/status"
+DEFAULT_HARBOR_ID = "ksss-saltsjobaden"
+DEFAULT_DOCK_ID = "ksss-saltsjobaden-pier-1"
+
+# Mirrors alembic seed migration ebf9af948b5b and the frontend harbor map.
+DEFAULT_BERTH_SUFFIXES = [
+    f"{side}{idx}" for side in ("t", "l", "r") for idx in range(1, 5)
+]
 
 
-def build_payload(berth_id: str, status: str) -> dict:
+def _node_id_for(berth_id: str) -> str:
+    # berth_id format: {dock_id}-{suffix}; take the last segment as node tag.
+    return f"node-{berth_id.rsplit('-', 1)[-1]}"
+
+
+def build_status_payload(node_id: str, berth_id: str, occupied: bool) -> dict:
     return {
+        "node_id": node_id,
         "berth_id": berth_id,
-        "status": status,
+        "occupied": occupied,
         "sensor_raw": random.randint(0, 1023),
         "battery_pct": random.randint(20, 100),
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.now(UTC).isoformat(),
     }
 
 
@@ -37,10 +51,22 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Publish fake berth status messages to the MQTT broker."
     )
+    parser.add_argument("--harbor-id", default=DEFAULT_HARBOR_ID)
+    parser.add_argument("--dock-id", default=DEFAULT_DOCK_ID)
     parser.add_argument(
         "--berth-id",
-        default="berth-001",
-        help="Berth identifier (default: berth-001)",
+        default=f"{DEFAULT_DOCK_ID}-{DEFAULT_BERTH_SUFFIXES[0]}",
+        help="Single berth to publish for (ignored when --all is set)",
+    )
+    parser.add_argument(
+        "--node-id",
+        default=None,
+        help="Node identifier. Derived from berth-id when omitted.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Publish for every berth on the seeded harbor map (12 berths)",
     )
     parser.add_argument(
         "--status",
@@ -69,14 +95,29 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--count",
         type=int,
         default=0,
-        help="Number of messages to send (0 = unlimited, default: 0)",
+        help="Number of ticks to send (0 = unlimited, default: 0)",
     )
     return parser.parse_args(argv)
 
 
+def _resolve_berths(args: argparse.Namespace) -> list[tuple[str, str]]:
+    """Return (berth_id, node_id) tuples to publish for each tick."""
+    if args.all:
+        return [
+            (f"{args.dock_id}-{suffix}", f"node-{suffix}")
+            for suffix in DEFAULT_BERTH_SUFFIXES
+        ]
+    node_id = args.node_id or _node_id_for(args.berth_id)
+    return [(args.berth_id, node_id)]
+
+
 def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
-    topic = f"{TOPIC_PREFIX}/{args.berth_id}"
+    berths = _resolve_berths(args)
+    states = {
+        berth_id: "free" if args.status == "toggle" else args.status
+        for berth_id, _ in berths
+    }
 
     client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
     try:
@@ -87,17 +128,24 @@ def main(argv: list[str] | None = None) -> None:
 
     client.loop_start()
     sent = 0
-    current_status = "free" if args.status == "toggle" else args.status
+    ticks = 0
     try:
         while True:
-            payload = build_payload(args.berth_id, current_status)
-            client.publish(topic, json.dumps(payload))
-            sent += 1
-            print(f"[{sent}] {topic} -> {json.dumps(payload)}")
-            if args.status == "toggle":
-                current_status = "free" if current_status == "occupied" else "occupied"
+            for berth_id, node_id in berths:
+                topic = (
+                    f"harbor/{args.harbor_id}/{args.dock_id}/{berth_id}/status"
+                )
+                current = states[berth_id]
+                occupied = current == "occupied"
+                payload = build_status_payload(node_id, berth_id, occupied)
+                client.publish(topic, json.dumps(payload), qos=1, retain=True)
+                sent += 1
+                print(f"[{sent}] {topic} -> {json.dumps(payload)}")
+                if args.status == "toggle":
+                    states[berth_id] = "free" if occupied else "occupied"
 
-            if args.count and sent >= args.count:
+            ticks += 1
+            if args.count and ticks >= args.count:
                 break
             time.sleep(args.rate)
     except KeyboardInterrupt:
@@ -105,7 +153,7 @@ def main(argv: list[str] | None = None) -> None:
     finally:
         client.loop_stop()
         client.disconnect()
-        print(f"\nDone. Sent {sent} message(s).")
+        print(f"\nDone. Sent {sent} message(s) across {ticks} tick(s).")
 
 
 if __name__ == "__main__":

--- a/tools/fake_publisher.py
+++ b/tools/fake_publisher.py
@@ -132,9 +132,7 @@ def main(argv: list[str] | None = None) -> None:
     try:
         while True:
             for berth_id, node_id in berths:
-                topic = (
-                    f"harbor/{args.harbor_id}/{args.dock_id}/{berth_id}/status"
-                )
+                topic = f"harbor/{args.harbor_id}/{args.dock_id}/{berth_id}/status"
                 current = states[berth_id]
                 occupied = current == "occupied"
                 payload = build_status_payload(node_id, berth_id, occupied)


### PR DESCRIPTION
## Summary

Add MQTT subscriber and event logging for berth state changes. The backend now connects to the MQTT broker on startup, listens for sensor status messages, and creates event records when a berth transitions between free and occupied. Duplicate/heartbeat messages that don't change state are recorded on the berth but do not generate events.

## Related Issue

Closes #4 
Closes #3 

## Changes

- Added node_id and sensor_raw columns to the Event model
- Created events.py with process_sensor_reading() that detects state transitions and logs events
- Created mqtt.py with MQTT subscriber that parses dockpulse/{node_id}/{berth_id}/status messages and auto-reconnects on broker disconnect
- Wired MQTT listener into FastAPI lifespan so it starts/stops with the app
- Updated OpenAPI spec and DB diagram to reflect new Event fields


## Checklist

- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [x] All existing tests pass
- [x] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
