### PR TITLE
refactor: centralize dependencies and modernize configuration

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -10,6 +10,11 @@ class Settings(BaseSettings):
     database_url: str = (
         "postgresql+asyncpg://dockpulse:dockpulse@localhost:5432/dockpulse"
     )
+    mqtt_broker: str = "localhost"
+    mqtt_tls_ca: str | None = None
+    mqtt_tls_cert: str | None = None
+    mqtt_tls_key: str | None = None
+    mqtt_port: int | None = None
 
 
 @lru_cache

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -11,10 +11,10 @@ SessionDep = Annotated[AsyncSession, Depends(get_session)]
 CurrentUserDep = Annotated[User, Depends(get_current_user)]
 
 
-async def _require_harbormaster(user: CurrentUserDep) -> User:
+async def require_harbormaster(user: CurrentUserDep) -> User:
     if user.role != "harbormaster":
         raise HTTPException(status_code=403, detail="Harbormaster role required")
     return user
 
 
-HarbormasterDep = Annotated[User, Depends(_require_harbormaster)]
+HarbormasterDep = Annotated[User, Depends(require_harbormaster)]

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,0 +1,20 @@
+from typing import Annotated
+
+from fastapi import Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_current_user
+from app.db import get_session
+from app.models import User
+
+SessionDep = Annotated[AsyncSession, Depends(get_session)]
+CurrentUserDep = Annotated[User, Depends(get_current_user)]
+
+
+async def _require_harbormaster(user: CurrentUserDep) -> User:
+    if user.role != "harbormaster":
+        raise HTTPException(status_code=403, detail="Harbormaster role required")
+    return user
+
+
+HarbormasterDep = Annotated[User, Depends(_require_harbormaster)]

--- a/backend/app/mqtt.py
+++ b/backend/app/mqtt.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import logging
-import os
 import ssl
 from datetime import UTC, datetime
 
@@ -9,17 +8,12 @@ import aiomqtt
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.adoption.finalize import complete_adoption_err, complete_adoption_ok
+from app.config import get_settings
 from app.db import get_sessionmaker
 from app.events import process_heartbeat, process_sensor_reading
 from app.models import Gateway
 
 logger = logging.getLogger(__name__)
-
-MQTT_BROKER = os.environ.get("MQTT_BROKER", "localhost")
-MQTT_TLS_CA = os.environ.get("MQTT_TLS_CA")
-MQTT_TLS_CERT = os.environ.get("MQTT_TLS_CERT")
-MQTT_TLS_KEY = os.environ.get("MQTT_TLS_KEY")
-MQTT_PORT = int(os.environ.get("MQTT_PORT", "8883" if MQTT_TLS_CA else "1883"))
 
 # Legacy berth-status topics.
 STATUS_TOPIC = "harbor/+/+/+/status"
@@ -43,12 +37,13 @@ def is_mqtt_connected() -> bool:
 
 
 def _build_tls_context() -> ssl.SSLContext | None:
-    if not (MQTT_TLS_CA and MQTT_TLS_CERT and MQTT_TLS_KEY):
+    s = get_settings()
+    if not (s.mqtt_tls_ca and s.mqtt_tls_cert and s.mqtt_tls_key):
         return None
     ctx = ssl.create_default_context(
-        purpose=ssl.Purpose.SERVER_AUTH, cafile=MQTT_TLS_CA
+        purpose=ssl.Purpose.SERVER_AUTH, cafile=s.mqtt_tls_ca
     )
-    ctx.load_cert_chain(certfile=MQTT_TLS_CERT, keyfile=MQTT_TLS_KEY)
+    ctx.load_cert_chain(certfile=s.mqtt_tls_cert, keyfile=s.mqtt_tls_key)
     ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     return ctx
 
