### PR TITLE
refactor(backend): lazy settings via pydantic-settings

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,4 +1,3 @@
-import os
 from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
@@ -7,11 +6,11 @@ from fastapi import Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import get_settings
 from app.db import get_session
 from app.models import User
 
 ALGORITHM = "HS256"
-SECRET_KEY = os.environ["SECRET_KEY"]
 ACCESS_TOKEN_TTL = timedelta(hours=1)
 
 _bearer = HTTPBearer()
@@ -23,7 +22,7 @@ def create_access_token(user: User, expires_in: timedelta = ACCESS_TOKEN_TTL) ->
         "ver": user.token_version,
         "exp": datetime.now(UTC) + expires_in,
     }
-    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+    return jwt.encode(payload, get_settings().secret_key, algorithm=ALGORITHM)
 
 
 async def get_current_user(
@@ -32,7 +31,9 @@ async def get_current_user(
 ) -> User:
     try:
         payload = jwt.decode(
-            credentials.credentials, SECRET_KEY, algorithms=[ALGORITHM]
+            credentials.credentials,
+            get_settings().secret_key,
+            algorithms=[ALGORITHM],
         )
         user_id: str = payload["sub"]
         token_version: int = payload["ver"]

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,17 @@
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(case_sensitive=False, extra="ignore")
+
+    secret_key: str
+    database_url: str = (
+        "postgresql+asyncpg://dockpulse:dockpulse@localhost:5432/dockpulse"
+    )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,21 +1,30 @@
-import os
+from functools import lru_cache
 
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import DeclarativeBase, sessionmaker
-
-DATABASE_URL = os.environ.get(
-    "DATABASE_URL",
-    "postgresql+asyncpg://dockpulse:dockpulse@localhost:5432/dockpulse",
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
 )
+from sqlalchemy.orm import DeclarativeBase
 
-engine = create_async_engine(DATABASE_URL)
-async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+from app.config import get_settings
 
 
 class Base(DeclarativeBase):
     pass
 
 
+@lru_cache
+def get_engine() -> AsyncEngine:
+    return create_async_engine(get_settings().database_url)
+
+
+@lru_cache
+def get_sessionmaker() -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(get_engine(), expire_on_commit=False)
+
+
 async def get_session():
-    async with async_session() as session:
+    async with get_sessionmaker()() as session:
         yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,7 +11,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from sqlalchemy import text
 
-from app.db import engine
+from app.db import get_engine
 from app.mqtt import is_mqtt_connected, mqtt_listener
 from app.routers import berths, docks, users
 
@@ -68,7 +68,7 @@ app.openapi = custom_openapi
 async def health():
     db_ok = True
     try:
-        async with engine.connect() as conn:
+        async with get_engine().connect() as conn:
             await conn.execute(text("SELECT 1"))
     except Exception:
         db_ok = False

--- a/backend/app/mqtt.py
+++ b/backend/app/mqtt.py
@@ -7,7 +7,7 @@ import ssl
 import aiomqtt
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db import async_session
+from app.db import get_sessionmaker
 from app.events import process_heartbeat, process_sensor_reading
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ async def _handle_message(message: aiomqtt.Message) -> None:
         logger.warning("Invalid JSON payload on %s", message.topic.value)
         return
 
-    async with async_session() as session:
+    async with get_sessionmaker()() as session:
         if kind == "status":
             await _handle_status(session, payload, berth_id)
         elif kind == "heartbeat":

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "alembic>=1.18",
   "aiomqtt>=2.5",
   "pydantic[email]>=2.12",
+  "pydantic-settings>=2.5",
   "pyyaml>=6.0",
   "sse-starlette>=2.4",
   "PyJWT[crypto]>=2.8",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -406,6 +406,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "fastapi" },
     { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -431,6 +432,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31" },
     { name = "fastapi", specifier = ">=0.135" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.12" },
+    { name = "pydantic-settings", specifier = ">=2.5" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
@@ -1007,6 +1009,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
     { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
     { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
SECRET_KEY and DATABASE_URL are now read on first use via a cached get_settings(), not at module import.

## Checklist

- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [x] All existing tests pass
- [ ] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
