### PR TITLE
feat(frontend): added delete account to settings

### DIFF
--- a/frontend/src/components/layout/AuthDialog.tsx
+++ b/frontend/src/components/layout/AuthDialog.tsx
@@ -18,8 +18,6 @@ type SignupForm = {
   confirmPassword: string;
   firstname: string;
   lastname: string;
-  phone: string;
-  boat_club: string;
 };
 
 const emptySignupForm: SignupForm = {
@@ -28,8 +26,6 @@ const emptySignupForm: SignupForm = {
   confirmPassword: "",
   firstname: "",
   lastname: "",
-  phone: "",
-  boat_club: "",
 };
 
 // mirror backend APP_ENV: prod build enforces the 12 char floor, dev/staging relaxed for testing
@@ -170,8 +166,6 @@ export function AuthDialog({
       email: rest.email.trim(),
       firstname: rest.firstname.trim(),
       lastname: rest.lastname.trim(),
-      phone: rest.phone.trim() || null,
-      boat_club: rest.boat_club.trim() || null,
     };
 
     try {
@@ -442,40 +436,6 @@ export function AuthDialog({
                   >
                     {passwordMismatch ? "Passwords do not match" : ""}
                   </p>
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="signup-phone" className={fieldLabelClass}>
-                    Phone
-                    <span className="ml-1 text-[8px] font-bold normal-case tracking-normal text-brand-navy/30">
-                      (optional)
-                    </span>
-                  </Label>
-                  <Input
-                    id="signup-phone"
-                    type="tel"
-                    autoComplete="tel"
-                    value={signupForm.phone}
-                    onChange={(e) => updateSignupField("phone", e.target.value)}
-                    className={fieldInputClass}
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="signup-boat-club" className={fieldLabelClass}>
-                    Boat Club
-                    <span className="ml-1 text-[8px] font-bold normal-case tracking-normal text-brand-navy/30">
-                      (optional)
-                    </span>
-                  </Label>
-                  <Input
-                    id="signup-boat-club"
-                    value={signupForm.boat_club}
-                    onChange={(e) =>
-                      updateSignupField("boat_club", e.target.value)
-                    }
-                    className={fieldInputClass}
-                  />
                 </div>
               </fieldset>
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -7,6 +7,14 @@ import type {
 } from "../components/layout/MainLayout";
 import { NotificationSettings } from "../components/NotificationSettings";
 import { Button } from "../components/shared/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../components/shared/ui/dialog";
 import { Input } from "../components/shared/ui/input";
 import { Label } from "../components/shared/ui/label";
 import { PasswordInput } from "../components/shared/ui/password-input";
@@ -78,7 +86,10 @@ function isSettingsField(field: unknown): field is keyof SettingsForm {
   );
 }
 
-async function getErrorsFromResponse(res: Response): Promise<FieldErrors> {
+async function getErrorsFromResponse(
+  res: Response,
+  fallback: string,
+): Promise<FieldErrors> {
   try {
     const data = await res.json();
 
@@ -103,9 +114,9 @@ async function getErrorsFromResponse(res: Response): Promise<FieldErrors> {
     if (typeof data.message === "string") return { general: data.message };
     if (typeof data.error === "string") return { general: data.error };
 
-    return { general: `Request failed. Status: ${res.status}` };
+    return { general: `${fallback} Status: ${res.status}` };
   } catch {
-    return { general: `Request failed. Status: ${res.status}` };
+    return { general: `${fallback} Status: ${res.status}` };
   }
 }
 
@@ -144,12 +155,10 @@ function Settings() {
   }
 
   function clearLocalAuthState() {
-    setUser(null);
-    setToken(null);
-
+    // mirrors MainLayout.handleLogout local cleanup, minus the server logout
     localStorage.removeItem("token");
-    localStorage.removeItem("user");
-    localStorage.removeItem("authToken");
+    setToken(null);
+    setUser(null);
   }
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
@@ -198,7 +207,7 @@ function Settings() {
       });
 
       if (!res.ok) {
-        setErrors(await getErrorsFromResponse(res));
+        setErrors(await getErrorsFromResponse(res, "Could not save profile."));
         return;
       }
 
@@ -227,14 +236,19 @@ function Settings() {
 
     const trimmedConfirmation = deleteConfirmText.trim();
     const normalizedConfirmation = trimmedConfirmation.toLowerCase();
-    const email = user?.email ?? "";
-    const normalizedEmail = email.trim().toLowerCase();
+    const email = user?.email?.trim() ?? "";
+    const normalizedEmail = email.toLowerCase();
 
+    // DELETE stays case-sensitive on purpose, email match is case-insensitive
     if (
       trimmedConfirmation !== "DELETE" &&
-      normalizedConfirmation !== normalizedEmail
+      (!normalizedEmail || normalizedConfirmation !== normalizedEmail)
     ) {
-      setDeleteError(`Type DELETE or ${email} to confirm.`);
+      setDeleteError(
+        email
+          ? `Type DELETE or ${email} to confirm.`
+          : "Type DELETE to confirm.",
+      );
       return;
     }
 
@@ -250,7 +264,10 @@ function Settings() {
       });
 
       if (!res.ok) {
-        const responseErrors = await getErrorsFromResponse(res);
+        const responseErrors = await getErrorsFromResponse(
+          res,
+          "Could not delete account.",
+        );
         setDeleteError(
           responseErrors.general ??
             "Could not delete account. Please try again.",
@@ -455,6 +472,7 @@ function Settings() {
 
         <Button
           type="button"
+          variant="destructive"
           onClick={() => {
             setDeleteConfirmText("");
             setDeleteError(null);
@@ -462,70 +480,86 @@ function Settings() {
             setSuccessMessage(null);
             setIsDeleteOpen(true);
           }}
-          className="mt-4 rounded-full bg-red-600 hover:bg-red-700"
+          className="mt-4 rounded-full"
         >
           Delete account
         </Button>
       </section>
 
-      {isDeleteOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
-          <div className="w-full max-w-md rounded-3xl bg-white p-6 shadow-xl">
-            <h2 className="text-xl font-semibold text-brand-navy">
-              Confirm account deletion
-            </h2>
-
-            <p className="mt-2 text-sm text-brand-navy/70">
+      <Dialog
+        open={isDeleteOpen}
+        onOpenChange={(next) => {
+          // block close mid-request so the in-flight DELETE has a place to surface errors
+          if (isDeleting && !next) return;
+          setIsDeleteOpen(next);
+          if (!next) {
+            setDeleteConfirmText("");
+            setDeleteError(null);
+          }
+        }}
+      >
+        <DialogContent className="rounded-3xl">
+          <DialogHeader>
+            <DialogTitle>Confirm account deletion</DialogTitle>
+            <DialogDescription>
               This will permanently delete your account. To confirm, type{" "}
               <span className="font-semibold text-red-600">DELETE</span> or your
-              account email:
-            </p>
+              account email.
+            </DialogDescription>
+          </DialogHeader>
 
-            <p className="mt-2 rounded-xl bg-slate-100 px-3 py-2 text-sm font-medium text-brand-navy">
-              {user.email}
-            </p>
+          <p className="rounded-xl bg-slate-100 px-3 py-2 text-sm font-medium text-brand-navy">
+            {user.email}
+          </p>
 
-            <div className="mt-4 space-y-1.5">
-              <Label htmlFor="delete-confirm">Confirmation</Label>
-              <Input
-                id="delete-confirm"
-                value={deleteConfirmText}
-                onChange={(e) => {
-                  setDeleteConfirmText(e.target.value);
-                  setDeleteError(null);
-                }}
-                placeholder="Type DELETE or your email"
-              />
-              {deleteError && <p className={errorClass}>{deleteError}</p>}
-            </div>
-
-            <div className="mt-6 flex gap-3">
-              <Button
-                type="button"
-                variant="outline"
-                disabled={isDeleting}
-                onClick={() => {
-                  setIsDeleteOpen(false);
-                  setDeleteConfirmText("");
-                  setDeleteError(null);
-                }}
-                className="flex-1 rounded-full"
-              >
-                Cancel
-              </Button>
-
-              <Button
-                type="button"
-                disabled={isDeleting || !canDelete}
-                onClick={handleDeleteAccount}
-                className="flex-1 rounded-full bg-red-600 hover:bg-red-700"
-              >
-                {isDeleting ? "Deleting..." : "Delete account"}
-              </Button>
-            </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="delete-confirm">Confirmation</Label>
+            <Input
+              id="delete-confirm"
+              value={deleteConfirmText}
+              onChange={(e) => {
+                setDeleteConfirmText(e.target.value);
+                setDeleteError(null);
+              }}
+              placeholder="Type DELETE or your email"
+              autoComplete="off"
+              aria-invalid={Boolean(deleteError)}
+              aria-describedby={deleteError ? "delete-error" : undefined}
+            />
+            {deleteError && (
+              <p id="delete-error" className={errorClass}>
+                {deleteError}
+              </p>
+            )}
           </div>
-        </div>
-      )}
+
+          <DialogFooter className="gap-3 sm:gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isDeleting}
+              onClick={() => setIsDeleteOpen(false)}
+              className="flex-1 rounded-full"
+            >
+              Cancel
+            </Button>
+
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={isDeleting || !canDelete}
+              aria-busy={isDeleting}
+              onClick={handleDeleteAccount}
+              className="flex-1 rounded-full"
+            >
+              {isDeleting && (
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              )}
+              {isDeleting ? "Deleting..." : "Delete account"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </main>
   );
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -45,13 +45,8 @@ function isValidEmail(email: string) {
 function validateForm(form: SettingsForm): FieldErrors {
   const errors: FieldErrors = {};
 
-  if (!form.firstname.trim()) {
-    errors.firstname = "First name is required.";
-  }
-
-  if (!form.lastname.trim()) {
-    errors.lastname = "Last name is required.";
-  }
+  if (!form.firstname.trim()) errors.firstname = "First name is required.";
+  if (!form.lastname.trim()) errors.lastname = "Last name is required.";
 
   if (!form.email.trim()) {
     errors.email = "Email is required.";
@@ -231,9 +226,14 @@ function Settings() {
     }
 
     const trimmedConfirmation = deleteConfirmText.trim();
+    const normalizedConfirmation = trimmedConfirmation.toLowerCase();
     const email = user?.email ?? "";
+    const normalizedEmail = email.trim().toLowerCase();
 
-    if (trimmedConfirmation !== "DELETE" && trimmedConfirmation !== email) {
+    if (
+      trimmedConfirmation !== "DELETE" &&
+      normalizedConfirmation !== normalizedEmail
+    ) {
       setDeleteError(`Type DELETE or ${email} to confirm.`);
       return;
     }
@@ -287,9 +287,12 @@ function Settings() {
     );
   }
 
+  const normalizedDeleteConfirmText = deleteConfirmText.trim().toLowerCase();
+  const normalizedUserEmail = user.email.trim().toLowerCase();
+
   const canDelete =
     deleteConfirmText.trim() === "DELETE" ||
-    deleteConfirmText.trim() === user.email;
+    normalizedDeleteConfirmText === normalizedUserEmail;
 
   return (
     <main className="mx-auto max-w-2xl px-4 pt-36 pb-20">
@@ -421,6 +424,9 @@ function Settings() {
               value={form.password}
               onChange={(e) => updateForm("password", e.target.value)}
             />
+            <p className="text-xs text-brand-navy/50">
+              Password must be at least {MIN_PASSWORD_LENGTH} characters.
+            </p>
             {errors.password && <p className={errorClass}>{errors.password}</p>}
           </div>
         </fieldset>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { Loader2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { useOutletContext } from "react-router-dom";
+import { useNavigate, useOutletContext } from "react-router-dom";
 import type {
   AuthOutletContext,
   AuthUser,
@@ -108,9 +108,9 @@ async function getErrorsFromResponse(res: Response): Promise<FieldErrors> {
     if (typeof data.message === "string") return { general: data.message };
     if (typeof data.error === "string") return { general: data.error };
 
-    return { general: `Could not save profile. Status: ${res.status}` };
+    return { general: `Request failed. Status: ${res.status}` };
   } catch {
-    return { general: `Could not save profile. Status: ${res.status}` };
+    return { general: `Request failed. Status: ${res.status}` };
   }
 }
 
@@ -118,14 +118,21 @@ const errorClass = "text-sm text-red-500";
 const labelGroupClass = "space-y-1.5";
 
 function Settings() {
-  const { user, setUser, token, setIsLoginOpen } =
+  const { user, setUser, token, setToken, setIsLoginOpen } =
     useOutletContext<AuthOutletContext>();
+
+  const navigate = useNavigate();
 
   const initialForm = useMemo(() => getInitialForm(user), [user]);
   const [form, setForm] = useState<SettingsForm>(initialForm);
   const [errors, setErrors] = useState<FieldErrors>({});
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [deleteConfirmText, setDeleteConfirmText] = useState("");
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   useEffect(() => {
     document.title = "Settings | DockPulse";
@@ -139,6 +146,15 @@ function Settings() {
     setForm((prev) => ({ ...prev, [field]: value }));
     setErrors((prev) => ({ ...prev, [field]: undefined, general: undefined }));
     setSuccessMessage(null);
+  }
+
+  function clearLocalAuthState() {
+    setUser(null);
+    setToken(null);
+
+    localStorage.removeItem("token");
+    localStorage.removeItem("user");
+    localStorage.removeItem("authToken");
   }
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
@@ -207,6 +223,52 @@ function Settings() {
     }
   }
 
+  async function handleDeleteAccount() {
+    if (!token) {
+      setDeleteError("You need to log in before deleting your account.");
+      setIsLoginOpen(true);
+      return;
+    }
+
+    const trimmedConfirmation = deleteConfirmText.trim();
+    const email = user?.email ?? "";
+
+    if (trimmedConfirmation !== "DELETE" && trimmedConfirmation !== email) {
+      setDeleteError(`Type DELETE or ${email} to confirm.`);
+      return;
+    }
+
+    setIsDeleting(true);
+    setDeleteError(null);
+
+    try {
+      const res = await fetch("/api/users/me", {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!res.ok) {
+        const responseErrors = await getErrorsFromResponse(res);
+        setDeleteError(
+          responseErrors.general ??
+            "Could not delete account. Please try again.",
+        );
+        return;
+      }
+
+      clearLocalAuthState();
+      setIsDeleteOpen(false);
+      navigate("/");
+      setIsLoginOpen(true);
+    } catch {
+      setDeleteError("Could not delete account. Please try again.");
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
   if (!user) {
     return (
       <main className="mx-auto flex min-h-screen max-w-xl flex-col items-center justify-center px-4 text-center">
@@ -224,6 +286,10 @@ function Settings() {
       </main>
     );
   }
+
+  const canDelete =
+    deleteConfirmText.trim() === "DELETE" ||
+    deleteConfirmText.trim() === user.email;
 
   return (
     <main className="mx-auto max-w-2xl px-4 pt-36 pb-20">
@@ -373,6 +439,87 @@ function Settings() {
       </form>
 
       {token && <NotificationSettings token={token} />}
+
+      <section className="mt-6 rounded-3xl border border-red-200 bg-red-50/80 p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-red-700">Delete account</h2>
+        <p className="mt-1 text-sm text-red-700/70">
+          Permanently delete your account and profile data. This action cannot
+          be undone.
+        </p>
+
+        <Button
+          type="button"
+          onClick={() => {
+            setDeleteConfirmText("");
+            setDeleteError(null);
+            setErrors({});
+            setSuccessMessage(null);
+            setIsDeleteOpen(true);
+          }}
+          className="mt-4 rounded-full bg-red-600 hover:bg-red-700"
+        >
+          Delete account
+        </Button>
+      </section>
+
+      {isDeleteOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div className="w-full max-w-md rounded-3xl bg-white p-6 shadow-xl">
+            <h2 className="text-xl font-semibold text-brand-navy">
+              Confirm account deletion
+            </h2>
+
+            <p className="mt-2 text-sm text-brand-navy/70">
+              This will permanently delete your account. To confirm, type{" "}
+              <span className="font-semibold text-red-600">DELETE</span> or your
+              account email:
+            </p>
+
+            <p className="mt-2 rounded-xl bg-slate-100 px-3 py-2 text-sm font-medium text-brand-navy">
+              {user.email}
+            </p>
+
+            <div className="mt-4 space-y-1.5">
+              <Label htmlFor="delete-confirm">Confirmation</Label>
+              <Input
+                id="delete-confirm"
+                value={deleteConfirmText}
+                onChange={(e) => {
+                  setDeleteConfirmText(e.target.value);
+                  setDeleteError(null);
+                }}
+                placeholder="Type DELETE or your email"
+              />
+              {deleteError && <p className={errorClass}>{deleteError}</p>}
+            </div>
+
+            <div className="mt-6 flex gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isDeleting}
+                onClick={() => {
+                  setIsDeleteOpen(false);
+                  setDeleteConfirmText("");
+                  setDeleteError(null);
+                }}
+                className="flex-1 rounded-full"
+              >
+                Cancel
+              </Button>
+
+              <Button
+                type="button"
+                disabled={isDeleting || !canDelete}
+                onClick={handleDeleteAccount}
+                className="flex-1 rounded-full bg-red-600 hover:bg-red-700"
+              >
+                {isDeleting ? "Deleting..." : "Delete account"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Added delete account button in the settings page, once pressed a confirmation modal shows up where you need to confirm that you want to delete your account. This is done through either writing your email or through writing delete.

## Related Issue

Closes #91 

## Changes

- Added delete account UI section
- implemented confirmation modal that appears, when the delete button is pressed
- Integrated backend delete endpoint Delete /api/users/me

## Checklist

- [ ] Code compiles/builds without errors or warnings
- [ ] Code follows the project style guide and has been formatted
- [ ] All existing tests pass
- [ ] New functionality includes appropriate tests
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