@@ -213,18 +208,20 @@ async def publish_provision_req(
 
 async def mqtt_listener() -> None:
     global _connected, _client
+    s = get_settings()
+    port = s.mqtt_port if s.mqtt_port is not None else (8883 if s.mqtt_tls_ca else 1883)
     tls_context = _build_tls_context()
     while True:
         try:
             async with aiomqtt.Client(
-                MQTT_BROKER, MQTT_PORT, tls_context=tls_context
+                s.mqtt_broker, port, tls_context=tls_context
             ) as client:
                 _client = client
                 _connected = True
                 logger.info(
                     "Connected to MQTT broker %s:%s (tls=%s)",
-                    MQTT_BROKER,
-                    MQTT_PORT,
+                    s.mqtt_broker,
+                    port,
                     tls_context is not None,
                 )
                 await client.subscribe(STATUS_TOPIC)

--- a/backend/app/routers/adoptions.py
+++ b/backend/app/routers/adoptions.py
@@ -1,16 +1,10 @@
-from typing import Annotated
+from fastapi import APIRouter, HTTPException
 
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from app.auth import get_current_user
-from app.db import get_session
-from app.models import AdoptionRequest, User
+from app.dependencies import HarbormasterDep, SessionDep
+from app.models import AdoptionRequest
 from app.schemas import AdoptionRequestOut
 
 router = APIRouter(prefix="/api/adoptions", tags=["adoptions"])
-sessiondep = Annotated[AsyncSession, Depends(get_session)]
-currentuser_dep = Annotated[User, Depends(get_current_user)]
 
 
 @router.get(
@@ -20,12 +14,9 @@ currentuser_dep = Annotated[User, Depends(get_current_user)]
 )
 async def get_adoption(
     request_id: str,
-    current_user: currentuser_dep,
-    session: sessiondep,
+    current_user: HarbormasterDep,
+    session: SessionDep,
 ):
-    if current_user.role != "harbormaster":
-        raise HTTPException(status_code=403, detail="Harbormaster role required")
-
     request = await session.get(AdoptionRequest, request_id)
     if request is None:
         raise HTTPException(status_code=404, detail="Adoption request not found")

--- a/backend/app/routers/adoptions.py
+++ b/backend/app/routers/adoptions.py
@@ -1,6 +1,6 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
-from app.dependencies import HarbormasterDep, SessionDep
+from app.dependencies import SessionDep, require_harbormaster
 from app.models import AdoptionRequest
 from app.schemas import AdoptionRequestOut
 
@@ -11,12 +11,9 @@ router = APIRouter(prefix="/api/adoptions", tags=["adoptions"])
     "/{request_id}",
     response_model=AdoptionRequestOut,
     operation_id="getAdoption",
+    dependencies=[Depends(require_harbormaster)],
 )
-async def get_adoption(
-    request_id: str,
-    current_user: HarbormasterDep,
-    session: SessionDep,
-):
+async def get_adoption(request_id: str, session: SessionDep):
     request = await session.get(AdoptionRequest, request_id)
     if request is None:
         raise HTTPException(status_code=404, detail="Adoption request not found")

--- a/backend/app/routers/berths.py
+++ b/backend/app/routers/berths.py
@@ -16,6 +16,28 @@ SSE_PING_SECONDS = 15
 
 
 @router.get(
+    "",
+    response_model=list[BerthOut],
+    operation_id="listBerths",
+    summary="List all berths",
+)
+async def list_berths(
+    session: SessionDep,
+    dock_id: str | None = Query(None, description="filter by dock"),
+    status: str | None = Query(
+        None, pattern="^(free|occupied)$", description="filter by status"
+    ),
+):
+    stmt = select(Berth)
+    if dock_id:
+        stmt = stmt.where(Berth.dock_id == dock_id)
+    if status:
+        stmt = stmt.where(Berth.status == status)
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+@router.get(
     "/stream",
     operation_id="streamBerths",
     summary="Subscribe to live berth updates via Server-Sent Events",
@@ -60,25 +82,3 @@ async def get_berth(berth_id: str, session: SessionDep):
     if not berth:
         raise HTTPException(status_code=404, detail="Berth not found")
     return berth
-
-
-@router.get(
-    "",
-    response_model=list[BerthOut],
-    operation_id="listBerths",
-    summary="List all berths",
-)
-async def list_berths(
-    session: SessionDep,
-    dock_id: str | None = Query(None, description="filter by dock"),
-    status: str | None = Query(
-        None, pattern="^(free|occupied)$", description="filter by status"
-    ),
-):
-    stmt = select(Berth)
-    if dock_id:
-        stmt = stmt.where(Berth.dock_id == dock_id)
-    if status:
-        stmt = stmt.where(Berth.status == status)
-    result = await session.execute(stmt)
-    return result.scalars().all()

--- a/backend/app/routers/berths.py
+++ b/backend/app/routers/berths.py
@@ -1,19 +1,16 @@
 import asyncio
 import json
-from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse
 
 from app import broadcaster
-from app.db import get_session
+from app.dependencies import SessionDep
 from app.models import Berth
 from app.schemas import BerthOut, BerthUpdateEvent
 
 router = APIRouter(prefix="/api/berths", tags=["berths"])
-sessiondep = Annotated[AsyncSession, Depends(get_session)]
 
 SSE_PING_SECONDS = 15
 
@@ -58,7 +55,7 @@ async def stream_berths(request: Request):
     operation_id="getBerth",
     summary="Get a single berth",
 )
