### PR TITLE
feat(api): implement owners CRUD API

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -3,12 +3,15 @@ from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
 import jwt
+from dotenv import load_dotenv
 from fastapi import Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
 from app.models import User
+
+load_dotenv()
 
 ALGORITHM = "HS256"
 SECRET_KEY = os.environ["SECRET_KEY"]

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,5 +1,7 @@
 import os
+from typing import Annotated
 
+from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
@@ -19,3 +21,6 @@ class Base(DeclarativeBase):
 async def get_session():
     async with async_session() as session:
         yield session
+
+
+DbSession = Annotated[AsyncSession, Depends(get_session)]

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,15 @@
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Double, Enum, ForeignKey, Integer, String
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Double,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db import Base
@@ -178,3 +187,14 @@ class FactoryKey(Base):
         DateTime(timezone=True), nullable=False
     )
     revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class Owner(Base):
+    __tablename__ = "owners"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    email = Column(String, unique=True, index=True, nullable=False)
+    phone = Column(String, nullable=True)
+    boat_name = Column(String, nullable=True)
+    boat_registration_number = Column(String, unique=True, index=True, nullable=True)

--- a/backend/app/routers/owners.py
+++ b/backend/app/routers/owners.py
@@ -1,0 +1,74 @@
+from fastapi import APIRouter, HTTPException, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.future import select
+
+from app.db import DbSession
+from app.models import Owner
+from app.schemas import OwnerCreate, OwnerResponse, OwnerUpdate
+
+router = APIRouter(prefix="/owners", tags=["owners"])
+
+
+@router.post("/", response_model=OwnerResponse, status_code=status.HTTP_201_CREATED)
+async def create_owner(owner: OwnerCreate, db: DbSession):
+    new_owner = Owner(**owner.model_dump())
+    db.add(new_owner)
+    try:
+        await db.commit()
+        await db.refresh(new_owner)
+        return new_owner
+    except IntegrityError as err:
+        await db.rollback()
+        raise HTTPException(
+            status_code=400,
+            detail="Email or Boat Registration Number already registered",
+        ) from err
+
+
+@router.get("/", response_model=list[OwnerResponse])
+async def list_owners(db: DbSession, skip: int = 0, limit: int = 100):
+    result = await db.execute(select(Owner).offset(skip).limit(limit))
+    return result.scalars().all()
+
+
+@router.get("/{owner_id}", response_model=OwnerResponse)
+async def get_owner(owner_id: int, db: DbSession):
+    result = await db.execute(select(Owner).filter(Owner.id == owner_id))
+    owner = result.scalars().first()
+    if not owner:
+        raise HTTPException(status_code=404, detail="Owner not found")
+    return owner
+
+
+@router.put("/{owner_id}", response_model=OwnerResponse)
+async def update_owner(owner_id: int, owner_update: OwnerUpdate, db: DbSession):
+    result = await db.execute(select(Owner).filter(Owner.id == owner_id))
+    db_owner = result.scalars().first()
+    if not db_owner:
+        raise HTTPException(status_code=404, detail="Owner not found")
+
+    update_data = owner_update.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(db_owner, key, value)
+
+    try:
+        await db.commit()
+        await db.refresh(db_owner)
+        return db_owner
+    except IntegrityError as err:
+        await db.rollback()
+        raise HTTPException(
+            status_code=400, detail="Email or Registration conflict"
+        ) from err
+
+
+@router.delete("/{owner_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_owner(owner_id: int, db: DbSession):
+    result = await db.execute(select(Owner).filter(Owner.id == owner_id))
+    db_owner = result.scalars().first()
+    if not db_owner:
+        raise HTTPException(status_code=404, detail="Owner not found")
+
+    await db.delete(db_owner)
+    await db.commit()
+    return None

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -140,8 +140,10 @@ class OwnerUpdate(BaseModel):
     boat_registration_number: str | None = None
 
 
-class OwnerResponse(OwnerBase):
+class OwnerOut(_Base):
     id: int
-
-    # Allows Pydantic to read the data even if it's not a dict (like a SQLAlchemy model)
-    model_config = ConfigDict(from_attributes=True)
+    name: str
+    email: EmailStr
+    phone: str | None = None
+    boat_name: str | None = None
+    boat_registration_number: str | None = None

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -118,3 +118,30 @@ class AdoptIn(BaseModel):
     )
     berth_id: str
     gateway_id: str
+
+
+class OwnerBase(BaseModel):
+    name: str
+    email: EmailStr
+    phone: str | None = None
+    boat_name: str | None = None
+    boat_registration_number: str | None = None
+
+
+class OwnerCreate(OwnerBase):
+    pass
+
+
+class OwnerUpdate(BaseModel):
+    name: str | None = None
+    email: EmailStr | None = None
+    phone: str | None = None
+    boat_name: str | None = None
+    boat_registration_number: str | None = None
+
+
+class OwnerResponse(OwnerBase):
+    id: int
+
+    # Allows Pydantic to read the data even if it's not a dict (like a SQLAlchemy model)
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary

Implemented Owner endpoints

- POST /owners creates a new owner
- GET /owners lists all owners
- GET /owners/:id returns a single owner
- PUT /owners/:id updates an owner
- DELETE /owners/:id deletes an owner

## Related Issue

Closes #23 

## Changes

## Changes
- **Database Models:** Created `Owner` SQLAlchemy model with unique constraints on email and boat registration number.
- **Schemas:** Defined `OwnerCreate`, `OwnerUpdate`, and `OwnerOut` Pydantic models.
- **CRUD Logic:** Implemented full async CRUD operations
- **Error Handling:** Added `IntegrityError` catches to return `400 Bad Request` for duplicate registrations or emails.
- **Dependency Injection:** Integrated the new `DbSession` type for cleaner route signatures.

## Checklist

- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [ ] All existing tests pass
- [x] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
