### PR TITLE
feat(frontend): tenant self service

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, HTTPException
 from sqlalchemy import select
 
 from app.dependencies import CurrentUserDep, SessionDep
-from app.models import User, UserNotificationPrefs
+from app.models import Assignment, User, UserNotificationPrefs
 from app.schemas import (
     NotificationPrefsOut,
     NotificationPrefsPatch,
@@ -21,14 +21,41 @@ def _hash_password(password: str) -> str:
     return _ph.hash(password)
 
 
+async def _assigned_berth_id(session, user_id: str) -> str | None:
+    # boat owner has at most one assignment in v1; pick first deterministically
+    result = await session.execute(
+        select(Assignment.berth_id)
+        .where(Assignment.user_id == user_id)
+        .order_by(Assignment.berth_id)
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+def _to_user_out(user: User, assigned_berth_id: str | None) -> UserOut:
+    return UserOut.model_validate(
+        {
+            "user_id": user.user_id,
+            "firstname": user.firstname,
+            "lastname": user.lastname,
+            "email": user.email,
+            "phone": user.phone,
+            "boat_club": user.boat_club,
+            "role": user.role,
+            "assigned_berth_id": assigned_berth_id,
+        }
+    )
+
+
 @router.get(
     "/me",
     response_model=UserOut,
     operation_id="getMe",
     summary="Get current user profile",
 )
-async def get_me(current_user: CurrentUserDep):
-    return current_user
+async def get_me(current_user: CurrentUserDep, session: SessionDep):
+    berth_id = await _assigned_berth_id(session, current_user.user_id)
+    return _to_user_out(current_user, berth_id)
 
 
 @router.patch(
@@ -68,7 +95,8 @@ async def update_me(body: UserPatch, current_user: CurrentUserDep, session: Sess
     session.add(current_user)
     await session.commit()
     await session.refresh(current_user)
-    return current_user
+    berth_id = await _assigned_berth_id(session, current_user.user_id)
+    return _to_user_out(current_user, berth_id)
 
 
 @router.delete(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -222,6 +222,7 @@ class UserOut(_BaseSchema):
     phone: str | None = Field(default=None, examples=["+46 70 123 45 67"])
     boat_club: str | None = Field(default=None, examples=["Saltsjöbadens BK"])
     role: Role
+    assigned_berth_id: str | None = Field(default=None, examples=["berth-001"])
 
 
 class UserPatch(BaseModel):

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -775,13 +775,21 @@ components:
       type: object
     UserOut:
       properties:
-        boat_club:
+        assigned_berth_id:
           anyOf:
           - examples: &id019
-            - Saltsjöbadens BK
+            - berth-001
             type: string
           - type: 'null'
           examples: *id019
+          title: Assigned Berth Id
+        boat_club:
+          anyOf:
+          - examples: &id020
+            - Saltsjöbadens BK
+            type: string
+          - type: 'null'
+          examples: *id020
           title: Boat Club
         email:
           examples:
@@ -801,11 +809,11 @@ components:
           type: string
         phone:
           anyOf:
-          - examples: &id020
+          - examples: &id021
             - +46 70 123 45 67
             type: string
           - type: 'null'
-          examples: *id020
+          examples: *id021
           title: Phone
         role:
           enum:
@@ -830,12 +838,12 @@ components:
       properties:
         boat_club:
           anyOf:
-          - examples: &id021
+          - examples: &id022
             - Saltsjöbadens BK
             maxLength: 100
             type: string
           - type: 'null'
-          examples: *id021
+          examples: *id022
           title: Boat Club
         current_password:
           anyOf:
@@ -846,25 +854,14 @@ components:
           title: Current Password
         email:
           anyOf:
-          - examples: &id022
+          - examples: &id023
             - alex@example.com
             format: email
             type: string
           - type: 'null'
-          examples: *id022
+          examples: *id023
           title: Email
         firstname:
-          anyOf:
-          - examples: &id023
-            - Alex
-            maxLength: 100
-            minLength: 1
-            pattern: ^[\p{L}\p{M}'’ .\-]+$
-            type: string
-          - type: 'null'
-          examples: *id023
-          title: Firstname
-        lastname:
           anyOf:
           - examples: &id024
             - Alex
@@ -874,10 +871,21 @@ components:
             type: string
           - type: 'null'
           examples: *id024
+          title: Firstname
+        lastname:
+          anyOf:
+          - examples: &id025
+            - Alex
+            maxLength: 100
+            minLength: 1
+            pattern: ^[\p{L}\p{M}'’ .\-]+$
+            type: string
+          - type: 'null'
+          examples: *id025
           title: Lastname
         password:
           anyOf:
-          - examples: &id025
+          - examples: &id026
             - correct horse battery staple
             format: password
             maxLength: 128
@@ -885,17 +893,17 @@ components:
             type: string
             writeOnly: true
           - type: 'null'
-          examples: *id025
+          examples: *id026
           title: Password
         phone:
           anyOf:
-          - examples: &id026
+          - examples: &id027
             - +46 70 123 45 67
             maxLength: 20
             pattern: ^\+?(?:[\s\-().]*\d){7,15}[\s\-().]*$
             type: string
           - type: 'null'
-          examples: *id026
+          examples: *id027
           title: Phone
       title: UserPatch
       type: object

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -126,6 +126,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/berths/availability": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List availability windows in a harbor */
+        get: operations["listHarborAvailability"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/berths/stream": {
         parameters: {
             query?: never;
@@ -176,6 +193,41 @@ export interface paths {
         post?: never;
         /** Remove a berth assignment */
         delete: operations["removeBerthAssignment"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/berths/{berth_id}/availability": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List availability windows for a berth */
+        get: operations["listBerthAvailability"];
+        put?: never;
+        /** Create an availability window for a berth */
+        post: operations["createBerthAvailability"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/berths/{berth_id}/availability/{window_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete an availability window */
+        delete: operations["deleteBerthAvailability"];
         options?: never;
         head?: never;
         patch?: never;
@@ -241,6 +293,23 @@ export interface paths {
         };
         /** List gateways visible to the harbormaster */
         get: operations["listGateways"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/harbors": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all harbors */
+        get: operations["listHarbors"];
         put?: never;
         post?: never;
         delete?: never;
@@ -328,7 +397,8 @@ export interface paths {
         get: operations["getMe"];
         put?: never;
         post?: never;
-        delete?: never;
+        /** Delete the current boat-owner account */
+        delete: operations["deleteMe"];
         options?: never;
         head?: never;
         /** Update current user profile */
@@ -359,9 +429,15 @@ export interface components {
     schemas: {
         /** AdoptIn */
         AdoptIn: {
-            /** Berth Id */
+            /**
+             * Berth Id
+             * @example berth-001
+             */
             berth_id: string;
-            /** Gateway Id */
+            /**
+             * Gateway Id
+             * @example gw-dock-a
+             */
             gateway_id: string;
             /**
              * Qr Payload
@@ -371,33 +447,62 @@ export interface components {
         };
         /** AdoptionRequestOut */
         AdoptionRequestOut: {
-            /** Berth Id */
+            /**
+             * Berth Id
+             * @example berth-001
+             */
             berth_id: string;
-            /** Completed At */
+            /**
+             * Completed At
+             * @example 2026-05-03T14:31:00Z
+             */
             completed_at?: string | null;
             /**
              * Created At
              * Format: date-time
+             * @example 2026-05-03T14:30:00Z
              */
             created_at: string;
-            /** Error Code */
+            /**
+             * Error Code
+             * @example timeout
+             */
             error_code?: string | null;
-            /** Error Msg */
+            /**
+             * Error Msg
+             * @example node did not respond
+             */
             error_msg?: string | null;
             /**
              * Expires At
              * Format: date-time
+             * @example 2026-05-03T14:35:00Z
              */
             expires_at: string;
-            /** Gateway Id */
+            /**
+             * Gateway Id
+             * @example gw-dock-a
+             */
             gateway_id: string;
-            /** Mesh Unicast Addr */
+            /**
+             * Mesh Unicast Addr
+             * @example 0x0042
+             */
             mesh_unicast_addr?: string | null;
-            /** Mesh Uuid */
+            /**
+             * Mesh Uuid
+             * @example a1b2c3d4-e5f6-7890-abcd-ef1234567890
+             */
             mesh_uuid: string;
-            /** Request Id */
+            /**
+             * Request Id
+             * @example req-0001
+             */
             request_id: string;
-            /** Serial Number */
+            /**
+             * Serial Number
+             * @example DP-N-000123
+             */
             serial_number: string;
             /**
              * Status
@@ -417,43 +522,133 @@ export interface components {
         };
         /** AssignBerthIn */
         AssignBerthIn: {
-            /** User Id */
+            /**
+             * User Id
+             * @example user-001
+             */
             user_id: string;
         };
         /** AssignmentOut */
         AssignmentOut: {
-            /** Berth Id */
+            /**
+             * Berth Id
+             * @example berth-001
+             */
             berth_id: string;
-            /** User Id */
+            /**
+             * User Id
+             * @example user-001
+             */
             user_id: string;
+        };
+        /** BerthAvailabilityWindowIn */
+        BerthAvailabilityWindowIn: {
+            /**
+             * From Date
+             * Format: date-time
+             * @example 2026-06-01T00:00:00Z
+             */
+            from_date: string;
+            /**
+             * Return Date
+             * Format: date-time
+             * @example 2026-06-08T00:00:00Z
+             */
+            return_date: string;
+        };
+        /** BerthAvailabilityWindowOut */
+        BerthAvailabilityWindowOut: {
+            /**
+             * Berth Id
+             * @example berth-001
+             */
+            berth_id: string;
+            /**
+             * Created At
+             * Format: date-time
+             * @example 2026-05-05T14:30:00Z
+             */
+            created_at: string;
+            /**
+             * From Date
+             * Format: date-time
+             * @example 2026-06-01T00:00:00Z
+             */
+            from_date: string;
+            /**
+             * Return Date
+             * Format: date-time
+             * @example 2026-06-08T00:00:00Z
+             */
+            return_date: string;
+            /**
+             * User Id
+             * @example user-001
+             */
+            user_id: string;
+            /**
+             * Window Id
+             * @example win-0001
+             */
+            window_id: string;
         };
         /** BerthOut */
         BerthOut: {
             assignment?: components["schemas"]["AssignmentOut"] | null;
-            /** Battery Pct */
+            /**
+             * Battery Pct
+             * @example 87
+             */
             battery_pct?: number | null;
-            /** Berth Id */
+            /**
+             * Berth Id
+             * @example berth-001
+             */
             berth_id: string;
-            /** Depth M */
+            /**
+             * Depth M
+             * @example 2
+             */
             depth_m?: number | null;
-            /** Dock Id */
+            /**
+             * Dock Id
+             * @example dock-a
+             */
             dock_id: string;
             /**
              * Is Reserved
              * @default false
              */
             is_reserved: boolean;
-            /** Label */
+            /**
+             * Label
+             * @example A1
+             */
             label?: string | null;
-            /** Last Updated */
+            /**
+             * Last Updated
+             * @example 2026-05-03T14:30:00Z
+             */
             last_updated?: string | null;
-            /** Length M */
+            /**
+             * Length M
+             * @example 8.5
+             */
             length_m?: number | null;
-            /** Sensor Raw */
+            /**
+             * Sensor Raw
+             * @example 1234
+             */
             sensor_raw?: number | null;
-            /** Status */
-            status: string;
-            /** Width M */
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "free" | "occupied";
+            /**
+             * Width M
+             * @example 3.2
+             */
             width_m?: number | null;
         };
         /** BerthUpdateEvent */
@@ -468,11 +663,20 @@ export interface components {
         };
         /** DockOut */
         DockOut: {
-            /** Dock Id */
+            /**
+             * Dock Id
+             * @example dock-a
+             */
             dock_id: string;
-            /** Harbor Id */
+            /**
+             * Harbor Id
+             * @example harbor-saltsjobaden
+             */
             harbor_id: string;
-            /** Name */
+            /**
+             * Name
+             * @example A Pier
+             */
             name: string;
         };
         /** DockWithBerthsOut */
@@ -482,43 +686,77 @@ export interface components {
              * @default []
              */
             berths: components["schemas"]["BerthOut"][];
-            /** Dock Id */
+            /**
+             * Dock Id
+             * @example dock-a
+             */
             dock_id: string;
-            /** Harbor Id */
+            /**
+             * Harbor Id
+             * @example harbor-saltsjobaden
+             */
             harbor_id: string;
-            /** Name */
+            /**
+             * Name
+             * @example A Pier
+             */
             name: string;
         };
         /** EventOut */
         EventOut: {
-            /** Berth Id */
+            /**
+             * Berth Id
+             * @example berth-001
+             */
             berth_id: string;
-            /** Event Id */
+            /**
+             * Event Id
+             * @example evt-0001
+             */
             event_id: string;
             /**
              * Event Type
              * @enum {string}
              */
             event_type: "occupied" | "freed" | "alert_unauthorized" | "heartbeat";
-            /** Node Id */
+            /**
+             * Node Id
+             * @example node-012
+             */
             node_id: string;
-            /** Sensor Raw */
+            /**
+             * Sensor Raw
+             * @example 1234
+             */
             sensor_raw: number;
             /**
              * Timestamp
              * Format: date-time
+             * @example 2026-05-03T14:30:00Z
              */
             timestamp: string;
         };
         /** GatewayOut */
         GatewayOut: {
-            /** Dock Id */
+            /**
+             * Dock Id
+             * @example dock-a
+             */
             dock_id: string;
-            /** Gateway Id */
+            /**
+             * Gateway Id
+             * @example gw-dock-a
+             */
             gateway_id: string;
-            /** Last Seen */
+            /**
+             * Last Seen
+             * @example 2026-05-03T14:30:00Z
+             */
             last_seen?: string | null;
-            /** Name */
+            /**
+             * Name
+             * @example Pier A gateway
+             */
             name: string;
             /**
              * Status
@@ -530,6 +768,19 @@ export interface components {
         HTTPValidationError: {
             /** Detail */
             detail?: components["schemas"]["ValidationError"][];
+        };
+        /** HarborOut */
+        HarborOut: {
+            /**
+             * Harbor Id
+             * @example harbor-saltsjobaden
+             */
+            harbor_id: string;
+            /**
+             * Name
+             * @example Saltsjöbaden Marina
+             */
+            name: string;
         };
         /** HealthStatus */
         HealthStatus: {
@@ -548,7 +799,10 @@ export interface components {
              * @enum {string}
              */
             status: "ok" | "degraded";
-            /** Uptime */
+            /**
+             * Uptime
+             * @example 12345.6
+             */
             uptime: number;
         };
         /** LoginIn */
@@ -556,6 +810,7 @@ export interface components {
             /**
              * Email
              * Format: email
+             * @example alex@example.com
              */
             email: string;
             /**
@@ -589,7 +844,6 @@ export interface components {
             gateway_id: string;
             /**
              * Health
-             * @example online
              * @enum {string}
              */
             health: "online" | "stale" | "offline" | "decommissioned";
@@ -644,7 +898,6 @@ export interface components {
             gateway_id: string;
             /**
              * Health
-             * @example online
              * @enum {string}
              */
             health: "online" | "stale" | "offline" | "decommissioned";
@@ -696,60 +949,116 @@ export interface components {
         };
         /** UserCreate */
         UserCreate: {
-            /** Boat Club */
+            /**
+             * Boat Club
+             * @example Saltsjöbadens BK
+             */
             boat_club?: string | null;
             /**
              * Email
              * Format: email
+             * @example alex@example.com
              */
             email: string;
-            /** Firstname */
+            /**
+             * Firstname
+             * @example Alex
+             */
             firstname: string;
-            /** Lastname */
+            /**
+             * Lastname
+             * @example Alex
+             */
             lastname: string;
             /**
              * Password
              * Format: password
+             * @example correct horse battery staple
              */
             password: string;
-            /** Phone */
+            /**
+             * Phone
+             * @example +46 70 123 45 67
+             */
             phone?: string | null;
         };
         /** UserOut */
         UserOut: {
-            /** Boat Club */
+            /**
+             * Assigned Berth Id
+             * @example berth-001
+             */
+            assigned_berth_id?: string | null;
+            /**
+             * Boat Club
+             * @example Saltsjöbadens BK
+             */
             boat_club?: string | null;
-            /** Email */
+            /**
+             * Email
+             * Format: email
+             * @example alex@example.com
+             */
             email: string;
-            /** Firstname */
+            /**
+             * Firstname
+             * @example Alex
+             */
             firstname: string;
-            /** Lastname */
+            /**
+             * Lastname
+             * @example Lindgren
+             */
             lastname: string;
-            /** Phone */
+            /**
+             * Phone
+             * @example +46 70 123 45 67
+             */
             phone?: string | null;
             /**
              * Role
              * @enum {string}
              */
             role: "harbormaster" | "boat_owner";
-            /** User Id */
+            /**
+             * User Id
+             * @example user-001
+             */
             user_id: string;
         };
         /** UserPatch */
         UserPatch: {
-            /** Boat Club */
+            /**
+             * Boat Club
+             * @example Saltsjöbadens BK
+             */
             boat_club?: string | null;
             /** Current Password */
             current_password?: string | null;
-            /** Email */
+            /**
+             * Email
+             * @example alex@example.com
+             */
             email?: string | null;
-            /** Firstname */
+            /**
+             * Firstname
+             * @example Alex
+             */
             firstname?: string | null;
-            /** Lastname */
+            /**
+             * Lastname
+             * @example Alex
+             */
             lastname?: string | null;
-            /** Password */
+            /**
+             * Password
+             * @example correct horse battery staple
+             */
             password?: string | null;
-            /** Phone */
+            /**
+             * Phone
+             * @example +46 70 123 45 67
+             */
             phone?: string | null;
         };
         /** ValidationError */
@@ -994,6 +1303,45 @@ export interface operations {
             };
         };
     };
+    listHarborAvailability: {
+        parameters: {
+            query: {
+                /** @description harbor to filter on */
+                harbor_id: string;
+                /** @description windows must end after */
+                from_date?: string | null;
+                /** @description windows must start before */
+                return_date?: string | null;
+                length_m?: number | null;
+                width_m?: number | null;
+                depth_m?: number | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BerthAvailabilityWindowOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     streamBerths: {
         parameters: {
             query?: never;
@@ -1099,6 +1447,102 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["BerthOut"];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    listBerthAvailability: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                berth_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BerthAvailabilityWindowOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    createBerthAvailability: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                berth_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BerthAvailabilityWindowIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BerthAvailabilityWindowOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    deleteBerthAvailability: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                berth_id: string;
+                window_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {
@@ -1239,6 +1683,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    listHarbors: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HarborOut"][];
                 };
             };
         };
@@ -1389,6 +1853,24 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["UserOut"];
                 };
+            };
+        };
+    };
+    deleteMe: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -19,6 +19,7 @@ export type AuthUser = {
   phone?: string;
   boat_club?: string;
   role?: string;
+  assigned_berth_id?: string | null;
 };
 
 export type AuthOutletContext = {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -29,6 +29,20 @@ type SettingsForm = {
   password: string;
 };
 
+type AvailabilityForm = {
+  from_date: string;
+  return_date: string;
+};
+
+type AvailabilityWindow = {
+  window_id: string;
+  berth_id: string;
+  user_id: string;
+  from_date: string;
+  return_date: string;
+  created_at: string;
+};
+
 type FieldErrors = Partial<Record<keyof SettingsForm | "general", string>>;
 
 // mirror backend APP_ENV: prod build enforces the 12 char floor, dev/staging relaxed for testing
@@ -44,6 +58,42 @@ function getInitialForm(user: AuthUser | null): SettingsForm {
     current_password: "",
     password: "",
   };
+}
+
+function getAssignedBerth(user: AuthUser | null) {
+  const berthId = user?.assigned_berth_id ?? null;
+  const berthLabel = berthId ? `Berth ${berthId}` : null;
+  return { berthId, berthLabel };
+}
+
+// input[type=date] is YYYY-MM-DD; backend expects ISO datetime, so anchor at UTC midnight
+function dateInputToIso(value: string): string {
+  return `${value}T00:00:00Z`;
+}
+
+function formatDateLong(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function todayInputValue(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function validateAvailabilityForm(form: AvailabilityForm): string | null {
+  if (!form.from_date) return "Start date is required.";
+  if (!form.return_date) return "Return date is required.";
+
+  if (form.return_date <= form.from_date) {
+    return "Return date must be after the start date.";
+  }
+
+  return null;
 }
 
 function isValidEmail(email: string) {
@@ -135,10 +185,29 @@ function Settings() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
 
+  const [availabilityForm, setAvailabilityForm] = useState<AvailabilityForm>({
+    from_date: "",
+    return_date: "",
+  });
+  const [availabilityWindows, setAvailabilityWindows] = useState<
+    AvailabilityWindow[]
+  >([]);
+  const [availabilityError, setAvailabilityError] = useState<string | null>(
+    null,
+  );
+  const [availabilitySuccess, setAvailabilitySuccess] = useState<string | null>(
+    null,
+  );
+  const [isLoadingAvailability, setIsLoadingAvailability] = useState(false);
+  const [isSavingAvailability, setIsSavingAvailability] = useState(false);
+  const [clearingWindowId, setClearingWindowId] = useState<string | null>(null);
+
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [deleteConfirmText, setDeleteConfirmText] = useState("");
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  const { berthId, berthLabel } = getAssignedBerth(user);
 
   useEffect(() => {
     document.title = "Settings | DockPulse";
@@ -148,10 +217,43 @@ function Settings() {
     setForm(initialForm);
   }, [initialForm]);
 
+  useEffect(() => {
+    if (!berthId) {
+      setAvailabilityWindows([]);
+      return;
+    }
+
+    const ac = new AbortController();
+    setIsLoadingAvailability(true);
+
+    fetch(`/api/berths/${berthId}/availability`, { signal: ac.signal })
+      .then((res) =>
+        res.ok ? (res.json() as Promise<AvailabilityWindow[]>) : [],
+      )
+      .then((windows) => setAvailabilityWindows(windows))
+      .catch((err) => {
+        if (err.name !== "AbortError") {
+          setAvailabilityError("Could not load existing availability windows.");
+        }
+      })
+      .finally(() => setIsLoadingAvailability(false));
+
+    return () => ac.abort();
+  }, [berthId]);
+
   function updateForm(field: keyof SettingsForm, value: string) {
     setForm((prev) => ({ ...prev, [field]: value }));
     setErrors((prev) => ({ ...prev, [field]: undefined, general: undefined }));
     setSuccessMessage(null);
+  }
+
+  function updateAvailabilityForm(
+    field: keyof AvailabilityForm,
+    value: string,
+  ) {
+    setAvailabilityForm((prev) => ({ ...prev, [field]: value }));
+    setAvailabilityError(null);
+    setAvailabilitySuccess(null);
   }
 
   function clearLocalAuthState() {
@@ -159,6 +261,125 @@ function Settings() {
     localStorage.removeItem("token");
     setToken(null);
     setUser(null);
+  }
+
+  async function handleSaveAvailability(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    if (!token) {
+      setAvailabilityError("You need to log in before updating availability.");
+      setIsLoginOpen(true);
+      return;
+    }
+
+    if (!berthId) {
+      setAvailabilityError("No assigned berth was found for your account.");
+      return;
+    }
+
+    const validationError = validateAvailabilityForm(availabilityForm);
+
+    if (validationError) {
+      setAvailabilityError(validationError);
+      setAvailabilitySuccess(null);
+      return;
+    }
+
+    setIsSavingAvailability(true);
+    setAvailabilityError(null);
+    setAvailabilitySuccess(null);
+
+    try {
+      const res = await fetch(`/api/berths/${berthId}/availability`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          from_date: dateInputToIso(availabilityForm.from_date),
+          return_date: dateInputToIso(availabilityForm.return_date),
+        }),
+      });
+
+      if (!res.ok) {
+        const responseErrors = await getErrorsFromResponse(
+          res,
+          "Could not save berth availability.",
+        );
+        setAvailabilityError(
+          responseErrors.general ??
+            "Could not save berth availability. Please try again.",
+        );
+        return;
+      }
+
+      const savedWindow = (await res.json()) as AvailabilityWindow;
+
+      setAvailabilityWindows((prev) =>
+        [...prev, savedWindow].sort((a, b) =>
+          a.from_date.localeCompare(b.from_date),
+        ),
+      );
+      setAvailabilityForm({ from_date: "", return_date: "" });
+      setAvailabilitySuccess("Berth availability saved successfully.");
+    } catch {
+      setAvailabilityError(
+        "Could not save berth availability. Please try again.",
+      );
+    } finally {
+      setIsSavingAvailability(false);
+    }
+  }
+
+  async function handleClearAvailability(window: AvailabilityWindow) {
+    if (!token) {
+      setAvailabilityError("You need to log in before clearing availability.");
+      setIsLoginOpen(true);
+      return;
+    }
+
+    if (!berthId) {
+      setAvailabilityError("No assigned berth was found for your account.");
+      return;
+    }
+
+    setClearingWindowId(window.window_id);
+    setAvailabilityError(null);
+    setAvailabilitySuccess(null);
+
+    try {
+      const res = await fetch(
+        `/api/berths/${berthId}/availability/${window.window_id}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      if (!res.ok) {
+        const responseErrors = await getErrorsFromResponse(
+          res,
+          "Could not clear berth availability.",
+        );
+        setAvailabilityError(
+          responseErrors.general ??
+            "Could not clear berth availability. Please try again.",
+        );
+        return;
+      }
+
+      setAvailabilityWindows((prev) =>
+        prev.filter((w) => w.window_id !== window.window_id),
+      );
+      setAvailabilitySuccess("Berth availability cleared.");
+    } catch {
+      setAvailabilityError(
+        "Could not clear berth availability. Please try again.",
+      );
+    } finally {
+      setClearingWindowId(null);
+    }
   }
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
@@ -462,6 +683,115 @@ function Settings() {
       </form>
 
       {token && <NotificationSettings token={token} />}
+
+      <section className="mt-6 rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-lg backdrop-blur">
+        <div>
+          <h2 className="text-xl font-semibold text-brand-navy">
+            Berth availability
+          </h2>
+          <p className="mt-1 text-sm text-brand-navy/60">
+            Mark your own berth as available and set the date you return.
+          </p>
+        </div>
+
+        {!berthId ? (
+          <p className="mt-4 rounded-xl bg-yellow-50 p-3 text-sm font-medium text-yellow-700">
+            No assigned berth was found for your account.
+          </p>
+        ) : (
+          <>
+            <div className="mt-4 rounded-2xl bg-slate-50 p-4 text-sm text-brand-navy">
+              <p className="font-semibold">Assigned berth</p>
+              <p className="mt-1 text-brand-navy/70">{berthLabel}</p>
+            </div>
+
+            {isLoadingAvailability ? (
+              <p className="mt-4 text-sm text-brand-navy/60">
+                Loading availability windows…
+              </p>
+            ) : availabilityWindows.length > 0 ? (
+              <ul className="mt-4 space-y-2">
+                {availabilityWindows.map((window) => (
+                  <li
+                    key={window.window_id}
+                    className="flex items-center justify-between gap-3 rounded-2xl bg-green-50 p-4 text-sm text-green-700"
+                  >
+                    <span>
+                      Available from {formatDateLong(window.from_date)} until
+                      return on {formatDateLong(window.return_date)}.
+                    </span>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      disabled={clearingWindowId === window.window_id}
+                      onClick={() => handleClearAvailability(window)}
+                      className="rounded-full"
+                    >
+                      {clearingWindowId === window.window_id
+                        ? "Clearing..."
+                        : "Clear"}
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mt-4 text-sm text-brand-navy/60">
+                No upcoming availability windows.
+              </p>
+            )}
+
+            {availabilityError && (
+              <p className="mt-4 rounded-xl bg-red-50 p-3 text-sm font-medium text-red-600">
+                {availabilityError}
+              </p>
+            )}
+
+            {availabilitySuccess && (
+              <p className="mt-4 rounded-xl bg-green-50 p-3 text-sm font-medium text-green-700">
+                {availabilitySuccess}
+              </p>
+            )}
+
+            <form onSubmit={handleSaveAvailability} className="mt-5 space-y-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className={labelGroupClass}>
+                  <Label htmlFor="availability-from-date">Available from</Label>
+                  <Input
+                    id="availability-from-date"
+                    type="date"
+                    min={todayInputValue()}
+                    value={availabilityForm.from_date}
+                    onChange={(e) =>
+                      updateAvailabilityForm("from_date", e.target.value)
+                    }
+                  />
+                </div>
+
+                <div className={labelGroupClass}>
+                  <Label htmlFor="availability-return-date">Return date</Label>
+                  <Input
+                    id="availability-return-date"
+                    type="date"
+                    value={availabilityForm.return_date}
+                    min={availabilityForm.from_date || todayInputValue()}
+                    onChange={(e) =>
+                      updateAvailabilityForm("return_date", e.target.value)
+                    }
+                  />
+                </div>
+              </div>
+
+              <Button
+                type="submit"
+                disabled={isSavingAvailability}
+                className="w-full rounded-full bg-brand-blue"
+              >
+                {isSavingAvailability ? "Saving..." : "Save availability"}
+              </Button>
+            </form>
+          </>
+        )}
+      </section>
 
       <section className="mt-6 rounded-3xl border border-red-200 bg-red-50/80 p-6 shadow-sm">
         <h2 className="text-lg font-semibold text-red-700">Delete account</h2>


### PR DESCRIPTION
## Summary

Added the frontend half of the tenant self service, if a user has been assigned a berth ID, they should be able to go into settings and be able to mark their berth as temporarily available and also set a return date. 

## Related Issue

Closes #26 

## Changes

- Added a Berth availability section in settings
- Implemented Availability API integration
- Introduced Date Based availability logic
- Added Berth Ownership Handling

## Checklist

- [ ] Code compiles/builds without errors or warnings
- [ ] Code follows the project style guide and has been formatted
- [ ] All existing tests pass
- [ ] New functionality includes appropriate tests
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