-async def get_berth(berth_id: str, session: sessiondep):
+async def get_berth(berth_id: str, session: SessionDep):
     berth = await session.get(Berth, berth_id)
     if not berth:
         raise HTTPException(status_code=404, detail="Berth not found")
@@ -72,7 +69,7 @@ async def get_berth(berth_id: str, session: sessiondep):
     summary="List all berths",
 )
 async def list_berths(
-    session: sessiondep,
+    session: SessionDep,
     dock_id: str | None = Query(None, description="filter by dock"),
     status: str | None = Query(
         None, pattern="^(free|occupied)$", description="filter by status"

--- a/backend/app/routers/docks.py
+++ b/backend/app/routers/docks.py
@@ -1,16 +1,11 @@
-from typing import Annotated
-
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db import get_session
+from app.dependencies import SessionDep
 from app.models import Dock
 from app.schemas import DockOut, DockWithBerthsOut
 
 router = APIRouter(prefix="/api/docks", tags=["docks"])
-
-sessiondep = Annotated[AsyncSession, Depends(get_session)]
 
 
 @router.get(
@@ -20,7 +15,7 @@ sessiondep = Annotated[AsyncSession, Depends(get_session)]
     summary="List all docks",
 )
 async def list_docks(
-    session: sessiondep,
+    session: SessionDep,
     harbor_id: str | None = Query(None, description="Filter by harbor"),
 ) -> list[DockOut]:
     stmt = select(Dock)
@@ -36,7 +31,7 @@ async def list_docks(
     operation_id="getDock",
     summary="Get a single dock with its berths",
 )
-async def get_dock(dock_id: str, session: sessiondep) -> DockWithBerthsOut:
+async def get_dock(dock_id: str, session: SessionDep) -> DockWithBerthsOut:
     dock = await session.get(Dock, dock_id)
     if not dock:
         raise HTTPException(

--- a/backend/app/routers/nodes.py
+++ b/backend/app/routers/nodes.py
@@ -3,23 +3,18 @@ import binascii
 import json
 import uuid
 from datetime import UTC, datetime, timedelta
-from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, HTTPException
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.adoption.claims import ClaimError, FactoryClaim, verify_claim_jwt
-from app.auth import get_current_user
-from app.db import get_session
-from app.models import AdoptionRequest, Berth, Gateway, Node, User
+from app.dependencies import HarbormasterDep, SessionDep
+from app.models import AdoptionRequest, Berth, Gateway, Node
 from app.mqtt import publish_provision_req
 from app.schemas import AdoptIn, AdoptionRequestOut
 
 router = APIRouter(prefix="/api/nodes", tags=["nodes"])
-sessiondep = Annotated[AsyncSession, Depends(get_session)]
-currentuser_dep = Annotated[User, Depends(get_current_user)]
 
 ADOPTION_TTL = timedelta(seconds=60)
 
@@ -55,12 +50,9 @@ def _verify_claim(qr: dict) -> FactoryClaim:
 )
 async def adopt_node(
     body: AdoptIn,
-    current_user: currentuser_dep,
-    session: sessiondep,
+    current_user: HarbormasterDep,
+    session: SessionDep,
 ):
-    if current_user.role != "harbormaster":
-        raise HTTPException(status_code=403, detail="Harbormaster role required")
-
     qr = _decode_qr_payload(body.qr_payload)
     claim = _verify_claim(qr)
 

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,20 +1,16 @@
 import uuid
-from typing import Annotated
 
 from argon2 import PasswordHasher
 from argon2.exceptions import VerifyMismatchError
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, HTTPException
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import create_access_token, get_current_user
-from app.db import get_session
+from app.auth import create_access_token
+from app.dependencies import CurrentUserDep, SessionDep
 from app.models import User
 from app.schemas import LoginIn, TokenOut, UserCreate, UserOut, UserPatch
 
 router = APIRouter(prefix="/api/users", tags=["users"])
-currentuser_dep = Annotated[User, Depends(get_current_user)]
-sessiondep = Annotated[AsyncSession, Depends(get_session)]
 
 _ph = PasswordHasher()
 # Precomputed dummy hash so unknown-email logins still pay the verify cost,
@@ -33,7 +29,7 @@ def _hash_password(password: str) -> str:
     operation_id="registerUser",
     summary="Register a new user",
 )
-async def register_user(body: UserCreate, session: sessiondep):
+async def register_user(body: UserCreate, session: SessionDep):
     existing = await session.execute(select(User).where(User.email == body.email))
     if existing.scalar_one_or_none() is not None:
         raise HTTPException(status_code=409, detail="Email already in use")
@@ -59,7 +55,7 @@ async def register_user(body: UserCreate, session: sessiondep):
     operation_id="login",
     summary="Log in and obtain an access token",
 )
