### PR TITLE
feat(deploy): add staging + prod compose overlays for komodo

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,5 @@
+POSTGRES_USER=dockpulse
+POSTGRES_PASSWORD=generate-strong-password
+POSTGRES_DB=dockpulse
+MQTT_PORT=1883
+TAG=sha-abcdef0

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,5 @@
+POSTGRES_USER=dockpulse
+POSTGRES_PASSWORD=change-me-staging
+POSTGRES_DB=dockpulse
+MQTT_PORT=1883
+TAG=staging

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ __pycache__/
 .env
 .env.*
 !.env.example
+!.env.*.example
 
 # IDE / Editor
 .idea/

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,15 @@
 services:
+  db:
+    ports:
+      - "5432:5432"
+
+  mosquitto:
+    ports:
+      - "1883:1883"
+
   backend:
     command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     volumes:
       - ./docs:/docs
+    ports:
+      - "8000:8000"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,44 @@
+services:
+  db:
+    container_name: dockpulse-prod-db
+
+  mosquitto:
+    container_name: dockpulse-prod-mosquitto
+
+  migrate:
+    container_name: dockpulse-prod-migrate
+
+  backend:
+    container_name: dockpulse-prod-backend
+    networks:
+      - internal
+      - proxy
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=proxy
+      - traefik.http.routers.dockpulse-api.rule=Host(`dockpulse.xyz`) && PathPrefix(`/api`)
+      - traefik.http.routers.dockpulse-api.entrypoints=https
+      - traefik.http.routers.dockpulse-api.tls=true
+      - traefik.http.routers.dockpulse-api.tls.certresolver=cloudflare
+      - traefik.http.services.dockpulse-api.loadbalancer.server.port=8000
+
+  frontend:
+    container_name: dockpulse-prod-frontend
+    profiles: !reset []
+    networks:
+      - internal
+      - proxy
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=proxy
+      - traefik.http.routers.dockpulse-web.rule=Host(`dockpulse.xyz`) || Host(`www.dockpulse.xyz`)
+      - traefik.http.routers.dockpulse-web.entrypoints=https
+      - traefik.http.routers.dockpulse-web.tls=true
+      - traefik.http.routers.dockpulse-web.tls.certresolver=cloudflare
+      - traefik.http.routers.dockpulse-web.tls.domains[0].main=dockpulse.xyz
+      - traefik.http.routers.dockpulse-web.tls.domains[0].sans=www.dockpulse.xyz
+      - traefik.http.services.dockpulse-web.loadbalancer.server.port=5173
+
+networks:
+  proxy:
+    external: true

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,70 @@
+services:
+  db:
+    container_name: dockpulse-staging-db
+    volumes: !reset []
+    tmpfs:
+      - /var/lib/postgresql/data
+
+  mosquitto:
+    container_name: dockpulse-staging-mosquitto
+
+  migrate:
+    container_name: dockpulse-staging-migrate
+
+  backend:
+    container_name: dockpulse-staging-backend
+
+  frontend:
+    container_name: dockpulse-staging-frontend
+    profiles: !reset []
+
+  fake-publisher-b1:
+    container_name: dockpulse-staging-fake-publisher-b1
+    image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    restart: unless-stopped
+    command: >
+      uv run /tools/fake_publisher.py
+      --host mosquitto
+      --berth-id ksss-saltsjobaden-pier-1-b1
+      --rate 3
+      --status toggle
+    volumes:
+      - ./tools:/tools
+    depends_on:
+      mosquitto:
+        condition: service_started
+    networks: [internal]
+
+  fake-publisher-b2:
+    container_name: dockpulse-staging-fake-publisher-b2
+    image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    restart: unless-stopped
+    command: >
+      uv run /tools/fake_publisher.py
+      --host mosquitto
+      --berth-id ksss-saltsjobaden-pier-1-b2
+      --rate 10
+      --status occupied
+    volumes:
+      - ./tools:/tools
+    depends_on:
+      mosquitto:
+        condition: service_started
+    networks: [internal]
+
+  fake-publisher-b3:
+    container_name: dockpulse-staging-fake-publisher-b3
+    image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    restart: unless-stopped
+    command: >
+      uv run /tools/fake_publisher.py
+      --host mosquitto
+      --berth-id ksss-saltsjobaden-pier-1-b3
+      --rate 10
+      --status free
+    volumes:
+      - ./tools:/tools
+    depends_on:
+      mosquitto:
+        condition: service_started
+    networks: [internal]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,9 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
-    ports:
-      - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+    networks: [internal]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
       interval: 5s
@@ -21,19 +20,32 @@ services:
     container_name: dockpulse-mosquitto
     image: eclipse-mosquitto:2
     restart: unless-stopped
-    ports:
-      - "1883:1883"
     volumes:
       - ./mosquitto.conf:/mosquitto/config/mosquitto.conf
+    networks: [internal]
+
+  migrate:
+    container_name: dockpulse-migrate
+    image: ghcr.io/ii1302-8/dockpulse-backend:${TAG:-staging}
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    command: uv run alembic upgrade head
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+    depends_on:
+      db:
+        condition: service_healthy
+    networks: [internal]
+    restart: "no"
 
   backend:
     container_name: dockpulse-backend
+    image: ghcr.io/ii1302-8/dockpulse-backend:${TAG:-staging}
     build:
       context: .
       dockerfile: backend/Dockerfile
     restart: unless-stopped
-    ports:
-      - "8000:8000"
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       MQTT_BROKER: mosquitto
@@ -43,17 +55,22 @@ services:
         condition: service_healthy
       mosquitto:
         condition: service_started
+      migrate:
+        condition: service_completed_successfully
+    networks: [internal]
 
   frontend:
     container_name: dockpulse-frontend
+    image: ghcr.io/ii1302-8/dockpulse-frontend:${TAG:-staging}
     build: ./frontend
     restart: unless-stopped
-    ports:
-      - "5173:5173"
     depends_on:
       - backend
-    profiles:
-      - prod
+    networks: [internal]
+    profiles: [prod]
+
+networks:
+  internal:
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary

Adds staging and production compose overlays so Komodo can manage both stacks from this repo. Staging runs a throwaway Postgres (tmpfs) plus three fake MQTT publishers for the sprint 1 demo. Prod wires the backend and frontend into our existing Traefik + Cloudflare DNS-01 setup at dockpulse.xyz.

## Related Issue

Closes #41 
Closes #42 

## Checklist

- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [x] All existing tests pass
- [ ] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format

## Notes / Follow-ups
  - Seed migration `143e62cd073b` runs on every `alembic upgrade` — will seed
    prod too. Separate backend PR will gate it behind an env var before prod
    goes live.
  - Mosquitto stays internal-only in staging; prod MQTT exposure blocked on #35
    (MQTT auth spike).
  - Komodo must be configured to pull images on every deploy so the `build:`
    fallback in the base compose isn't used.
  - Next branch: `feat/21-cf-tunnel` for staging CF Tunnel + Access gate.
