### PR TITLE
feat(frontend): add settings page

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,4 +1,5 @@
 from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
 from fastapi import APIRouter, HTTPException
 from sqlalchemy import select
 
@@ -48,6 +49,20 @@ async def update_me(body: UserPatch, current_user: CurrentUserDep, session: Sess
             setattr(current_user, field, value)
 
     if body.password is not None:
+        if body.current_password is None:
+            raise HTTPException(
+                status_code=422,
+                detail="Current password is required to change password.",
+            )
+        try:
+            _ph.verify(
+                current_user.password_hash,
+                body.current_password.get_secret_value(),
+            )
+        except VerifyMismatchError:
+            raise HTTPException(
+                status_code=401, detail="Current password is incorrect."
+            ) from None
         current_user.password_hash = _hash_password(body.password.get_secret_value())
 
     session.add(current_user)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -77,6 +77,8 @@ class UserPatch(BaseModel):
     phone: PhoneOpt = None
     boat_club: str | None = Field(default=None, max_length=100)
     password: PasswordOpt = None
+    # required only when password is being changed, verified server-side
+    current_password: SecretStr | None = None
 
 
 class UserCreate(BaseModel):

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -70,12 +70,39 @@ async def test_patch_me_updates_password(
     token = make_token(test_user.user_id)
     r = await client.patch(
         "/api/users/me",
-        json={"password": "newpassword"},
+        json={"password": "newpassword", "current_password": "secretpassword"},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert r.status_code == 200
     await session.refresh(test_user)
     assert verify_password(test_user.password_hash, "newpassword")
+
+
+async def test_patch_me_password_requires_current_password(
+    client: AsyncClient, test_user: User
+):
+    token = make_token(test_user.user_id)
+    r = await client.patch(
+        "/api/users/me",
+        json={"password": "newpassword"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 422
+
+
+async def test_patch_me_password_rejects_wrong_current_password(
+    client: AsyncClient, test_user: User, session: AsyncSession
+):
+    token = make_token(test_user.user_id)
+    original_hash = test_user.password_hash
+    r = await client.patch(
+        "/api/users/me",
+        json={"password": "newpassword", "current_password": "wrongpassword"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 401
+    await session.refresh(test_user)
+    assert test_user.password_hash == original_hash
 
 
 async def test_patch_me_email_conflict(

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -626,6 +626,13 @@ components:
             type: string
           - type: 'null'
           title: Boat Club
+        current_password:
+          anyOf:
+          - format: password
+            type: string
+            writeOnly: true
+          - type: 'null'
+          title: Current Password
         email:
           anyOf:
           - format: email

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,17 +6,31 @@ const Dashboard = lazy(() =>
   import("./pages/Dashboard").then((m) => ({ default: m.Dashboard })),
 );
 
+const Settings = lazy(() =>
+  import("./pages/Settings").then((m) => ({ default: m.Settings })),
+);
+
 export function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Navigate to="/saltsjobaden" replace />} />
+
         <Route path="/:marinaSlug" element={<MainLayout />}>
           <Route
             index
             element={
               <Suspense fallback={<div className="h-full w-full" />}>
                 <Dashboard />
+              </Suspense>
+            }
+          />
+
+          <Route
+            path="settings"
+            element={
+              <Suspense fallback={<div className="h-full w-full" />}>
+                <Settings />
               </Suspense>
             }
           />

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -739,6 +739,8 @@ export interface components {
         UserPatch: {
             /** Boat Club */
             boat_club?: string | null;
+            /** Current Password */
+            current_password?: string | null;
             /** Email */
             email?: string | null;
             /** Firstname */

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -42,8 +42,14 @@ function Header({
     };
   }, [isUserMenuOpen]);
 
-  function handleLogoutClick() {
+  const marinaPath = marinaSlug ? `/${marinaSlug}` : "/saltsjobaden";
+
+  function closeUserMenu() {
     setIsUserMenuOpen(false);
+  }
+
+  function handleLogoutClick() {
+    closeUserMenu();
     onLogoutClickCB();
   }
 
@@ -58,12 +64,13 @@ function Header({
       )}
     >
       <div className="flex items-center gap-3">
-        <Link to="/" className="block">
+        <Link to={marinaPath} className="block">
           <h1 className="flex items-center gap-4 group cursor-pointer">
             <div className="flex items-center tracking-[0.3em] uppercase transition-all duration-300 group-hover:tracking-[0.35em]">
               <span className="text-lg font-light text-brand-navy">Dock</span>
               <span className="text-lg font-black text-brand-blue">Pulse</span>
             </div>
+
             <div className="flex items-center gap-2 border-l border-brand-navy/10 pl-4">
               <div className="w-1.5 h-1.5 bg-emerald-500 rounded-full animate-pulse glow-emerald" />
               <span className="text-[9px] font-black text-brand-navy/30 uppercase tracking-[0.2em]">
@@ -75,12 +82,12 @@ function Header({
       </div>
 
       <nav className="flex items-center gap-2">
-        <button
-          type="button"
+        <Link
+          to={marinaPath}
           className="bg-gradient-to-r from-brand-blue to-brand-cyan px-6 py-2 rounded-full shadow-lg shadow-brand-blue/20 text-white text-xs font-black transition-transform hover:scale-105"
         >
           Dashboard
-        </button>
+        </Link>
       </nav>
 
       <div className="relative flex items-center gap-4" ref={userMenuRef}>
@@ -102,6 +109,14 @@ function Header({
                 role="menu"
                 className="absolute top-12 right-0 w-40 rounded-xl border border-slate-200 bg-white p-2 shadow-lg"
               >
+                <Link
+                  to={`${marinaPath}/settings`}
+                  role="menuitem"
+                  onClick={closeUserMenu}
+                  className="block w-full rounded-lg px-3 py-2 text-left text-sm font-semibold text-brand-navy transition-colors hover:bg-slate-100"
+                >
+                  Settings
+                </Link>
                 <button
                   type="button"
                   role="menuitem"

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -17,6 +17,15 @@ export type AuthUser = {
   boat_club?: string;
 };
 
+export type AuthOutletContext = {
+  user: AuthUser | null;
+  setUser: React.Dispatch<React.SetStateAction<AuthUser | null>>;
+  token: string | null;
+  setToken: React.Dispatch<React.SetStateAction<string | null>>;
+  isLoginOpen: boolean;
+  setIsLoginOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
 type AuthTab = "login" | "signup";
 
 type LoginForm = {
@@ -60,7 +69,7 @@ async function getErrorMessage(
 
     if (Array.isArray(data.detail)) {
       return data.detail
-        .map((err) => {
+        .map((err: { loc?: unknown[]; msg?: string }) => {
           const field = Array.isArray(err.loc) ? err.loc.at(-1) : null;
           return field ? `${field}: ${err.msg}` : err.msg;
         })
@@ -243,7 +252,18 @@ function MainLayout() {
       />
 
       <main className="absolute inset-0 z-0">
-        <Outlet />
+        <Outlet
+          context={
+            {
+              user,
+              setUser,
+              token,
+              setToken,
+              isLoginOpen,
+              setIsLoginOpen,
+            } satisfies AuthOutletContext
+          }
+        />
       </main>
 
       <Dialog

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -234,7 +234,7 @@ function MainLayout() {
       : user?.email?.slice(0, 2).toUpperCase();
 
   return (
-    <div className="bg-transparent duration-1000 font-body h-screen overflow-hidden relative transition-colors w-screen">
+    <div className="bg-transparent duration-1000 font-body min-h-screen overflow-x-hidden relative transition-colors w-screen">
       <Header
         isLoggedIn={Boolean(token)}
         userInitials={userInitials}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,15 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import { useOutletContext } from "react-router-dom";
-import type { AuthUser } from "../components/layout/MainLayout";
-
-type SettingsOutletContext = {
-  user: AuthUser | null;
-  setUser: React.Dispatch<React.SetStateAction<AuthUser | null>>;
-  token: string | null;
-  setToken: React.Dispatch<React.SetStateAction<string | null>>;
-  isLoginOpen: boolean;
-  setIsLoginOpen: React.Dispatch<React.SetStateAction<boolean>>;
-};
+import type {
+  AuthOutletContext,
+  AuthUser,
+} from "../components/layout/MainLayout";
+import { Button } from "../components/shared/ui/button";
+import { Input } from "../components/shared/ui/input";
+import { Label } from "../components/shared/ui/label";
 
 type SettingsForm = {
   firstname: string;
@@ -22,10 +19,6 @@ type SettingsForm = {
 };
 
 type FieldErrors = Partial<Record<keyof SettingsForm | "general", string>>;
-
-const inputClass = "w-full rounded border p-2";
-const labelClass = "space-y-1 text-sm font-semibold text-brand-navy";
-const errorClass = "text-sm text-red-500";
 
 const MIN_PASSWORD_LENGTH = 8;
 
@@ -117,9 +110,12 @@ async function getErrorsFromResponse(res: Response): Promise<FieldErrors> {
   }
 }
 
+const errorClass = "text-sm text-red-500";
+const labelGroupClass = "space-y-1.5";
+
 function Settings() {
   const { user, setUser, token, setIsLoginOpen } =
-    useOutletContext<SettingsOutletContext>();
+    useOutletContext<AuthOutletContext>();
 
   const initialForm = useMemo(() => getInitialForm(user), [user]);
   const [form, setForm] = useState<SettingsForm>(initialForm);
@@ -191,7 +187,7 @@ function Settings() {
         return;
       }
 
-      const updatedUser = await res.json();
+      const updatedUser = (await res.json()) as AuthUser;
 
       setUser(updatedUser);
       setForm({
@@ -214,13 +210,13 @@ function Settings() {
         <p className="mt-2 text-brand-navy/60">
           You need to log in before editing your profile.
         </p>
-        <button
+        <Button
           type="button"
           onClick={() => setIsLoginOpen(true)}
-          className="mt-4 rounded-full bg-brand-blue px-6 py-2 text-sm font-bold text-white"
+          className="mt-4 rounded-full bg-brand-blue"
         >
           Log in
-        </button>
+        </Button>
       </main>
     );
   }
@@ -247,63 +243,64 @@ function Settings() {
         )}
 
         <div className="grid gap-4 sm:grid-cols-2">
-          <label className={labelClass}>
-            First name
-            <input
-              className={inputClass}
+          <div className={labelGroupClass}>
+            <Label htmlFor="settings-firstname">First name</Label>
+            <Input
+              id="settings-firstname"
+              autoComplete="given-name"
               value={form.firstname}
               onChange={(e) => updateForm("firstname", e.target.value)}
             />
             {errors.firstname && (
-              <span className={errorClass}>{errors.firstname}</span>
+              <p className={errorClass}>{errors.firstname}</p>
             )}
-          </label>
+          </div>
 
-          <label className={labelClass}>
-            Last name
-            <input
-              className={inputClass}
+          <div className={labelGroupClass}>
+            <Label htmlFor="settings-lastname">Last name</Label>
+            <Input
+              id="settings-lastname"
+              autoComplete="family-name"
               value={form.lastname}
               onChange={(e) => updateForm("lastname", e.target.value)}
             />
-            {errors.lastname && (
-              <span className={errorClass}>{errors.lastname}</span>
-            )}
-          </label>
+            {errors.lastname && <p className={errorClass}>{errors.lastname}</p>}
+          </div>
         </div>
 
-        <label className={labelClass}>
-          Email
-          <input
+        <div className={labelGroupClass}>
+          <Label htmlFor="settings-email">Email</Label>
+          <Input
+            id="settings-email"
             type="email"
-            className={inputClass}
+            autoComplete="email"
             value={form.email}
             onChange={(e) => updateForm("email", e.target.value)}
           />
-          {errors.email && <span className={errorClass}>{errors.email}</span>}
-        </label>
+          {errors.email && <p className={errorClass}>{errors.email}</p>}
+        </div>
 
-        <label className={labelClass}>
-          Phone optional
-          <input
-            className={inputClass}
+        <div className={labelGroupClass}>
+          <Label htmlFor="settings-phone">Phone (optional)</Label>
+          <Input
+            id="settings-phone"
+            type="tel"
+            autoComplete="tel"
             value={form.phone}
             onChange={(e) => updateForm("phone", e.target.value)}
           />
-          {errors.phone && <span className={errorClass}>{errors.phone}</span>}
-        </label>
+          {errors.phone && <p className={errorClass}>{errors.phone}</p>}
+        </div>
 
-        <label className={labelClass}>
-          Home boat club
-          <input
-            className={inputClass}
+        <div className={labelGroupClass}>
+          <Label htmlFor="settings-boat-club">Home boat club (optional)</Label>
+          <Input
+            id="settings-boat-club"
             value={form.boat_club}
             onChange={(e) => updateForm("boat_club", e.target.value)}
           />
-          {errors.boat_club && (
-            <span className={errorClass}>{errors.boat_club}</span>
-          )}
-        </label>
+          {errors.boat_club && <p className={errorClass}>{errors.boat_club}</p>}
+        </div>
 
         <div className="border-t border-slate-200 pt-5">
           <h2 className="text-lg font-semibold text-brand-navy">
@@ -314,39 +311,39 @@ function Settings() {
           </p>
         </div>
 
-        <label className={labelClass}>
-          Current password
-          <input
+        <div className={labelGroupClass}>
+          <Label htmlFor="settings-current-password">Current password</Label>
+          <Input
+            id="settings-current-password"
             type="password"
-            className={inputClass}
+            autoComplete="current-password"
             value={form.current_password}
             onChange={(e) => updateForm("current_password", e.target.value)}
           />
           {errors.current_password && (
-            <span className={errorClass}>{errors.current_password}</span>
+            <p className={errorClass}>{errors.current_password}</p>
           )}
-        </label>
+        </div>
 
-        <label className={labelClass}>
-          New password
-          <input
+        <div className={labelGroupClass}>
+          <Label htmlFor="settings-new-password">New password</Label>
+          <Input
+            id="settings-new-password"
             type="password"
-            className={inputClass}
+            autoComplete="new-password"
             value={form.password}
             onChange={(e) => updateForm("password", e.target.value)}
           />
-          {errors.password && (
-            <span className={errorClass}>{errors.password}</span>
-          )}
-        </label>
+          {errors.password && <p className={errorClass}>{errors.password}</p>}
+        </div>
 
-        <button
+        <Button
           type="submit"
           disabled={isSaving}
-          className="w-full rounded-full bg-brand-navy p-3 text-sm font-bold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+          className="w-full rounded-full bg-brand-navy"
         >
           {isSaving ? "Saving..." : "Save changes"}
-        </button>
+        </Button>
       </form>
     </main>
   );

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,0 +1,355 @@
+import { useEffect, useMemo, useState } from "react";
+import { useOutletContext } from "react-router-dom";
+import type { AuthUser } from "../components/layout/MainLayout";
+
+type SettingsOutletContext = {
+  user: AuthUser | null;
+  setUser: React.Dispatch<React.SetStateAction<AuthUser | null>>;
+  token: string | null;
+  setToken: React.Dispatch<React.SetStateAction<string | null>>;
+  isLoginOpen: boolean;
+  setIsLoginOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+type SettingsForm = {
+  firstname: string;
+  lastname: string;
+  email: string;
+  phone: string;
+  boat_club: string;
+  current_password: string;
+  password: string;
+};
+
+type FieldErrors = Partial<Record<keyof SettingsForm | "general", string>>;
+
+const inputClass = "w-full rounded border p-2";
+const labelClass = "space-y-1 text-sm font-semibold text-brand-navy";
+const errorClass = "text-sm text-red-500";
+
+const MIN_PASSWORD_LENGTH = 8;
+
+function getInitialForm(user: AuthUser | null): SettingsForm {
+  return {
+    firstname: user?.firstname ?? "",
+    lastname: user?.lastname ?? "",
+    email: user?.email ?? "",
+    phone: user?.phone ?? "",
+    boat_club: user?.boat_club ?? "",
+    current_password: "",
+    password: "",
+  };
+}
+
+function isValidEmail(email: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function validateForm(form: SettingsForm): FieldErrors {
+  const errors: FieldErrors = {};
+
+  if (!form.firstname.trim()) {
+    errors.firstname = "First name is required.";
+  }
+
+  if (!form.lastname.trim()) {
+    errors.lastname = "Last name is required.";
+  }
+
+  if (!form.email.trim()) {
+    errors.email = "Email is required.";
+  } else if (!isValidEmail(form.email.trim())) {
+    errors.email = "Enter a valid email address.";
+  }
+
+  if (form.password && form.password.length < MIN_PASSWORD_LENGTH) {
+    errors.password = `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`;
+  }
+
+  if (form.password && !form.current_password) {
+    errors.current_password =
+      "Current password is required to change password.";
+  }
+
+  return errors;
+}
+
+function isSettingsField(field: unknown): field is keyof SettingsForm {
+  return (
+    field === "firstname" ||
+    field === "lastname" ||
+    field === "email" ||
+    field === "phone" ||
+    field === "boat_club" ||
+    field === "current_password" ||
+    field === "password"
+  );
+}
+
+async function getErrorsFromResponse(res: Response): Promise<FieldErrors> {
+  try {
+    const data = await res.json();
+
+    if (Array.isArray(data.detail)) {
+      const errors: FieldErrors = {};
+
+      for (const err of data.detail) {
+        const field = Array.isArray(err.loc) ? err.loc.at(-1) : null;
+        const message = err.msg ?? "Invalid value.";
+
+        if (isSettingsField(field)) {
+          errors[field] = message;
+        } else {
+          errors.general = message;
+        }
+      }
+
+      return errors;
+    }
+
+    if (typeof data.detail === "string") return { general: data.detail };
+    if (typeof data.message === "string") return { general: data.message };
+    if (typeof data.error === "string") return { general: data.error };
+
+    return { general: `Could not save profile. Status: ${res.status}` };
+  } catch {
+    return { general: `Could not save profile. Status: ${res.status}` };
+  }
+}
+
+function Settings() {
+  const { user, setUser, token, setIsLoginOpen } =
+    useOutletContext<SettingsOutletContext>();
+
+  const initialForm = useMemo(() => getInitialForm(user), [user]);
+  const [form, setForm] = useState<SettingsForm>(initialForm);
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    document.title = "Settings | DockPulse";
+  }, []);
+
+  useEffect(() => {
+    setForm(initialForm);
+  }, [initialForm]);
+
+  function updateForm(field: keyof SettingsForm, value: string) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    setErrors((prev) => ({ ...prev, [field]: undefined, general: undefined }));
+    setSuccessMessage(null);
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    if (!token) {
+      setErrors({ general: "You need to log in before editing settings." });
+      setIsLoginOpen(true);
+      return;
+    }
+
+    const validationErrors = validateForm(form);
+
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      setSuccessMessage(null);
+      return;
+    }
+
+    const payload = {
+      firstname: form.firstname.trim(),
+      lastname: form.lastname.trim(),
+      email: form.email.trim(),
+      phone: form.phone.trim() || null,
+      boat_club: form.boat_club.trim() || null,
+      ...(form.password
+        ? {
+            password: form.password,
+            current_password: form.current_password,
+          }
+        : {}),
+    };
+
+    setIsSaving(true);
+    setErrors({});
+    setSuccessMessage(null);
+
+    try {
+      const res = await fetch("/api/users/me", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        setErrors(await getErrorsFromResponse(res));
+        return;
+      }
+
+      const updatedUser = await res.json();
+
+      setUser(updatedUser);
+      setForm({
+        ...getInitialForm(updatedUser),
+        current_password: "",
+        password: "",
+      });
+      setSuccessMessage("Profile updated successfully.");
+    } catch {
+      setErrors({ general: "Could not save profile. Please try again." });
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  if (!user) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-xl flex-col items-center justify-center px-4 text-center">
+        <h1 className="text-3xl font-semibold text-brand-navy">Settings</h1>
+        <p className="mt-2 text-brand-navy/60">
+          You need to log in before editing your profile.
+        </p>
+        <button
+          type="button"
+          onClick={() => setIsLoginOpen(true)}
+          className="mt-4 rounded-full bg-brand-blue px-6 py-2 text-sm font-bold text-white"
+        >
+          Log in
+        </button>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 pt-36 pb-20">
+      <div className="mb-6">
+        <h1 className="text-3xl font-semibold text-brand-navy">Settings</h1>
+        <p className="mt-1 text-brand-navy/60">
+          Edit your profile information and password.
+        </p>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-5 rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-lg backdrop-blur"
+      >
+        {errors.general && <p className={errorClass}>{errors.general}</p>}
+
+        {successMessage && (
+          <p className="rounded-xl bg-green-50 p-3 text-sm font-medium text-green-700">
+            {successMessage}
+          </p>
+        )}
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className={labelClass}>
+            First name
+            <input
+              className={inputClass}
+              value={form.firstname}
+              onChange={(e) => updateForm("firstname", e.target.value)}
+            />
+            {errors.firstname && (
+              <span className={errorClass}>{errors.firstname}</span>
+            )}
+          </label>
+
+          <label className={labelClass}>
+            Last name
+            <input
+              className={inputClass}
+              value={form.lastname}
+              onChange={(e) => updateForm("lastname", e.target.value)}
+            />
+            {errors.lastname && (
+              <span className={errorClass}>{errors.lastname}</span>
+            )}
+          </label>
+        </div>
+
+        <label className={labelClass}>
+          Email
+          <input
+            type="email"
+            className={inputClass}
+            value={form.email}
+            onChange={(e) => updateForm("email", e.target.value)}
+          />
+          {errors.email && <span className={errorClass}>{errors.email}</span>}
+        </label>
+
+        <label className={labelClass}>
+          Phone optional
+          <input
+            className={inputClass}
+            value={form.phone}
+            onChange={(e) => updateForm("phone", e.target.value)}
+          />
+          {errors.phone && <span className={errorClass}>{errors.phone}</span>}
+        </label>
+
+        <label className={labelClass}>
+          Home boat club
+          <input
+            className={inputClass}
+            value={form.boat_club}
+            onChange={(e) => updateForm("boat_club", e.target.value)}
+          />
+          {errors.boat_club && (
+            <span className={errorClass}>{errors.boat_club}</span>
+          )}
+        </label>
+
+        <div className="border-t border-slate-200 pt-5">
+          <h2 className="text-lg font-semibold text-brand-navy">
+            Change password
+          </h2>
+          <p className="mt-1 text-sm text-brand-navy/60">
+            Leave these fields empty if you do not want to change your password.
+          </p>
+        </div>
+
+        <label className={labelClass}>
+          Current password
+          <input
+            type="password"
+            className={inputClass}
+            value={form.current_password}
+            onChange={(e) => updateForm("current_password", e.target.value)}
+          />
+          {errors.current_password && (
+            <span className={errorClass}>{errors.current_password}</span>
+          )}
+        </label>
+
+        <label className={labelClass}>
+          New password
+          <input
+            type="password"
+            className={inputClass}
+            value={form.password}
+            onChange={(e) => updateForm("password", e.target.value)}
+          />
+          {errors.password && (
+            <span className={errorClass}>{errors.password}</span>
+          )}
+        </label>
+
+        <button
+          type="submit"
+          disabled={isSaving}
+          className="w-full rounded-full bg-brand-navy p-3 text-sm font-bold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isSaving ? "Saving..." : "Save changes"}
+        </button>
+      </form>
+    </main>
+  );
+}
+
+export { Settings };


### PR DESCRIPTION
## Summary

Created a settings page, were a logged in user can change their firstname, lastname, password, and other account information and save those changes, if they are already logged in. 

## 64

Closes #64 

## Changes

- New settings page
- Added settings button in drop down menu, when you press profile avatar
- updated files on frontend to include a new page beside dashboard

## Checklist

- [ ] Code compiles/builds without errors or warnings
- [ ] Code follows the project style guide and has been formatted
- [ ] All existing tests pass
- [ ] New functionality includes appropriate tests
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
