### PR TITLE
chore: migrate to pydantic-settings, remove os.environ usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ POSTGRES_USER=dockpulse
 POSTGRES_PASSWORD=dockpulse
 POSTGRES_DB=dockpulse
 # Signs JWTs. Generate with: openssl rand -hex 32
-SECRET_KEY=dev-secret-do-not-use-in-production
+JWT_SECRET_KEY=dev-secret-do-not-use-in-production-xx
 MQTT_BROKER=localhost
 MQTT_PORT=8883
 MQTT_TLS_CA=/certs/service-ca/ca.crt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,6 @@ jobs:
           --health-interval 5s
           --health-timeout 3s
           --health-retries 10
-    env:
-      TEST_DATABASE_URL: postgresql+asyncpg://dockpulse:dockpulse@localhost:5432/dockpulse_test
-      SECRET_KEY: ci-test-secret-key-not-for-production
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,16 +70,20 @@ Both teams implement against `docs/api/openapi.yml`.
 ```
 backend/
 ├── app/
-│   ├── __init__.py
-│   ├── main.py          <- FastAPI app, OpenAPI override
-│   ├── models.py         <- Pydantic schemas (mirror openapi.yml)
+│   ├── main.py           <- FastAPI app entry point, lifespan, OpenAPI spec
+│   ├── config.py         <- pydantic-settings config, reads from env / .env
 │   ├── db.py             <- SQLAlchemy engine + session
-│   └── routes/
-│       ├── health.py
-│       ├── docks.py
+│   ├── models.py         <- SQLAlchemy ORM models
+│   ├── schemas.py        <- Pydantic request/response schemas
+│   ├── auth.py           <- JWT creation and verification
+│   ├── events.py         <- Berth state machine and event processing
+│   ├── mqtt.py           <- MQTT listener
+│   ├── broadcaster.py    <- SSE broadcast bus
+│   └── routers/
 │       ├── berths.py
-│       └── alerts.py
-├── alembic/               <- DB migrations
+│       ├── docks.py
+│       └── users.py
+├── alembic/              <- DB migrations
 ├── pyproject.toml
 └── Dockerfile
 ```
@@ -87,8 +91,8 @@ backend/
 ### Adding a new endpoint
 
 1. Add the endpoint to `docs/api/openapi.yml`
-2. Add/update the Pydantic model in `models.py` to match the spec schema
-3. Create the route in `routes/`
+2. Add/update the Pydantic schema in `schemas.py` to match the spec
+3. Create the route in `routers/`
 4. Test (from `backend/`): `uv run pytest`
 5. Verify against spec (from `backend/`): `uv run schemathesis run ../docs/api/openapi.yml --url http://localhost:8000`
 
@@ -138,13 +142,15 @@ Re-run this whenever `docs/api/openapi.yml` changes.
 
 Defined in `.env` (copied from `.env.example`). Docker Compose reads them automatically.
 
-| Variable            | Description      | Default     |
-| ------------------- | ---------------- | ----------- |
-| `POSTGRES_USER`     | DB username      | `dockpulse` |
-| `POSTGRES_PASSWORD` | DB password      | `dockpulse` |
-| `POSTGRES_DB`       | DB name          | `dockpulse` |
-| `MQTT_BROKER`       | MQTT broker host                          | `localhost`                              |
-| `MQTT_PORT`         | MQTT broker port (8883 TLS, 1883 plain)   | `8883`                                   |
-| `MQTT_TLS_CA`       | CA cert path for broker verification      | `/certs/service-ca/ca.crt`               |
-| `MQTT_TLS_CERT`     | Client cert path (mTLS)                   | `/certs/clients/backend/backend.crt`     |
-| `MQTT_TLS_KEY`      | Client key path (mTLS)                    | `/certs/clients/backend/backend.key`     |
+| Variable            | Description                                     | Default                              |
+| ------------------- | ----------------------------------------------- | ------------------------------------ |
+| `POSTGRES_USER`     | DB username                                     | `dockpulse`                          |
+| `POSTGRES_PASSWORD` | DB password                                     | `dockpulse`                          |
+| `POSTGRES_DB`       | DB name                                         | `dockpulse`                          |
+| `DATABASE_URL`      | Backend DB connection string (set by Compose)   | —                                    |
+| `JWT_SECRET_KEY`    | Signs JWTs,generate with `openssl rand -hex 32` | **required**                         |
+| `MQTT_BROKER`       | MQTT broker host                                | `localhost`                          |
+| `MQTT_PORT`         | MQTT broker port (8883 TLS, 1883 plain)         | `8883`                               |
+| `MQTT_TLS_CA`       | CA cert path for broker verification            | `/certs/service-ca/ca.crt`           |
+| `MQTT_TLS_CERT`     | Client cert path (mTLS)                         | `/certs/clients/backend/backend.crt` |
+| `MQTT_TLS_KEY`      | Client key path (mTLS)                          | `/certs/clients/backend/backend.key` |

