### PR TITLE
feat(api): harbormaster notification prefs and  berth event log

### DIFF
--- a/backend/alembic/versions/2dfb33216c12_add_user_notification_prefs_table.py
+++ b/backend/alembic/versions/2dfb33216c12_add_user_notification_prefs_table.py
@@ -1,0 +1,45 @@
+"""add user_notification_prefs table
+
+Revision ID: 2dfb33216c12
+Revises: a1f3c8d27b50
+Create Date: 2026-05-03 01:04:25.114981
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "2dfb33216c12"
+down_revision: str | Sequence[str] | None = "a1f3c8d27b50"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_notification_prefs",
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column(
+            "notify_arrival",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+        sa.Column(
+            "notify_departure",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.user_id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("user_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_notification_prefs")

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -1,13 +1,20 @@
+import asyncio
+import logging
 import uuid
 from datetime import UTC, datetime
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import joinedload, selectinload
 
 from app import broadcaster
-from app.models import Berth, Event
+from app.models import Berth, Event, User
+from app.notifications import send_email
 from app.schemas import BerthUpdateEvent
+
+logger = logging.getLogger(__name__)
+
+# todo harbor-scope once User has harbor_id pages every hm right now
 
 
 def _publish_berth_update(berth: Berth) -> None:
@@ -23,6 +30,45 @@ async def _load_berth(session: AsyncSession, berth_id: str) -> Berth | None:
         .where(Berth.berth_id == berth_id)
     )
     return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def _notify_harbormasters(
+    session: AsyncSession,
+    berth: Berth,
+    new_status: str,
+    event_id: str,
+) -> None:
+    result = await session.execute(
+        select(User)
+        .where(User.role == "harbormaster")
+        .options(joinedload(User.notification_prefs))
+    )
+    harbormasters = result.unique().scalars().all()
+
+    label = berth.label or berth.berth_id
+    if new_status == "occupied":
+        subject = f"Berth {label} is now occupied"
+        html = f"<p>Berth <strong>{label}</strong> has been occupied.</p>"
+    else:
+        subject = f"Berth {label} is now free"
+        html = f"<p>Berth <strong>{label}</strong> has been freed.</p>"
+
+    coros = []
+    for hm in harbormasters:
+        prefs = hm.notification_prefs
+        if prefs is not None:
+            if new_status == "occupied" and not prefs.notify_arrival:
+                continue
+            if new_status == "free" and not prefs.notify_departure:
+                continue
+
+        idem_key = f"berth-status/{event_id}/{hm.user_id}"
+        coros.append(send_email(hm.email, subject, html, idem_key))
+
+    results = await asyncio.gather(*coros, return_exceptions=True)
+    for exc in results:
+        if isinstance(exc, BaseException):
+            logger.warning("Failed to send notification email: %s", exc)
 
 
 async def process_sensor_reading(
@@ -68,6 +114,7 @@ async def process_sensor_reading(
     session.add(event)
     await session.commit()
     _publish_berth_update(berth)
+    await _notify_harbormasters(session, berth, new_status, event.event_id)
     return event
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -33,6 +33,9 @@ class User(Base):
         user_role_enum, nullable=False, default="boat_owner"
     )
     assignments: Mapped[list["Assignment"]] = relationship(back_populates="user")
+    notification_prefs: Mapped["UserNotificationPrefs | None"] = relationship(
+        back_populates="user", uselist=False, cascade="all, delete-orphan"
+    )
 
 
 class Harbor(Base):
@@ -183,6 +186,20 @@ class FactoryKey(Base):
         DateTime(timezone=True), nullable=False
     )
     revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class UserNotificationPrefs(Base):
+    __tablename__ = "user_notification_prefs"
+
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("users.user_id", ondelete="CASCADE"), primary_key=True
+    )
+    notify_arrival: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    notify_departure: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True
+    )
+
+    user: Mapped["User"] = relationship(back_populates="notification_prefs")
 
 
 class Assignment(Base):

--- a/backend/app/notifications.py
+++ b/backend/app/notifications.py
@@ -8,7 +8,12 @@ from app.config import get_settings
 logger = logging.getLogger(__name__)
 
 
-async def send_email(to: str | list[str], subject: str, html: str) -> None:
+async def send_email(
+    to: str | list[str],
+    subject: str,
+    html: str,
+    idempotency_key: str | None = None,
+) -> None:
     settings = get_settings()
     if not settings.resend_api_key:
         logger.warning(
@@ -16,20 +21,28 @@ async def send_email(to: str | list[str], subject: str, html: str) -> None:
         )
         return
     # resend sdk sync, offload so handler doesnt block loop
-    await asyncio.to_thread(_send_sync, settings, to, subject, html)
+    await asyncio.to_thread(_send_sync, settings, to, subject, html, idempotency_key)
 
 
-def _send_sync(settings, to: str | list[str], subject: str, html: str) -> None:
+def _send_sync(
+    settings,
+    to: str | list[str],
+    subject: str,
+    html: str,
+    idempotency_key: str | None,
+) -> None:
     resend.api_key = settings.resend_api_key
+    params: resend.Emails.SendParams = {
+        "from": settings.email_from,
+        "to": [to] if isinstance(to, str) else to,
+        "subject": subject,
+        "html": html,
+    }
     try:
-        resend.Emails.send(
-            {
-                "from": settings.email_from,
-                "to": [to] if isinstance(to, str) else to,
-                "subject": subject,
-                "html": html,
-            }
-        )
+        if idempotency_key:
+            resend.Emails.send(params, {"idempotency_key": idempotency_key})
+        else:
+            resend.Emails.send(params)
     except Exception:
         logger.exception("Failed to send email to %s", to)
 

--- a/backend/app/routers/berths.py
+++ b/backend/app/routers/berths.py
@@ -8,8 +8,8 @@ from sse_starlette.sse import EventSourceResponse
 
 from app import broadcaster
 from app.dependencies import HarbormasterDep, SessionDep
-from app.models import Assignment, Berth, User
-from app.schemas import AssignBerthIn, BerthOut, BerthUpdateEvent
+from app.models import Assignment, Berth, Event, User
+from app.schemas import AssignBerthIn, BerthOut, BerthUpdateEvent, EventOut
 
 router = APIRouter(prefix="/api/berths", tags=["berths"])
 
@@ -120,6 +120,30 @@ async def assign_berth(
     await session.commit()
 
     return await _load_berth_with_assignment(session, berth_id)
+
+
+@router.get(
+    "/{berth_id}/events",
+    response_model=list[EventOut],
+    operation_id="listBerthEvents",
+    summary="List events for a berth",
+)
+async def list_berth_events(
+    berth_id: str,
+    session: SessionDep,
+    _: HarbormasterDep,
+    limit: int = Query(100, ge=1, le=1000),
+):
+    berth = await session.get(Berth, berth_id)
+    if not berth:
+        raise HTTPException(status_code=404, detail="Berth not found")
+    result = await session.execute(
+        select(Event)
+        .where(Event.berth_id == berth_id)
+        .order_by(Event.timestamp.desc())
+        .limit(limit)
+    )
+    return result.scalars().all()
 
 
 @router.delete(

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -7,8 +7,16 @@ from sqlalchemy import select
 
 from app.auth import create_access_token
 from app.dependencies import CurrentUserDep, SessionDep
-from app.models import User
-from app.schemas import LoginIn, TokenOut, UserCreate, UserOut, UserPatch
+from app.models import User, UserNotificationPrefs
+from app.schemas import (
+    LoginIn,
+    NotificationPrefsOut,
+    NotificationPrefsPatch,
+    TokenOut,
+    UserCreate,
+    UserOut,
+    UserPatch,
+)
 
 router = APIRouter(prefix="/api/users", tags=["users"])
 
@@ -116,3 +124,43 @@ async def logout(current_user: CurrentUserDep, session: SessionDep):
     current_user.token_version += 1
     session.add(current_user)
     await session.commit()
+
+
+@router.get(
+    "/me/notifications",
+    response_model=NotificationPrefsOut,
+    operation_id="getNotificationPrefs",
+    summary="Get notification preferences for the current user",
+)
+async def get_notification_prefs(current_user: CurrentUserDep, session: SessionDep):
+    prefs = await session.get(UserNotificationPrefs, current_user.user_id)
+    if prefs is None:
+        return NotificationPrefsOut(
+            notify_arrival=True,
+            notify_departure=True,
+        )
+    return prefs
+
+
+@router.patch(
+    "/me/notifications",
+    response_model=NotificationPrefsOut,
+    operation_id="updateNotificationPrefs",
+    summary="Update notification preferences for the current user",
+)
+async def update_notification_prefs(
+    body: NotificationPrefsPatch,
+    current_user: CurrentUserDep,
+    session: SessionDep,
+):
+    prefs = await session.get(UserNotificationPrefs, current_user.user_id)
+    if prefs is None:
+        prefs = UserNotificationPrefs(user_id=current_user.user_id)
+        session.add(prefs)
+
+    for field, value in body.model_dump(exclude_none=True).items():
+        setattr(prefs, field, value)
+
+    await session.commit()
+    await session.refresh(prefs)
+    return prefs

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -153,3 +153,22 @@ class AdoptIn(BaseModel):
 class AdoptionUpdateEvent(BaseModel):
     type: Literal["adoption.update"] = "adoption.update"
     request: AdoptionRequestOut
+
+
+class EventOut(_BaseSchema):
+    event_id: str
+    berth_id: str
+    node_id: str
+    event_type: Literal["occupied", "freed", "alert_unauthorized", "heartbeat"]
+    sensor_raw: int
+    timestamp: datetime
+
+
+class NotificationPrefsOut(_BaseSchema):
+    notify_arrival: bool
+    notify_departure: bool
+
+
+class NotificationPrefsPatch(BaseModel):
+    notify_arrival: bool | None = None
+    notify_departure: bool | None = None

--- a/backend/tests/test_berths_api.py
+++ b/backend/tests/test_berths_api.py
@@ -1,4 +1,5 @@
 from app.events import process_sensor_reading
+from tests._helpers import make_auth_token
 
 
 async def test_api_reflects_mqtt_reading(client, session, seeded_berth):
@@ -37,4 +38,44 @@ async def test_api_filter_by_status(client, session, seeded_berth):
 
 async def test_api_unknown_berth_404(client):
     r = await client.get("/api/berths/does-not-exist")
+    assert r.status_code == 404
+
+
+async def test_list_berth_events_empty(client, seeded_berth, harbor_master):
+    token = make_auth_token(harbor_master.user_id)
+    r = await client.get(
+        "/api/berths/b1/events", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+async def test_list_berth_events_returns_events(
+    client, session, seeded_berth, harbor_master
+):
+    await process_sensor_reading(
+        session, berth_id="b1", node_id="n1", occupied=True, sensor_raw=500
+    )
+    token = make_auth_token(harbor_master.user_id)
+    r = await client.get(
+        "/api/berths/b1/events", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data) == 1
+    assert data[0]["event_type"] == "occupied"
+    assert data[0]["node_id"] == "n1"
+
+
+async def test_list_berth_events_requires_auth(client, seeded_berth):
+    r = await client.get("/api/berths/b1/events")
+    assert r.status_code == 401
+
+
+async def test_list_berth_events_unknown_berth(client, harbor_master):
+    token = make_auth_token(harbor_master.user_id)
+    r = await client.get(
+        "/api/berths/does-not-exist/events",
+        headers={"Authorization": f"Bearer {token}"},
+    )
     assert r.status_code == 404

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -93,3 +93,66 @@ async def test_heartbeat_touches_berth_without_event(session, seeded_berth):
 async def test_heartbeat_unknown_berth_raises(session):
     with pytest.raises(ValueError, match="Unknown berth"):
         await process_heartbeat(session, berth_id="does-not-exist")
+
+
+async def test_notify_harbormasters_called_on_state_change(
+    session, seeded_berth, harbor_master, monkeypatch
+):
+    sent: list[dict] = []
+
+    async def _fake_send(to, subject, html, idempotency_key=None):
+        sent.append({"to": to, "subject": subject, "idem": idempotency_key})
+
+    monkeypatch.setattr("app.events.send_email", _fake_send)
+
+    event = await process_sensor_reading(
+        session, berth_id="b1", node_id="n1", occupied=True, sensor_raw=500
+    )
+    assert event is not None
+    assert len(sent) == 1
+    assert sent[0]["to"] == harbor_master.email
+    assert "occupied" in sent[0]["subject"].lower()
+    assert event.event_id in sent[0]["idem"]
+
+
+async def test_notify_harbormasters_respects_arrival_pref(
+    session, seeded_berth, harbor_master, monkeypatch
+):
+    from app.models import UserNotificationPrefs
+
+    prefs = UserNotificationPrefs(
+        user_id=harbor_master.user_id,
+        notify_arrival=False,
+        notify_departure=True,
+    )
+    session.add(prefs)
+    await session.commit()
+
+    sent: list = []
+
+    async def _fake_send(*a, **kw):
+        sent.append(a)
+
+    monkeypatch.setattr("app.events.send_email", _fake_send)
+
+    await process_sensor_reading(
+        session, berth_id="b1", node_id="n1", occupied=True, sensor_raw=500
+    )
+    assert sent == []
+
+
+async def test_no_notification_on_same_status(
+    session, seeded_berth, harbor_master, monkeypatch
+):
+    # b1 already free so occupied=False is noop early-returns before notify
+    sent: list = []
+
+    async def _fake_send(*a, **kw):
+        sent.append(a)
+
+    monkeypatch.setattr("app.events.send_email", _fake_send)
+
+    await process_sensor_reading(
+        session, berth_id="b1", node_id="n1", occupied=False, sensor_raw=100
+    )
+    assert sent == []

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -236,3 +236,36 @@ async def test_logout_invalidates_token(client: AsyncClient, test_user: User):
 async def test_logout_requires_auth(client: AsyncClient):
     r = await client.post("/api/users/me/logout")
     assert r.status_code == 401
+
+
+async def test_get_notification_prefs_returns_defaults(
+    client: AsyncClient, test_user: User
+):
+    token = make_token(test_user.user_id)
+    r = await client.get(
+        "/api/users/me/notifications", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["notify_arrival"] is True
+    assert data["notify_departure"] is True
+
+
+async def test_patch_notification_prefs_updates_fields(
+    client: AsyncClient, test_user: User
+):
+    token = make_token(test_user.user_id)
+    r = await client.patch(
+        "/api/users/me/notifications",
+        json={"notify_arrival": False},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["notify_arrival"] is False
+    assert data["notify_departure"] is True
+
+
+async def test_notification_prefs_requires_auth(client: AsyncClient):
+    r = await client.get("/api/users/me/notifications")
+    assert r.status_code == 401

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -219,6 +219,41 @@ components:
       - name
       title: DockWithBerthsOut
       type: object
+    EventOut:
+      properties:
+        berth_id:
+          title: Berth Id
+          type: string
+        event_id:
+          title: Event Id
+          type: string
+        event_type:
+          enum:
+          - occupied
+          - freed
+          - alert_unauthorized
+          - heartbeat
+          title: Event Type
+          type: string
+        node_id:
+          title: Node Id
+          type: string
+        sensor_raw:
+          title: Sensor Raw
+          type: integer
+        timestamp:
+          format: date-time
+          title: Timestamp
+          type: string
+      required:
+      - event_id
+      - berth_id
+      - node_id
+      - event_type
+      - sensor_raw
+      - timestamp
+      title: EventOut
+      type: object
     HTTPValidationError:
       properties:
         detail:
@@ -273,6 +308,33 @@ components:
       - email
       - password
       title: LoginIn
+      type: object
+    NotificationPrefsOut:
+      properties:
+        notify_arrival:
+          title: Notify Arrival
+          type: boolean
+        notify_departure:
+          title: Notify Departure
+          type: boolean
+      required:
+      - notify_arrival
+      - notify_departure
+      title: NotificationPrefsOut
+      type: object
+    NotificationPrefsPatch:
+      properties:
+        notify_arrival:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Notify Arrival
+        notify_departure:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Notify Departure
+      title: NotificationPrefsPatch
       type: object
     TokenOut:
       properties:
@@ -642,6 +704,46 @@ paths:
       summary: Assign a berth to a user
       tags:
       - berths
+  /api/berths/{berth_id}/events:
+    get:
+      operationId: listBerthEvents
+      parameters:
+      - in: path
+        name: berth_id
+        required: true
+        schema:
+          title: Berth Id
+          type: string
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 100
+          maximum: 1000
+          minimum: 1
+          title: Limit
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/EventOut'
+                title: Response Listberthevents
+                type: array
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - HTTPBearer: []
+      summary: List events for a berth
+      tags:
+      - berths
   /api/docks:
     get:
       operationId: listDocks
@@ -822,6 +924,47 @@ paths:
       security:
       - HTTPBearer: []
       summary: Invalidate all tokens for the current user
+      tags:
+      - users
+  /api/users/me/notifications:
+    get:
+      operationId: getNotificationPrefs
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPrefsOut'
+          description: Successful Response
+      security:
+      - HTTPBearer: []
+      summary: Get notification preferences for the current user
+      tags:
+      - users
+    patch:
+      operationId: updateNotificationPrefs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationPrefsPatch'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPrefsOut'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - HTTPBearer: []
+      summary: Update notification preferences for the current user
       tags:
       - users
   /api/users/token:


### PR DESCRIPTION
## Summary

Adds per-harbormaster notification preferences and a berth event log endpoint. On each berth state change, harbormasters are notified via Resend email according to their individual preferences. Emails are suppressed outside prod. Idempotency keys prevent duplicate sends on retry.

[Resend Idempotency Keys](https://resend.com/docs/dashboard/emails/idempotency-keys#idempotency-keys)

## Related Issue

Closes #88

## Changes

- Add `user_notification_prefs` table with cascade delete
- `GET/PATCH /api/users/me/notifications` to read and update notification preferences
- `GET /api/berths/{berth_id}/events` event log for detail panel (harbormaster only)               
- `app/notifications.py`, `send_email` wrapper with prod gate and idempotency support             
- Wire `_notify_harbormasters` into `process_sensor_reading` after state-change commit 
- Add `resend` dependency, expose `RESEND_API_KEY` and `ENVIRONMENT` in docker-compose                
                       
  Note: `notify_berth_green` / `notify_berth_red` are implemented but not used.

## Checklist

- [ ] Code compiles/builds without errors or warnings
- [ ] Code follows the project style guide and has been formatted
- [ ] All existing tests pass
- [ ] New functionality includes appropriate tests
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
