### PR TITLE
fix(events): skip SSE publish on noop sensor reading

### DIFF
--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -27,6 +27,9 @@ async def process_sensor_reading(
     if berth is None:
         raise ValueError(f"Unknown berth: {berth_id}")
 
+    prev_status = berth.status
+    prev_battery = berth.battery_pct
+
     now = datetime.now(UTC)
     new_status = "occupied" if occupied else "free"
 
@@ -35,9 +38,10 @@ async def process_sensor_reading(
     if battery_pct is not None:
         berth.battery_pct = battery_pct
 
-    if new_status == berth.status:
+    if new_status == prev_status:
         await session.commit()
-        _publish_berth_update(berth)
+        if berth.battery_pct != prev_battery:
+            _publish_berth_update(berth)
         return None
 
     event = Event(

--- a/backend/tests/test_stream.py
+++ b/backend/tests/test_stream.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import pytest
+
 from app import broadcaster
 from app.events import process_heartbeat, process_sensor_reading
 
@@ -42,6 +44,52 @@ async def test_multiple_subscribers_each_receive_events(session, seeded_berth):
 
     assert e1["berth"]["status"] == "occupied"
     assert e2["berth"]["status"] == "occupied"
+
+
+async def test_subscriber_does_not_receive_noop_sensor_reading(session, seeded_berth):
+    await process_sensor_reading(
+        session,
+        berth_id="b1",
+        node_id="n1",
+        occupied=False,
+        sensor_raw=100,
+        battery_pct=80,
+    )
+    async with broadcaster.subscribe() as queue:
+        await process_sensor_reading(
+            session,
+            berth_id="b1",
+            node_id="n1",
+            occupied=False,
+            sensor_raw=110,
+            battery_pct=80,
+        )
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(queue.get(), timeout=0.1)
+
+
+async def test_subscriber_receives_battery_change_without_status_change(
+    session, seeded_berth
+):
+    await process_sensor_reading(
+        session,
+        berth_id="b1",
+        node_id="n1",
+        occupied=False,
+        sensor_raw=100,
+        battery_pct=80,
+    )
+    async with broadcaster.subscribe() as queue:
+        await process_sensor_reading(
+            session,
+            berth_id="b1",
+            node_id="n1",
+            occupied=False,
+            sensor_raw=100,
+            battery_pct=70,
+        )
+        event = await asyncio.wait_for(queue.get(), timeout=1.0)
+    assert event["berth"]["battery_pct"] == 70
 
 
 async def test_unsubscribe_after_context_exit(session, seeded_berth):


### PR DESCRIPTION
## Summary

Sensor readings that don't change status or battery_pct no longer fire a berth.update SSE event.

## Checklist

- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [x] All existing tests pass
- [ ] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