--- a/backend/README.md
+++ b/backend/README.md
@@ -48,13 +48,13 @@ docker compose exec db psql -U dockpulse -c "CREATE DATABASE dockpulse_test;"
 **Run tests:**
 
 ```bash
-SECRET_KEY=any-local-secret uv run pytest -v
+uv run pytest -v
 ```
 
-The test database URL defaults to `postgresql+asyncpg://dockpulse:dockpulse@localhost:5432/dockpulse_test`. Override with:
+Defaults are set in `pyproject.toml` under `[tool.pytest.ini_options] env`. Override at the command line:
 
 ```bash
-TEST_DATABASE_URL=postgresql+asyncpg://user:pass@host/dbname uv run pytest
+DATABASE_URL=postgresql+asyncpg://user:pass@host/dbname uv run pytest
 ```
 
 The test suite drops and recreates all tables on each run, so it is safe to run repeatedly.
@@ -64,6 +64,7 @@ The test suite drops and recreates all tables on each run, so it is safe to run 
 ```text
 app/
 ├── main.py           <- FastAPI app entry point, lifespan, OpenAPI spec
+├── config.py         <- pydantic-settings config, reads from env / .env
 ├── db.py             <- SQLAlchemy engine + session
 ├── models.py         <- SQLAlchemy ORM models
 ├── schemas.py        <- Pydantic request/response schemas
@@ -74,5 +75,5 @@ app/
 └── routers/
     ├── berths.py     <- GET /api/berths/*
     ├── docks.py      <- GET /api/docks/*
-    └── users.py      <- POST /api/users/register, login, logout, refresh
+    └── users.py      <- POST /api/users, /api/users/token, GET/PATCH /api/users/me
 ```

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 from logging.config import fileConfig
 
 from sqlalchemy import pool
@@ -7,14 +6,16 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
-from app.db import DATABASE_URL, Base
+from app import models  # noqa: F401
+from app.config import settings
+from app.db import Base
 
 config = context.config
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-config.set_main_option("sqlalchemy.url", os.environ.get("DATABASE_URL", DATABASE_URL))
+config.set_main_option("sqlalchemy.url", settings.database_url)
 
 target_metadata = Base.metadata
 

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
 from app import models  # noqa: F401
-from app.config import settings
+from app.config import get_settings
 from app.db import Base
 
 config = context.config
@@ -15,7 +15,7 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-config.set_main_option("sqlalchemy.url", settings.database_url)
+config.set_main_option("sqlalchemy.url", get_settings().database_url)
 
 target_metadata = Base.metadata
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,1 +1,0 @@
-from app import models  # noqa: F401  (register models on Base.metadata)

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -6,7 +6,7 @@ from fastapi import Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import settings
+from app.config import get_settings
 from app.db import get_session
 from app.models import User
 
@@ -22,7 +22,7 @@ def create_access_token(user: User, expires_in: timedelta = ACCESS_TOKEN_TTL) ->
         "ver": user.token_version,
         "exp": datetime.now(UTC) + expires_in,
     }
-    secret = settings.jwt_secret_key.get_secret_value()
+    secret = get_settings().jwt_secret_key.get_secret_value()
     return jwt.encode(payload, secret, algorithm=ALGORITHM)
 
 
@@ -31,7 +31,7 @@ async def get_current_user(
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> User:
     try:
-        secret = settings.jwt_secret_key.get_secret_value()
+        secret = get_settings().jwt_secret_key.get_secret_value()
         payload = jwt.decode(credentials.credentials, secret, algorithms=[ALGORITHM])
         user_id: str = payload["sub"]
         token_version: int = payload["ver"]

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,4 +1,3 @@
-import os
 from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
@@ -7,11 +6,11 @@ from fastapi import Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.db import get_session
 from app.models import User
 
 ALGORITHM = "HS256"
-SECRET_KEY = os.environ["SECRET_KEY"]
 ACCESS_TOKEN_TTL = timedelta(hours=1)
 
 _bearer = HTTPBearer()
@@ -23,7 +22,8 @@ def create_access_token(user: User, expires_in: timedelta = ACCESS_TOKEN_TTL) ->
         "ver": user.token_version,
         "exp": datetime.now(UTC) + expires_in,
     }