-async def login(body: LoginIn, session: sessiondep):
+async def login(body: LoginIn, session: SessionDep):
     result = await session.execute(select(User).where(User.email == body.email))
     user = result.scalar_one_or_none()
 
@@ -80,7 +76,7 @@ async def login(body: LoginIn, session: sessiondep):
     operation_id="getMe",
     summary="Get current user profile",
 )
-async def get_me(current_user: currentuser_dep):
+async def get_me(current_user: CurrentUserDep):
     return current_user
 
 
@@ -90,9 +86,7 @@ async def get_me(current_user: currentuser_dep):
     operation_id="updateMe",
     summary="Update current user profile",
 )
-async def update_me(
-    body: UserPatch, current_user: currentuser_dep, session: sessiondep
-):
+async def update_me(body: UserPatch, current_user: CurrentUserDep, session: SessionDep):
     if body.email and body.email != current_user.email:
         existing = await session.execute(select(User).where(User.email == body.email))
         if existing.scalar_one_or_none() is not None:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -4,12 +4,11 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 
-class _Base(BaseModel):
+class BaseSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
-    # Something about this being better for pydantic
 
 
-class BerthOut(_Base):  # Grundläggande begränsningar
+class BerthOut(BaseSchema):
     berth_id: str
     dock_id: str
     label: str | None = None
@@ -22,20 +21,20 @@ class BerthOut(_Base):  # Grundläggande begränsningar
     last_updated: datetime | None = None
 
 
-class DockOut(_Base):
+class DockOut(BaseSchema):
     dock_id: str
     harbor_id: str
     name: str
 
 
-class DockWithBerthsOut(_Base):
+class DockWithBerthsOut(BaseSchema):
     dock_id: str
     harbor_id: str
     name: str
     berths: list[BerthOut] = []
 
 
-class UserOut(_Base):
+class UserOut(BaseSchema):
     user_id: str
     firstname: str
     lastname: str
@@ -85,7 +84,7 @@ class BerthUpdateEvent(BaseModel):
     berth: BerthOut
 
 
-class GatewayOut(_Base):
+class GatewayOut(BaseSchema):
     gateway_id: str
     dock_id: str
     name: str
@@ -93,7 +92,7 @@ class GatewayOut(_Base):
     last_seen: datetime | None = None
 
 
-class NodeOut(_Base):
+class NodeOut(BaseSchema):
     node_id: str
     mesh_uuid: str
     serial_number: str
@@ -104,7 +103,7 @@ class NodeOut(_Base):
     adopted_at: datetime
 
 
-class AdoptionRequestOut(_Base):
+class AdoptionRequestOut(BaseSchema):
     request_id: str
     mesh_uuid: str
     serial_number: str

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -4,11 +4,11 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 
-class BaseSchema(BaseModel):
+class _BaseSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-class BerthOut(BaseSchema):
+class BerthOut(_BaseSchema):
     berth_id: str
     dock_id: str
     label: str | None = None
@@ -21,20 +21,20 @@ class BerthOut(BaseSchema):
     last_updated: datetime | None = None
 
 
-class DockOut(BaseSchema):
+class DockOut(_BaseSchema):
     dock_id: str
     harbor_id: str
     name: str
 
 
-class DockWithBerthsOut(BaseSchema):
+class DockWithBerthsOut(_BaseSchema):
     dock_id: str
     harbor_id: str
     name: str
     berths: list[BerthOut] = []
 
 
-class UserOut(BaseSchema):
+class UserOut(_BaseSchema):
     user_id: str
     firstname: str
     lastname: str
@@ -84,7 +84,7 @@ class BerthUpdateEvent(BaseModel):
     berth: BerthOut
 
 
-class GatewayOut(BaseSchema):
+class GatewayOut(_BaseSchema):
     gateway_id: str
     dock_id: str
     name: str
@@ -92,7 +92,7 @@ class GatewayOut(BaseSchema):
     last_seen: datetime | None = None
 
 
-class NodeOut(BaseSchema):
+class NodeOut(_BaseSchema):
     node_id: str
     mesh_uuid: str
     serial_number: str
@@ -103,7 +103,7 @@ class NodeOut(BaseSchema):
     adopted_at: datetime
 
 
