### PR TITLE
feat(api): implement logout endpoint by bumping token_version

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -104,3 +104,15 @@ async def update_me(body: UserPatch, current_user: CurrentUserDep, session: Sess
     await session.commit()
     await session.refresh(current_user)
     return current_user
+
+
+@router.post(
+    "/me/logout",
+    status_code=204,
+    operation_id="logout",
+    summary="Invalidate all tokens for the current user",
+)
+async def logout(current_user: CurrentUserDep, session: SessionDep):
+    current_user.token_version += 1
+    session.add(current_user)
+    await session.commit()

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -179,3 +179,25 @@ async def test_login_unknown_email_returns_401(client: AsyncClient):
         json={"email": "nobody@example.com", "password": "secret"},
     )
     assert r.status_code == 401
+
+
+async def test_logout_returns_204(client: AsyncClient, test_user: User):
+    token = make_token(test_user.user_id)
+    r = await client.post(
+        "/api/users/me/logout", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert r.status_code == 204
+
+
+async def test_logout_invalidates_token(client: AsyncClient, test_user: User):
+    token = make_token(test_user.user_id)
+    await client.post(
+        "/api/users/me/logout", headers={"Authorization": f"Bearer {token}"}
+    )
+    r = await client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 401
+
+
+async def test_logout_requires_auth(client: AsyncClient):
+    r = await client.post("/api/users/me/logout")
+    assert r.status_code == 401

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -788,6 +788,17 @@ paths:
       summary: Update current user profile
       tags:
       - users
+  /api/users/me/logout:
+    post:
+      operationId: logout
+      responses:
+        '204':
+          description: Successful Response
+      security:
+      - HTTPBearer: []
+      summary: Invalidate all tokens for the current user
+      tags:
+      - users
   /api/users/token:
     post:
       operationId: login


### PR DESCRIPTION
## Summary                                                                     
                                                                                 
Minimal logout implementation.                                                 
   
- Adds `POST /api/users/me/logout` endpoint                                    
- Bumps `token_version` to invalidate all existing tokens server-side
- Returns 204

## Related Issue

Closes #63

## Notes                                                                       
   
Bumping `token_version` invalidates all tokens for the user at once. A proper solution would require refresh tokens.

Short-lived access tokens paired with long-lived refresh tokens stored server-side, allowing per-device logout by invalidating individual refresh tokens without affecting other sessions.

No unit tests written since test suite is being reworked.

## Checklist

- [ ] Code compiles/builds without errors or warnings
- [ ] Code follows the project style guide and has been formatted
- [ ] All existing tests pass
- [ ] New functionality includes appropriate tests
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