-    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+    secret = settings.jwt_secret_key.get_secret_value()
+    return jwt.encode(payload, secret, algorithm=ALGORITHM)
 
 
 async def get_current_user(
@@ -31,9 +31,8 @@ async def get_current_user(
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> User:
     try:
-        payload = jwt.decode(
-            credentials.credentials, SECRET_KEY, algorithms=[ALGORITHM]
-        )
+        secret = settings.jwt_secret_key.get_secret_value()
+        payload = jwt.decode(credentials.credentials, secret, algorithms=[ALGORITHM])
         user_id: str = payload["sub"]
         token_version: int = payload["ver"]
     except (jwt.PyJWTError, KeyError) as err:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,36 @@
+from functools import lru_cache
+
+from pydantic import SecretStr, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    database_url: str
+    jwt_secret_key: SecretStr
+    mqtt_broker: str = "localhost"
+    mqtt_port: int | None = None
+    mqtt_tls_ca: str | None = None
+    mqtt_tls_cert: str | None = None
+    mqtt_tls_key: str | None = None
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+        env_ignore_missing=True,
+    )
+
+    @field_validator("jwt_secret_key")
+    @classmethod
+    def jwt_secret_key_strong_enough(cls, v: SecretStr) -> SecretStr:
+        if len(v.get_secret_value()) < 32:
+            raise ValueError("JWT_SECRET_KEY must be at least 32 characters")
+        return v
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()
+
+
+settings = get_settings()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,12 +13,7 @@ class Settings(BaseSettings):
     mqtt_tls_cert: str | None = None
     mqtt_tls_key: str | None = None
 
-    model_config = SettingsConfigDict(
-        env_file=".env",
-        env_file_encoding="utf-8",
-        extra="ignore",
-        env_ignore_missing=True,
-    )
+    model_config = SettingsConfigDict(env_file=".env")
 
     @field_validator("jwt_secret_key")
     @classmethod
@@ -31,6 +26,3 @@ class Settings(BaseSettings):
 @lru_cache
 def get_settings() -> Settings:
     return Settings()
-
-
-settings = get_settings()

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,9 +1,9 @@
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
-from app.config import settings
+from app.config import get_settings
 
-engine = create_async_engine(settings.database_url)
+engine = create_async_engine(get_settings().database_url)
 async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,14 +1,9 @@
-import os
-
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
-DATABASE_URL = os.environ.get(
-    "DATABASE_URL",
-    "postgresql+asyncpg://dockpulse:dockpulse@localhost:5432/dockpulse",
-)
+from app.config import settings
 
-engine = create_async_engine(DATABASE_URL)
+engine = create_async_engine(settings.database_url)
 async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 

--- a/backend/app/mqtt.py
+++ b/backend/app/mqtt.py
@@ -6,16 +6,15 @@ import ssl
 import aiomqtt
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import settings
+from app.config import get_settings
 from app.db import async_session
 from app.events import process_heartbeat, process_sensor_reading
 
 logger = logging.getLogger(__name__)
 
+_s = get_settings()
 MQTT_PORT = (
-    settings.mqtt_port
-    if settings.mqtt_port is not None
-    else (8883 if settings.mqtt_tls_ca else 1883)
+    _s.mqtt_port if _s.mqtt_port is not None else (8883 if _s.mqtt_tls_ca else 1883)
 )
 STATUS_TOPIC = "harbor/+/+/+/status"
 HEARTBEAT_TOPIC = "harbor/+/+/+/heartbeat"
@@ -29,12 +28,13 @@ def is_mqtt_connected() -> bool:
 
 
 def _build_tls_context() -> ssl.SSLContext | None:
-    if not (settings.mqtt_tls_ca and settings.mqtt_tls_cert and settings.mqtt_tls_key):
+    s = get_settings()
+    if not (s.mqtt_tls_ca and s.mqtt_tls_cert and s.mqtt_tls_key):
         return None
     ctx = ssl.create_default_context(
-        purpose=ssl.Purpose.SERVER_AUTH, cafile=settings.mqtt_tls_ca
+        purpose=ssl.Purpose.SERVER_AUTH, cafile=s.mqtt_tls_ca
     )
-    ctx.load_cert_chain(certfile=settings.mqtt_tls_cert, keyfile=settings.mqtt_tls_key)
+    ctx.load_cert_chain(certfile=s.mqtt_tls_cert, keyfile=s.mqtt_tls_key)
     ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     return ctx
 
@@ -114,12 +114,12 @@ async def mqtt_listener() -> None:
     while True:
         try:
             async with aiomqtt.Client(
-                settings.mqtt_broker, MQTT_PORT, tls_context=tls_context
+                get_settings().mqtt_broker, MQTT_PORT, tls_context=tls_context
             ) as client:
                 _connected = True
                 logger.info(
                     "Connected to MQTT broker %s:%s (tls=%s)",
-                    settings.mqtt_broker,
+                    get_settings().mqtt_broker,
                     MQTT_PORT,
                     tls_context is not None,
                 )

--- a/backend/app/mqtt.py
+++ b/backend/app/mqtt.py
@@ -1,22 +1,22 @@
 import asyncio
 import json
 import logging
-import os
 import ssl
 
 import aiomqtt
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.db import async_session
 from app.events import process_heartbeat, process_sensor_reading
 
 logger = logging.getLogger(__name__)
 
-MQTT_BROKER = os.environ.get("MQTT_BROKER", "localhost")
-MQTT_TLS_CA = os.environ.get("MQTT_TLS_CA")
-MQTT_TLS_CERT = os.environ.get("MQTT_TLS_CERT")
-MQTT_TLS_KEY = os.environ.get("MQTT_TLS_KEY")
-MQTT_PORT = int(os.environ.get("MQTT_PORT", "8883" if MQTT_TLS_CA else "1883"))
+MQTT_PORT = (
+    settings.mqtt_port
+    if settings.mqtt_port is not None
+    else (8883 if settings.mqtt_tls_ca else 1883)
+)
 STATUS_TOPIC = "harbor/+/+/+/status"
 HEARTBEAT_TOPIC = "harbor/+/+/+/heartbeat"
 RECONNECT_DELAY = 5
@@ -29,12 +29,12 @@ def is_mqtt_connected() -> bool:
 
 
 def _build_tls_context() -> ssl.SSLContext | None:
-    if not (MQTT_TLS_CA and MQTT_TLS_CERT and MQTT_TLS_KEY):
+    if not (settings.mqtt_tls_ca and settings.mqtt_tls_cert and settings.mqtt_tls_key):
         return None
     ctx = ssl.create_default_context(
-        purpose=ssl.Purpose.SERVER_AUTH, cafile=MQTT_TLS_CA
+        purpose=ssl.Purpose.SERVER_AUTH, cafile=settings.mqtt_tls_ca
     )
-    ctx.load_cert_chain(certfile=MQTT_TLS_CERT, keyfile=MQTT_TLS_KEY)
+    ctx.load_cert_chain(certfile=settings.mqtt_tls_cert, keyfile=settings.mqtt_tls_key)
     ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     return ctx
 
@@ -114,12 +114,12 @@ async def mqtt_listener() -> None:
     while True:
         try:
             async with aiomqtt.Client(
-                MQTT_BROKER, MQTT_PORT, tls_context=tls_context
+                settings.mqtt_broker, MQTT_PORT, tls_context=tls_context
             ) as client:
                 _connected = True
                 logger.info(
                     "Connected to MQTT broker %s:%s (tls=%s)",
-                    MQTT_BROKER,
+                    settings.mqtt_broker,
                     MQTT_PORT,
                     tls_context is not None,
                 )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -6,10 +6,9 @@ from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 class _Base(BaseModel):
     model_config = ConfigDict(from_attributes=True)
-    # Something about this being better for pydantic
 
 
-class BerthOut(_Base):  # Grundläggande begränsningar
+class BerthOut(_Base):
     berth_id: str
     dock_id: str
     label: str | None = None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "sse-starlette>=2.4",
   "PyJWT>=2.8",
   "argon2-cffi>=21.0",
+  "pydantic-settings>=2.14.0",
 ]
 
 [dependency-groups]