-class AdoptionRequestOut(BaseSchema):
+class AdoptionRequestOut(_BaseSchema):
     request_id: str
     mesh_uuid: str
     serial_number: str

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,26 @@
+from app.config import Settings
+
+
+def test_mqtt_settings_default_broker():
+    s = Settings(secret_key="x")
+    assert s.mqtt_broker == "localhost"
+
+
+def test_mqtt_settings_tls_fields_default_to_none():
+    s = Settings(secret_key="x")
+    assert s.mqtt_tls_ca is None
+    assert s.mqtt_tls_cert is None
+    assert s.mqtt_tls_key is None
+
+
+def test_mqtt_port_defaults_to_none():
+    s = Settings(secret_key="x")
+    assert s.mqtt_port is None
+
+
+def test_mqtt_settings_read_from_env(monkeypatch):
+    monkeypatch.setenv("MQTT_BROKER", "mqtt.example.com")
+    monkeypatch.setenv("MQTT_PORT", "1883")
+    s = Settings(secret_key="x")
+    assert s.mqtt_broker == "mqtt.example.com"
+    assert s.mqtt_port == 1883

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,26 +1,31 @@
+import pytest
+
 from app.config import Settings
 
 
+@pytest.fixture(autouse=True)
+def _secret_key_env(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "x")
+
+
 def test_mqtt_settings_default_broker():
-    s = Settings(secret_key="x")
-    assert s.mqtt_broker == "localhost"
+    assert Settings().mqtt_broker == "localhost"
 
 
 def test_mqtt_settings_tls_fields_default_to_none():
-    s = Settings(secret_key="x")
+    s = Settings()
     assert s.mqtt_tls_ca is None
     assert s.mqtt_tls_cert is None
     assert s.mqtt_tls_key is None
 
 
 def test_mqtt_port_defaults_to_none():
-    s = Settings(secret_key="x")
-    assert s.mqtt_port is None
+    assert Settings().mqtt_port is None
 
 
 def test_mqtt_settings_read_from_env(monkeypatch):
     monkeypatch.setenv("MQTT_BROKER", "mqtt.example.com")
     monkeypatch.setenv("MQTT_PORT", "1883")
-    s = Settings(secret_key="x")
+    s = Settings()
     assert s.mqtt_broker == "mqtt.example.com"
     assert s.mqtt_port == 1883

--- a/backend/tests/test_dependencies.py
+++ b/backend/tests/test_dependencies.py
@@ -1,0 +1,30 @@
+import pytest
+from fastapi import HTTPException
+
+from app.dependencies import _require_harbormaster
+from app.models import User
+
+
+def _make_user(role: str) -> User:
+    return User(
+        user_id="u1",
+        firstname="X",
+        lastname="Y",
+        email="x@y.com",
+        password_hash="h",
+        role=role,
+    )
+
+
+async def test_require_harbormaster_raises_for_boat_owner():
+    user = _make_user("boat_owner")
+    with pytest.raises(HTTPException) as exc:
+        await _require_harbormaster(user)
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Harbormaster role required"
+
+
+async def test_require_harbormaster_returns_user_for_harbormaster():
+    user = _make_user("harbormaster")
+    result = await _require_harbormaster(user)
+    assert result is user

--- a/backend/tests/test_dependencies.py
+++ b/backend/tests/test_dependencies.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi import HTTPException
 
-from app.dependencies import _require_harbormaster
+from app.dependencies import require_harbormaster
 from app.models import User
 
 
@@ -16,15 +16,15 @@ def _make_user(role: str) -> User:
     )
 
 
-async def test_require_harbormaster_raises_for_boat_owner():
+async def testrequire_harbormaster_raises_for_boat_owner():
     user = _make_user("boat_owner")
     with pytest.raises(HTTPException) as exc:
-        await _require_harbormaster(user)
+        await require_harbormaster(user)
     assert exc.value.status_code == 403
     assert exc.value.detail == "Harbormaster role required"
 
 
-async def test_require_harbormaster_returns_user_for_harbormaster():
+async def testrequire_harbormaster_returns_user_for_harbormaster():
     user = _make_user("harbormaster")
-    result = await _require_harbormaster(user)
+    result = await require_harbormaster(user)
     assert result is user


### PR DESCRIPTION
## Summary

General code clean up. No functional changes.

## Changes

- Removed some unnecessary comments
- Centralized dependencies into dependencies.py
- Reordering of some functions within files
- mqtt broker now uses pydantic_settings instead of os.environ

## Checklist

- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [x] All existing tests pass
- [x] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format

## Further clean-up considerations

Weird global enum variables at the top of models.py and using Strings for everything.

Example:
> berth_status_enum = Enum("free", "occupied", name="berth_status")

Could use:

> from enum import StrEnum
> from sqlalchemy import Enum // (avoid naming colission if importing enum.Enum)
> 
> class BerthStatus(StrEnum):
>     FREE = "free"
>     OCCUPIED = "occupied"



