### PR TITLE
fix(api): input validation and security hardening for user schemas

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -92,10 +92,10 @@ async def update_me(body: UserPatch, current_user: CurrentUserDep, session: Sess
         if existing.scalar_one_or_none() is not None:
             raise HTTPException(status_code=409, detail="Email already in use")
 
-    for field, value in body.model_dump(
-        exclude_none=True, exclude={"password"}
-    ).items():
-        setattr(current_user, field, value)
+    for field in ("firstname", "lastname", "email", "phone", "boat_club"):
+        value = getattr(body, field)
+        if value is not None:
+            setattr(current_user, field, value)
 
     if body.password is not None:
         current_user.password_hash = _hash_password(body.password.get_secret_value())

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -41,7 +41,7 @@ async def register_user(body: UserCreate, session: SessionDep):
         email=body.email,
         phone=body.phone,
         boat_club=body.boat_club,
-        password_hash=_hash_password(body.password),
+        password_hash=_hash_password(body.password.get_secret_value()),
     )
     session.add(user)
     await session.commit()
@@ -61,7 +61,7 @@ async def login(body: LoginIn, session: SessionDep):
 
     target_hash = user.password_hash if user is not None else _DUMMY_HASH
     try:
-        _ph.verify(target_hash, body.password)
+        _ph.verify(target_hash, body.password.get_secret_value())
     except VerifyMismatchError:
         raise HTTPException(status_code=401, detail="Invalid credentials") from None
     if user is None:
@@ -98,7 +98,7 @@ async def update_me(body: UserPatch, current_user: CurrentUserDep, session: Sess
             setattr(current_user, field, value)
 
     if body.password is not None:
-        current_user.password_hash = _hash_password(body.password)
+        current_user.password_hash = _hash_password(body.password.get_secret_value())
 
     session.add(current_user)
     await session.commit()

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -92,10 +92,10 @@ async def update_me(body: UserPatch, current_user: CurrentUserDep, session: Sess
         if existing.scalar_one_or_none() is not None:
             raise HTTPException(status_code=409, detail="Email already in use")
 
-    for field in ("firstname", "lastname", "email", "phone", "boat_club"):
-        value = getattr(body, field)
-        if value is not None:
-            setattr(current_user, field, value)
+    for field, value in body.model_dump(
+        exclude_none=True, exclude={"password"}
+    ).items():
+        setattr(current_user, field, value)
 
     if body.password is not None:
         current_user.password_hash = _hash_password(body.password.get_secret_value())

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -55,26 +55,32 @@ class UserOut(_BaseSchema):
     role: Literal["harbormaster", "boat_owner"]
 
 
+_NAME_FIELD = dict(min_length=1, max_length=100, pattern=r"^[\D]+$")
+_PHONE_FIELD = dict(pattern=r"^\+?[\d\s\-().]{7,20}$")
+
+
 class UserPatch(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
-    firstname: str | None = None
-    lastname: str | None = None
+    firstname: str | None = Field(default=None, **_NAME_FIELD)
+    lastname: str | None = Field(default=None, **_NAME_FIELD)
     email: EmailStr | None = None
-    phone: str | None = None
-    boat_club: str | None = None
-    password: SecretStr | None = Field(default=None, strip_whitespace=False)
+    phone: str | None = Field(default=None, **_PHONE_FIELD)
+    boat_club: str | None = Field(default=None, max_length=100)
+    password: SecretStr | None = Field(
+        default=None, min_length=8, max_length=128, strip_whitespace=False
+    )
 
 
 class UserCreate(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
-    firstname: str = Field(min_length=1)
-    lastname: str = Field(min_length=1)
+    firstname: str = Field(**_NAME_FIELD)
+    lastname: str = Field(**_NAME_FIELD)
     email: EmailStr
-    phone: str | None = None
-    boat_club: str | None = None
-    password: SecretStr = Field(min_length=8, strip_whitespace=False)
+    phone: str | None = Field(default=None, **_PHONE_FIELD)
+    boat_club: str | None = Field(default=None, max_length=100)
+    password: SecretStr = Field(min_length=8, max_length=128, strip_whitespace=False)
 
 
 class LoginIn(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, SecretStr
 
 
 class _BaseSchema(BaseModel):
@@ -61,7 +61,7 @@ class UserPatch(BaseModel):
     email: EmailStr | None = None
     phone: str | None = None
     boat_club: str | None = None
-    password: str | None = None
+    password: SecretStr | None = None
 
 
 class UserCreate(BaseModel):
@@ -70,12 +70,12 @@ class UserCreate(BaseModel):
     email: EmailStr
     phone: str | None = None
     boat_club: str | None = None
-    password: str = Field(min_length=8)
+    password: SecretStr = Field(min_length=8)
 
 
 class LoginIn(BaseModel):
     email: EmailStr
-    password: str
+    password: SecretStr
 
 
 class TokenOut(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -55,7 +55,7 @@ class UserOut(_BaseSchema):
     role: Literal["harbormaster", "boat_owner"]
 
 
-_NAME_FIELD = dict(min_length=1, max_length=100, pattern=r"^[\D]+$")
+_NAME_FIELD = dict(min_length=1, max_length=100, pattern=r"^[A-Za-zÀ-ÖØ-öø-ÿ' \-]+$")
 _PHONE_FIELD = dict(pattern=r"^\+?[\d\s\-().]{7,20}$")
 _PASSWORD_FIELD = dict(min_length=8, max_length=128)
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -87,7 +87,7 @@ class LoginIn(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
     email: EmailStr
-    password: SecretStr = Field(strip_whitespace=False)
+    password: SecretStr = Field(min_length=8, max_length=128, strip_whitespace=False)
 
 
 class TokenOut(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -57,6 +57,12 @@ class UserOut(_BaseSchema):
 
 _NAME_FIELD = dict(min_length=1, max_length=100, pattern=r"^[\D]+$")
 _PHONE_FIELD = dict(pattern=r"^\+?[\d\s\-().]{7,20}$")
+_PASSWORD_FIELD = dict(
+    min_length=8,
+    max_length=128,
+    strip_whitespace=False,
+    json_schema_extra=lambda s: s.pop("strip_whitespace", None),
+)
 
 
 class UserPatch(BaseModel):
@@ -67,9 +73,7 @@ class UserPatch(BaseModel):
     email: EmailStr | None = None
     phone: str | None = Field(default=None, **_PHONE_FIELD)
     boat_club: str | None = Field(default=None, max_length=100)
-    password: SecretStr | None = Field(
-        default=None, min_length=8, max_length=128, strip_whitespace=False
-    )
+    password: SecretStr | None = Field(default=None, **_PASSWORD_FIELD)
 
 
 class UserCreate(BaseModel):
@@ -80,14 +84,14 @@ class UserCreate(BaseModel):
     email: EmailStr
     phone: str | None = Field(default=None, **_PHONE_FIELD)
     boat_club: str | None = Field(default=None, max_length=100)
-    password: SecretStr = Field(min_length=8, max_length=128, strip_whitespace=False)
+    password: SecretStr = Field(**_PASSWORD_FIELD)
 
 
 class LoginIn(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
     email: EmailStr
-    password: SecretStr = Field(min_length=8, max_length=128, strip_whitespace=False)
+    password: SecretStr = Field(**_PASSWORD_FIELD)
 
 
 class TokenOut(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -56,26 +56,32 @@ class UserOut(_BaseSchema):
 
 
 class UserPatch(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
     firstname: str | None = None
     lastname: str | None = None
     email: EmailStr | None = None
     phone: str | None = None
     boat_club: str | None = None
-    password: SecretStr | None = None
+    password: SecretStr | None = Field(default=None, strip_whitespace=False)
 
 
 class UserCreate(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
     firstname: str = Field(min_length=1)
     lastname: str = Field(min_length=1)
     email: EmailStr
     phone: str | None = None
     boat_club: str | None = None
-    password: SecretStr = Field(min_length=8)
+    password: SecretStr = Field(min_length=8, strip_whitespace=False)
 
 
 class LoginIn(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
     email: EmailStr
-    password: SecretStr
+    password: SecretStr = Field(strip_whitespace=False)
 
 
 class TokenOut(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -57,12 +57,7 @@ class UserOut(_BaseSchema):
 
 _NAME_FIELD = dict(min_length=1, max_length=100, pattern=r"^[\D]+$")
 _PHONE_FIELD = dict(pattern=r"^\+?[\d\s\-().]{7,20}$")
-_PASSWORD_FIELD = dict(
-    min_length=8,
-    max_length=128,
-    strip_whitespace=False,
-    json_schema_extra=lambda s: s.pop("strip_whitespace", None),
-)
+_PASSWORD_FIELD = dict(min_length=8, max_length=128)
 
 
 class UserPatch(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -86,7 +86,7 @@ class LoginIn(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
     email: EmailStr
-    password: SecretStr = Field(**_PASSWORD_FIELD)
+    password: SecretStr
 
 
 class TokenOut(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -55,8 +55,10 @@ class UserOut(_BaseSchema):
     role: Literal["harbormaster", "boat_owner"]
 
 
-_NAME_FIELD = dict(min_length=1, max_length=100, pattern=r"^[A-Za-zÀ-ÖØ-öø-ÿ' \-]+$")
-_PHONE_FIELD = dict(pattern=r"^\+?[\d\s\-().]{7,20}$")
+# \p{L} unicode letter \p{M} combining marks
+_NAME_FIELD = dict(min_length=1, max_length=100, pattern=r"^[\p{L}\p{M}'’ .\-]+$")
+# 7 to 15 digits E.164 separators not counted
+_PHONE_FIELD = dict(max_length=20, pattern=r"^\+?(?:[\s\-().]*\d){7,15}[\s\-().]*$")
 _PASSWORD_FIELD = dict(min_length=8, max_length=128)
 
 

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -22,7 +22,7 @@ async def test_user(session: AsyncSession) -> User:
         lastname="Svensson",
         email="anna@example.com",
         phone="0701234567",
-        password_hash=_hash("secret"),
+        password_hash=_hash("secretpassword"),
         boat_club="Göteborgs Segelsällskap",
         token_version=0,
     )
@@ -153,7 +153,7 @@ async def test_register_rejects_invalid_email(client: AsyncClient):
 async def test_login_returns_usable_token(client: AsyncClient, test_user: User):
     r = await client.post(
         "/api/users/token",
-        json={"email": test_user.email, "password": "secret"},
+        json={"email": test_user.email, "password": "secretpassword"},
     )
     assert r.status_code == 200
     body = r.json()
@@ -168,7 +168,7 @@ async def test_login_returns_usable_token(client: AsyncClient, test_user: User):
 async def test_login_wrong_password_returns_401(client: AsyncClient, test_user: User):
     r = await client.post(
         "/api/users/token",
-        json={"email": test_user.email, "password": "wrong"},
+        json={"email": test_user.email, "password": "wrongpassword"},
     )
     assert r.status_code == 401
 
@@ -176,7 +176,7 @@ async def test_login_wrong_password_returns_401(client: AsyncClient, test_user: 
 async def test_login_unknown_email_returns_401(client: AsyncClient):
     r = await client.post(
         "/api/users/token",
-        json={"email": "nobody@example.com", "password": "secret"},
+        json={"email": "nobody@example.com", "password": "secretpassword"},
     )
     assert r.status_code == 401
 

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -150,6 +150,41 @@ async def test_register_rejects_invalid_email(client: AsyncClient):
     assert r.status_code == 422
 
 
+async def test_register_accepts_unicode_names(client: AsyncClient):
+    payload = {
+        **_REGISTER_PAYLOAD,
+        "email": "lukasz@example.com",
+        "firstname": "Łukasz",
+        "lastname": "O’Brien",
+    }
+    r = await client.post("/api/users", json=payload)
+    assert r.status_code == 201
+
+
+async def test_register_rejects_digits_in_name(client: AsyncClient):
+    payload = {**_REGISTER_PAYLOAD, "firstname": "Anna1"}
+    r = await client.post("/api/users", json=payload)
+    assert r.status_code == 422
+
+
+async def test_register_rejects_phone_without_digits(client: AsyncClient):
+    payload = {**_REGISTER_PAYLOAD, "phone": "()()()()()()()"}
+    r = await client.post("/api/users", json=payload)
+    assert r.status_code == 422
+
+
+async def test_register_rejects_overlong_name(client: AsyncClient):
+    payload = {**_REGISTER_PAYLOAD, "firstname": "A" * 101}
+    r = await client.post("/api/users", json=payload)
+    assert r.status_code == 422
+
+
+async def test_register_rejects_overlong_password(client: AsyncClient):
+    payload = {**_REGISTER_PAYLOAD, "password": "a" * 129}
+    r = await client.post("/api/users", json=payload)
+    assert r.status_code == 422
+
+
 async def test_login_returns_usable_token(client: AsyncClient, test_user: User):
     r = await client.post(
         "/api/users/token",

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -268,7 +268,6 @@ components:
           format: password
           maxLength: 128
           minLength: 8
-          strip_whitespace: false
           title: Password
           type: string
           writeOnly: true
@@ -319,7 +318,6 @@ components:
           format: password
           maxLength: 128
           minLength: 8
-          strip_whitespace: false
           title: Password
           type: string
           writeOnly: true
@@ -412,7 +410,6 @@ components:
             type: string
             writeOnly: true
           - type: 'null'
-          strip_whitespace: false
           title: Password
         phone:
           anyOf:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -265,8 +265,10 @@ components:
           title: Email
           type: string
         password:
+          format: password
           title: Password
           type: string
+          writeOnly: true
       required:
       - email
       - password
@@ -306,9 +308,11 @@ components:
           title: Lastname
           type: string
         password:
+          format: password
           minLength: 8
           title: Password
           type: string
+          writeOnly: true
         phone:
           anyOf:
           - type: string
@@ -384,7 +388,9 @@ components:
           title: Lastname
         password:
           anyOf:
-          - type: string
+          - format: password
+            type: string
+            writeOnly: true
           - type: 'null'
           title: Password
         phone:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -303,13 +303,13 @@ components:
         firstname:
           maxLength: 100
           minLength: 1
-          pattern: ^[A-Za-zÀ-ÖØ-öø-ÿ' \-]+$
+          pattern: ^[\p{L}\p{M}'’ .\-]+$
           title: Firstname
           type: string
         lastname:
           maxLength: 100
           minLength: 1
-          pattern: ^[A-Za-zÀ-ÖØ-öø-ÿ' \-]+$
+          pattern: ^[\p{L}\p{M}'’ .\-]+$
           title: Lastname
           type: string
         password:
@@ -321,7 +321,8 @@ components:
           writeOnly: true
         phone:
           anyOf:
-          - pattern: ^\+?[\d\s\-().]{7,20}$
+          - maxLength: 20
+            pattern: ^\+?(?:[\s\-().]*\d){7,15}[\s\-().]*$
             type: string
           - type: 'null'
           title: Phone
@@ -388,7 +389,7 @@ components:
           anyOf:
           - maxLength: 100
             minLength: 1
-            pattern: ^[A-Za-zÀ-ÖØ-öø-ÿ' \-]+$
+            pattern: ^[\p{L}\p{M}'’ .\-]+$
             type: string
           - type: 'null'
           title: Firstname
@@ -396,7 +397,7 @@ components:
           anyOf:
           - maxLength: 100
             minLength: 1
-            pattern: ^[A-Za-zÀ-ÖØ-öø-ÿ' \-]+$
+            pattern: ^[\p{L}\p{M}'’ .\-]+$
             type: string
           - type: 'null'
           title: Lastname
@@ -411,7 +412,8 @@ components:
           title: Password
         phone:
           anyOf:
-          - pattern: ^\+?[\d\s\-().]{7,20}$
+          - maxLength: 20
+            pattern: ^\+?(?:[\s\-().]*\d){7,15}[\s\-().]*$
             type: string
           - type: 'null'
           title: Phone

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -266,8 +266,6 @@ components:
           type: string
         password:
           format: password
-          maxLength: 128
-          minLength: 8
           title: Password
           type: string
           writeOnly: true
@@ -305,13 +303,13 @@ components:
         firstname:
           maxLength: 100
           minLength: 1
-          pattern: ^[\D]+$
+          pattern: ^[A-Za-zÀ-ÖØ-öø-ÿ' \-]+$
           title: Firstname
           type: string
         lastname:
           maxLength: 100
           minLength: 1
-          pattern: ^[\D]+$
+          pattern: ^[A-Za-zÀ-ÖØ-öø-ÿ' \-]+$
           title: Lastname
           type: string
         password:
@@ -390,7 +388,7 @@ components:
           anyOf:
           - maxLength: 100
             minLength: 1
-            pattern: ^[\D]+$
+            pattern: ^[A-Za-zÀ-ÖØ-öø-ÿ' \-]+$
             type: string
           - type: 'null'
           title: Firstname
@@ -398,7 +396,7 @@ components:
           anyOf:
           - maxLength: 100
             minLength: 1
-            pattern: ^[\D]+$
+            pattern: ^[A-Za-zÀ-ÖØ-öø-ÿ' \-]+$
             type: string
           - type: 'null'
           title: Lastname

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -266,6 +266,7 @@ components:
           type: string
         password:
           format: password
+          strip_whitespace: false
           title: Password
           type: string
           writeOnly: true
@@ -310,6 +311,7 @@ components:
         password:
           format: password
           minLength: 8
+          strip_whitespace: false
           title: Password
           type: string
           writeOnly: true
@@ -392,6 +394,7 @@ components:
             type: string
             writeOnly: true
           - type: 'null'
+          strip_whitespace: false
           title: Password
         phone:
           anyOf:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -266,6 +266,8 @@ components:
           type: string
         password:
           format: password
+          maxLength: 128
+          minLength: 8
           strip_whitespace: false
           title: Password
           type: string

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -293,7 +293,8 @@ components:
       properties:
         boat_club:
           anyOf:
-          - type: string
+          - maxLength: 100
+            type: string
           - type: 'null'
           title: Boat Club
         email:
@@ -301,15 +302,20 @@ components:
           title: Email
           type: string
         firstname:
+          maxLength: 100
           minLength: 1
+          pattern: ^[\D]+$
           title: Firstname
           type: string
         lastname:
+          maxLength: 100
           minLength: 1
+          pattern: ^[\D]+$
           title: Lastname
           type: string
         password:
           format: password
+          maxLength: 128
           minLength: 8
           strip_whitespace: false
           title: Password
@@ -317,7 +323,8 @@ components:
           writeOnly: true
         phone:
           anyOf:
-          - type: string
+          - pattern: ^\+?[\d\s\-().]{7,20}$
+            type: string
           - type: 'null'
           title: Phone
       required:
@@ -369,7 +376,8 @@ components:
       properties:
         boat_club:
           anyOf:
-          - type: string
+          - maxLength: 100
+            type: string
           - type: 'null'
           title: Boat Club
         email:
@@ -380,17 +388,25 @@ components:
           title: Email
         firstname:
           anyOf:
-          - type: string
+          - maxLength: 100
+            minLength: 1
+            pattern: ^[\D]+$
+            type: string
           - type: 'null'
           title: Firstname
         lastname:
           anyOf:
-          - type: string
+          - maxLength: 100
+            minLength: 1
+            pattern: ^[\D]+$
+            type: string
           - type: 'null'
           title: Lastname
         password:
           anyOf:
           - format: password
+            maxLength: 128
+            minLength: 8
             type: string
             writeOnly: true
           - type: 'null'
@@ -398,7 +414,8 @@ components:
           title: Password
         phone:
           anyOf:
-          - type: string
+          - pattern: ^\+?[\d\s\-().]{7,20}$
+            type: string
           - type: 'null'
           title: Phone
       title: UserPatch


### PR DESCRIPTION
## Summary

Hardens user-facing input fields with improved validation and security.

## Changes

  - Use `SecretStr` for all password fields to prevent plaintext passwords appearing in logs or serialization
  - Strip whitespace from user input fields (`firstname`, `lastname`, `email`, `phone`, `boat_club`) - passwords excluded                 
  - Add field constraints: `min_length`/`max_length` on names, phone regex, `max_length=128` on passwords
  - Add `min_length=8` / `max_length=128` to `LoginIn.password` 

## Checklist

- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [x] All existing tests pass
- [x] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