@@ -24,6 +25,7 @@ dev = [
   "schemathesis>=4.15",
   "ruff>=0.11",
   "pre-commit>=4.5",
+  "pytest-env>=1.6.0",
 ]
 
 [tool.pytest.ini_options]
@@ -32,6 +34,10 @@ asyncio_default_fixture_loop_scope = "session"
 asyncio_default_test_loop_scope = "session"
 pythonpath = ["."]
 testpaths = ["tests"]
+env = [
+  "JWT_SECRET_KEY=test-secret-key-not-for-production-x",
+  "DATABASE_URL=postgresql+asyncpg://dockpulse:dockpulse@localhost:5432/dockpulse_test",
+]
 
 [tool.ruff]
 target-version = "py312"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,3 @@
-import os
 from collections.abc import AsyncIterator
 
 import pytest_asyncio
@@ -7,19 +6,16 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
+from app import models as _models  # noqa: F401
+from app.config import settings
 from app.db import Base, get_session
 from app.main import app
 from app.models import Berth, Dock, Harbor
 
-TEST_DATABASE_URL = os.environ.get(
-    "TEST_DATABASE_URL",
-    "postgresql+asyncpg://dockpulse:dockpulse@localhost:5432/dockpulse_test",
-)
-
 
 @pytest_asyncio.fixture(scope="session")
 async def engine():
-    eng = create_async_engine(TEST_DATABASE_URL)
+    eng = create_async_engine(settings.database_url)
     async with eng.begin() as conn:
         await conn.execute(text("DROP SCHEMA public CASCADE"))
         await conn.execute(text("CREATE SCHEMA public"))

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from app import models as _models  # noqa: F401
-from app.config import settings
+from app.config import get_settings
 from app.db import Base, get_session
 from app.main import app
 from app.models import Berth, Dock, Harbor
@@ -15,7 +15,7 @@ from app.models import Berth, Dock, Harbor
 
 @pytest_asyncio.fixture(scope="session")
 async def engine():
-    eng = create_async_engine(settings.database_url)
+    eng = create_async_engine(get_settings().database_url)
     async with eng.begin() as conn:
         await conn.execute(text("DROP SCHEMA public CASCADE"))
         await conn.execute(text("CREATE SCHEMA public"))

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,73 @@
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings, get_settings
+
+_SECRET = "a-strong-secret-key-for-testing-purposes"
+_DB = "postgresql+asyncpg://dockpulse:dockpulse@localhost:5432/dockpulse_test"
+
+
+def test_loads_jwt_secret_from_env(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET_KEY", _SECRET)
+    monkeypatch.setenv("DATABASE_URL", _DB)
+    s = Settings(_env_file=None)
+    assert s.jwt_secret_key.get_secret_value() == _SECRET
+
+
+def test_missing_jwt_secret_raises(monkeypatch):
+    monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+    monkeypatch.setenv("DATABASE_URL", _DB)
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None)
+
+
+def test_missing_database_url_raises(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET_KEY", _SECRET)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None)
+
+
+def test_weak_jwt_secret_raises(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET_KEY", "tooshort")
+    monkeypatch.setenv("DATABASE_URL", _DB)
+    with pytest.raises(ValidationError, match="at least 32 characters"):
+        Settings(_env_file=None)
+
+
+def test_secret_is_masked(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET_KEY", _SECRET)
+    monkeypatch.setenv("DATABASE_URL", _DB)
+    s = Settings(_env_file=None)
+    assert _SECRET not in str(s)
+    assert _SECRET not in repr(s)
+
+
+def test_defaults(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET_KEY", _SECRET)
+    monkeypatch.setenv("DATABASE_URL", _DB)
+    s = Settings(_env_file=None)
+    assert s.mqtt_broker == "localhost"
+    assert s.mqtt_port is None
+    assert s.mqtt_tls_ca is None
+    assert s.mqtt_tls_cert is None
+    assert s.mqtt_tls_key is None
+
+
+def test_overrides(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET_KEY", _SECRET)
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://other/db")
+    monkeypatch.setenv("MQTT_BROKER", "broker.example.com")
+    monkeypatch.setenv("MQTT_PORT", "1234")
+    s = Settings(_env_file=None)
+    assert s.mqtt_broker == "broker.example.com"
+    assert s.mqtt_port == 1234
+    assert s.database_url == "postgresql+asyncpg://other/db"
+
+
+def test_get_settings_is_cached(monkeypatch):
+    get_settings.cache_clear()
+    monkeypatch.setenv("JWT_SECRET_KEY", _SECRET)
+    monkeypatch.setenv("DATABASE_URL", _DB)
+    assert get_settings() is get_settings()
+    get_settings.cache_clear()

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -4,7 +4,7 @@ from argon2 import PasswordHasher
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import settings
+from app.config import get_settings
 from app.models import User
 
 ALGORITHM = "HS256"
@@ -13,7 +13,7 @@ ALGORITHM = "HS256"
 def make_token(user_id: str, token_version: int = 0) -> str:
     return jwt.encode(
         {"sub": user_id, "ver": token_version},
-        settings.jwt_secret_key.get_secret_value(),
+        get_settings().jwt_secret_key.get_secret_value(),
         algorithm=ALGORITHM,
     )
 

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -1,20 +1,20 @@
-import os
-
 import jwt
 import pytest_asyncio
 from argon2 import PasswordHasher
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.models import User
 
-SECRET_KEY = os.environ.get("SECRET_KEY", "test-secret")
 ALGORITHM = "HS256"
 
 
 def make_token(user_id: str, token_version: int = 0) -> str:
     return jwt.encode(
-        {"sub": user_id, "ver": token_version}, SECRET_KEY, algorithm=ALGORITHM
+        {"sub": user_id, "ver": token_version},
+        settings.jwt_secret_key.get_secret_value(),
+        algorithm=ALGORITHM,
     )
 
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -353,6 +353,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "fastapi" },
     { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -366,6 +367,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-env" },
     { name = "ruff" },
     { name = "schemathesis" },
 ]
@@ -378,6 +380,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31" },
     { name = "fastapi", specifier = ">=0.135" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.12" },
+    { name = "pydantic-settings", specifier = ">=2.14.0" },
     { name = "pyjwt", specifier = ">=2.8" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
@@ -391,6 +394,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.5" },
     { name = "pytest", specifier = ">=9.0" },
     { name = "pytest-asyncio", specifier = ">=0.25" },
+    { name = "pytest-env", specifier = ">=1.6.0" },
     { name = "ruff", specifier = ">=0.11" },
     { name = "schemathesis", specifier = ">=4.15" },
 ]
@@ -957,6 +961,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1010,6 +1028,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-env"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/69/4db1c30625af0621df8dbe73797b38b6d1b04e15d021dd5d26a6d297f78c/pytest_env-1.6.0.tar.gz", hash = "sha256:ac02d6fba16af54d61e311dd70a3c61024a4e966881ea844affc3c8f0bf207d3", size = 16163, upload-time = "2026-03-12T22:39:43.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl", hash = "sha256:1e7f8a62215e5885835daaed694de8657c908505b964ec8097a7ce77b403d9a3", size = 10400, upload-time = "2026-03-12T22:39:41.887Z" },
 ]
 
 [[package]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     command: sh -c "uv run alembic upgrade head && uv run uvicorn app.main:app --host 0.0.0.0 --port 8000"
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
-      SECRET_KEY: ${SECRET_KEY:?SECRET_KEY must be set (32+ random bytes, e.g. openssl rand -hex 32)}
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY:?JWT_SECRET_KEY must be set (32+ random bytes, e.g. openssl rand -hex 32)}
       MQTT_BROKER: mosquitto
       MQTT_PORT: ${MQTT_PORT:-8883}
       MQTT_TLS_CA: /certs/service-ca/ca.crt


### PR DESCRIPTION
## Summary

Replaces all `os.environ` calls with a single `pydantic-settings` config module. `JWT_SECRET_KEY` is now validated as `SecretStr` (≥32 chars) and `DATABASE_URL` is required, both fail fast on startup if missing or weak.

## Related Issue

Closes #95 

## Changes

- Add `app/config.py` with `pydantic-settings` `Settings` class                                                                 
- Remove all `os.environ` calls from `app/`, `alembic/`, and `tests/`                                                            
- `JWT_SECRET_KEY` uses `SecretStr`, validated ≥32 chars                                                                         
- `DATABASE_URL` required with no default                                                                                        
- `pytest-env` sets test defaults in `pyproject.toml` — no import-order hacks in `conftest.py`                                  
- Update `docker-compose.yml`, `.env.example`, `README.md`, `CONTRIBUTING.md` to `JWT_SECRET_KEY`

## Checklist

- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [x] All existing tests pass
- [x] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
