### PR TITLE
feat(api): scope harbormaster authz to harbor membership

### DIFF
--- a/backend/alembic/versions/43e642039c65_add_user_harbor_roles_for_harbor_scoped_.py
+++ b/backend/alembic/versions/43e642039c65_add_user_harbor_roles_for_harbor_scoped_.py
@@ -1,0 +1,65 @@
+"""add user_harbor_roles for harbor scoped authz
+
+Revision ID: 43e642039c65
+Revises: 3b8f4d2c1e7a
+Create Date: 2026-05-06 00:20:13.453384
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "43e642039c65"
+down_revision: str | Sequence[str] | None = "3b8f4d2c1e7a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_harbor_roles",
+        sa.Column(
+            "user_id",
+            sa.String(),
+            sa.ForeignKey("users.user_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "harbor_id",
+            sa.String(),
+            sa.ForeignKey("harbors.harbor_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("role", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("user_id", "harbor_id", "role"),
+        sa.CheckConstraint(
+            "role = 'harbormaster'", name="user_harbor_roles_role_check"
+        ),
+    )
+    op.create_index(
+        "ix_user_harbor_roles_harbor_id", "user_harbor_roles", ["harbor_id"]
+    )
+    op.create_index(
+        "ix_user_harbor_roles_user_id", "user_harbor_roles", ["user_id"]
+    )
+
+    # backfill: every existing harbormaster gets authority over every harbor
+    # single-tenant world today, so this preserves current behaviour exactly
+    op.execute(
+        """
+        INSERT INTO user_harbor_roles (user_id, harbor_id, role)
+        SELECT u.user_id, h.harbor_id, 'harbormaster'
+        FROM users u CROSS JOIN harbors h
+        WHERE u.role = 'harbormaster'
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_harbor_roles_user_id", "user_harbor_roles")
+    op.drop_index("ix_user_harbor_roles_harbor_id", "user_harbor_roles")
+    op.drop_table("user_harbor_roles")

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,11 +1,20 @@
 from typing import Annotated
 
 from fastapi import Depends, HTTPException
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_current_user
 from app.db import get_session
-from app.models import User
+from app.models import (
+    AdoptionRequest,
+    Berth,
+    Dock,
+    Gateway,
+    Node,
+    User,
+    UserHarborRole,
+)
 
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
 CurrentUserDep = Annotated[User, Depends(get_current_user)]
@@ -18,3 +27,149 @@ async def require_harbormaster(user: CurrentUserDep) -> User:
 
 
 HarbormasterDep = Annotated[User, Depends(require_harbormaster)]
+
+
+async def require_harbor_authority(
+    user: CurrentUserDep, harbor_id: str, session: SessionDep
+) -> User:
+    if user.role != "harbormaster":
+        raise HTTPException(status_code=403, detail="Harbormaster role required")
+    row = await session.execute(
+        select(UserHarborRole.user_id).where(
+            UserHarborRole.user_id == user.user_id,
+            UserHarborRole.harbor_id == harbor_id,
+            UserHarborRole.role == "harbormaster",
+        )
+    )
+    if row.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=403, detail="Not authorized for this harbor"
+        )
+    return user
+
+
+async def user_managed_harbor_ids(
+    user: User, session: AsyncSession
+) -> set[str]:
+    result = await session.execute(
+        select(UserHarborRole.harbor_id).where(
+            UserHarborRole.user_id == user.user_id,
+            UserHarborRole.role == "harbormaster",
+        )
+    )
+    return set(result.scalars().all())
+
+
+async def harbor_id_from_berth(berth_id: str, session: SessionDep) -> str:
+    row = await session.execute(
+        select(Dock.harbor_id)
+        .join(Berth, Berth.dock_id == Dock.dock_id)
+        .where(Berth.berth_id == berth_id)
+    )
+    harbor_id = row.scalar_one_or_none()
+    if harbor_id is None:
+        raise HTTPException(status_code=404, detail="Berth not found")
+    return harbor_id
+
+
+async def harbor_id_from_dock(dock_id: str, session: SessionDep) -> str:
+    row = await session.execute(
+        select(Dock.harbor_id).where(Dock.dock_id == dock_id)
+    )
+    harbor_id = row.scalar_one_or_none()
+    if harbor_id is None:
+        raise HTTPException(status_code=404, detail="Dock not found")
+    return harbor_id
+
+
+async def harbor_id_from_gateway(gateway_id: str, session: SessionDep) -> str:
+    row = await session.execute(
+        select(Dock.harbor_id)
+        .join(Gateway, Gateway.dock_id == Dock.dock_id)
+        .where(Gateway.gateway_id == gateway_id)
+    )
+    harbor_id = row.scalar_one_or_none()
+    if harbor_id is None:
+        raise HTTPException(status_code=404, detail="Gateway not found")
+    return harbor_id
+
+
+async def harbor_id_from_node(node_id: str, session: SessionDep) -> str:
+    row = await session.execute(
+        select(Dock.harbor_id)
+        .join(Berth, Berth.dock_id == Dock.dock_id)
+        .join(Node, Node.berth_id == Berth.berth_id)
+        .where(Node.node_id == node_id)
+    )
+    harbor_id = row.scalar_one_or_none()
+    if harbor_id is None:
+        raise HTTPException(status_code=404, detail="Node not found")
+    return harbor_id
+
+
+async def harbor_id_from_adoption_request(
+    request_id: str, session: SessionDep
+) -> str:
+    row = await session.execute(
+        select(Dock.harbor_id)
+        .join(Berth, Berth.dock_id == Dock.dock_id)
+        .join(AdoptionRequest, AdoptionRequest.berth_id == Berth.berth_id)
+        .where(AdoptionRequest.request_id == request_id)
+    )
+    harbor_id = row.scalar_one_or_none()
+    if harbor_id is None:
+        raise HTTPException(
+            status_code=404, detail="Adoption request not found"
+        )
+    return harbor_id
+
+
+async def require_harbormaster_for_berth(
+    user: CurrentUserDep,
+    session: SessionDep,
+    harbor_id: Annotated[str, Depends(harbor_id_from_berth)],
+) -> User:
+    return await require_harbor_authority(user, harbor_id, session)
+
+
+async def require_harbormaster_for_dock(
+    user: CurrentUserDep,
+    session: SessionDep,
+    harbor_id: Annotated[str, Depends(harbor_id_from_dock)],
+) -> User:
+    return await require_harbor_authority(user, harbor_id, session)
+
+
+async def require_harbormaster_for_gateway(
+    user: CurrentUserDep,
+    session: SessionDep,
+    harbor_id: Annotated[str, Depends(harbor_id_from_gateway)],
+) -> User:
+    return await require_harbor_authority(user, harbor_id, session)
+
+
+async def require_harbormaster_for_node(
+    user: CurrentUserDep,
+    session: SessionDep,
+    harbor_id: Annotated[str, Depends(harbor_id_from_node)],
+) -> User:
+    return await require_harbor_authority(user, harbor_id, session)
+
+
+async def require_harbormaster_for_adoption_request(
+    user: CurrentUserDep,
+    session: SessionDep,
+    harbor_id: Annotated[str, Depends(harbor_id_from_adoption_request)],
+) -> User:
+    return await require_harbor_authority(user, harbor_id, session)
+
+
+HarbormasterForBerthDep = Annotated[User, Depends(require_harbormaster_for_berth)]
+HarbormasterForDockDep = Annotated[User, Depends(require_harbormaster_for_dock)]
+HarbormasterForGatewayDep = Annotated[
+    User, Depends(require_harbormaster_for_gateway)
+]
+HarbormasterForNodeDep = Annotated[User, Depends(require_harbormaster_for_node)]
+HarbormasterForAdoptionRequestDep = Annotated[
+    User, Depends(require_harbormaster_for_adoption_request)
+]

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -33,15 +33,11 @@ async def require_harbor_authority(
         )
     )
     if row.scalar_one_or_none() is None:
-        raise HTTPException(
-            status_code=403, detail="Not authorized for this harbor"
-        )
+        raise HTTPException(status_code=403, detail="Not authorized for this harbor")
     return user
 
 
-async def user_managed_harbor_ids(
-    user: User, session: AsyncSession
-) -> set[str]:
+async def user_managed_harbor_ids(user: User, session: AsyncSession) -> set[str]:
     result = await session.execute(
         select(UserHarborRole.harbor_id).where(
             UserHarborRole.user_id == user.user_id,
@@ -64,9 +60,7 @@ async def harbor_id_from_berth(berth_id: str, session: SessionDep) -> str:
 
 
 async def harbor_id_from_dock(dock_id: str, session: SessionDep) -> str:
-    row = await session.execute(
-        select(Dock.harbor_id).where(Dock.dock_id == dock_id)
-    )
+    row = await session.execute(select(Dock.harbor_id).where(Dock.dock_id == dock_id))
     harbor_id = row.scalar_one_or_none()
     if harbor_id is None:
         raise HTTPException(status_code=404, detail="Dock not found")
@@ -98,9 +92,7 @@ async def harbor_id_from_node(node_id: str, session: SessionDep) -> str:
     return harbor_id
 
 
-async def harbor_id_from_adoption_request(
-    request_id: str, session: SessionDep
-) -> str:
+async def harbor_id_from_adoption_request(request_id: str, session: SessionDep) -> str:
     row = await session.execute(
         select(Dock.harbor_id)
         .join(Berth, Berth.dock_id == Dock.dock_id)
@@ -109,9 +101,7 @@ async def harbor_id_from_adoption_request(
     )
     harbor_id = row.scalar_one_or_none()
     if harbor_id is None:
-        raise HTTPException(
-            status_code=404, detail="Adoption request not found"
-        )
+        raise HTTPException(status_code=404, detail="Adoption request not found")
     return harbor_id
 
 
@@ -157,9 +147,7 @@ async def require_harbormaster_for_adoption_request(
 
 HarbormasterForBerthDep = Annotated[User, Depends(require_harbormaster_for_berth)]
 HarbormasterForDockDep = Annotated[User, Depends(require_harbormaster_for_dock)]
-HarbormasterForGatewayDep = Annotated[
-    User, Depends(require_harbormaster_for_gateway)
-]
+HarbormasterForGatewayDep = Annotated[User, Depends(require_harbormaster_for_gateway)]
 HarbormasterForNodeDep = Annotated[User, Depends(require_harbormaster_for_node)]
 HarbormasterForAdoptionRequestDep = Annotated[
     User, Depends(require_harbormaster_for_adoption_request)

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -20,15 +20,6 @@ SessionDep = Annotated[AsyncSession, Depends(get_session)]
 CurrentUserDep = Annotated[User, Depends(get_current_user)]
 
 
-async def require_harbormaster(user: CurrentUserDep) -> User:
-    if user.role != "harbormaster":
-        raise HTTPException(status_code=403, detail="Harbormaster role required")
-    return user
-
-
-HarbormasterDep = Annotated[User, Depends(require_harbormaster)]
-
-
 async def require_harbor_authority(
     user: CurrentUserDep, harbor_id: str, session: SessionDep
 ) -> User:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from sqlalchemy import (
     Boolean,
+    CheckConstraint,
     DateTime,
     Double,
     Enum,
@@ -251,3 +252,24 @@ class Assignment(Base):
 
     berth: Mapped["Berth"] = relationship(back_populates="assignment")
     user: Mapped["User"] = relationship(back_populates="assignments")
+
+
+class UserHarborRole(Base):
+    __tablename__ = "user_harbor_roles"
+    __table_args__ = (
+        CheckConstraint(
+            "role = 'harbormaster'", name="user_harbor_roles_role_check"
+        ),
+    )
+
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("users.user_id", ondelete="CASCADE"),
+        primary_key=True,
+        index=True,
+    )
+    harbor_id: Mapped[str] = mapped_column(
+        ForeignKey("harbors.harbor_id", ondelete="CASCADE"),
+        primary_key=True,
+        index=True,
+    )
+    role: Mapped[str] = mapped_column(String, primary_key=True)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -257,9 +257,7 @@ class Assignment(Base):
 class UserHarborRole(Base):
     __tablename__ = "user_harbor_roles"
     __table_args__ = (
-        CheckConstraint(
-            "role = 'harbormaster'", name="user_harbor_roles_role_check"
-        ),
+        CheckConstraint("role = 'harbormaster'", name="user_harbor_roles_role_check"),
     )
 
     user_id: Mapped[str] = mapped_column(

--- a/backend/app/routers/adoptions.py
+++ b/backend/app/routers/adoptions.py
@@ -12,7 +12,13 @@ from sse_starlette.sse import EventSourceResponse
 
 from app import broadcaster
 from app.adoption.claims import ClaimError, FactoryClaim, verify_claim_jwt
-from app.dependencies import HarbormasterDep, SessionDep, require_harbormaster
+from app.dependencies import (
+    CurrentUserDep,
+    SessionDep,
+    harbor_id_from_berth,
+    require_harbor_authority,
+    require_harbormaster_for_adoption_request,
+)
 from app.models import AdoptionRequest, Berth, Gateway, Node
 from app.mqtt import publish_provision_req
 from app.schemas import AdoptIn, AdoptionRequestOut, AdoptionUpdateEvent
@@ -55,7 +61,7 @@ def _verify_claim(qr: dict) -> FactoryClaim:
 )
 async def create_adoption(
     body: AdoptIn,
-    current_user: HarbormasterDep,
+    current_user: CurrentUserDep,
     session: SessionDep,
 ):
     qr = _decode_qr_payload(body.qr_payload)
@@ -64,6 +70,10 @@ async def create_adoption(
     oob = qr.get("oob")
     if not isinstance(oob, str) or not oob:
         raise HTTPException(status_code=400, detail="QR missing 'oob' field")
+
+    # role + harbor authority before any other lookups
+    harbor_id = await harbor_id_from_berth(body.berth_id, session)
+    await require_harbor_authority(current_user, harbor_id, session)
 
     gateway = await session.get(Gateway, body.gateway_id)
     if gateway is None:
@@ -127,7 +137,7 @@ async def create_adoption(
     response_model=AdoptionRequestOut,
     operation_id="getAdoption",
     summary="Get an adoption request by id",
-    dependencies=[Depends(require_harbormaster)],
+    dependencies=[Depends(require_harbormaster_for_adoption_request)],
 )
 async def get_adoption(request_id: str, session: SessionDep):
     request = await session.get(AdoptionRequest, request_id)
@@ -155,6 +165,7 @@ async def get_adoption(request_id: str, session: SessionDep):
         },
         404: {"description": "Adoption request not found"},
     },
+    dependencies=[Depends(require_harbormaster_for_adoption_request)],
 )
 async def stream_adoption(request_id: str, request: Request, session: SessionDep):
     initial = await session.get(AdoptionRequest, request_id)

--- a/backend/app/routers/berths.py
+++ b/backend/app/routers/berths.py
@@ -9,7 +9,11 @@ from sqlalchemy.orm import selectinload
 from sse_starlette.sse import EventSourceResponse
 
 from app import broadcaster
-from app.dependencies import CurrentUserDep, HarbormasterDep, SessionDep
+from app.dependencies import (
+    CurrentUserDep,
+    HarbormasterForBerthDep,
+    SessionDep,
+)
 from app.models import Assignment, Berth, BerthAvailabilityWindow, Dock, Event, User
 from app.schemas import (
     AssignBerthIn,
@@ -114,7 +118,7 @@ async def assign_berth(
     berth_id: str,
     body: AssignBerthIn,
     session: SessionDep,
-    _: HarbormasterDep,
+    _: HarbormasterForBerthDep,
 ):
     berth = await session.get(Berth, berth_id)
     if not berth:
@@ -140,7 +144,7 @@ async def assign_berth(
 async def list_berth_events(
     berth_id: str,
     session: SessionDep,
-    _: HarbormasterDep,
+    _: HarbormasterForBerthDep,
     limit: int = Query(100, ge=1, le=1000),
 ):
     berth = await session.get(Berth, berth_id)
@@ -162,7 +166,7 @@ async def list_berth_events(
     summary="Remove a berth assignment",
 )
 async def remove_berth_assignment(
-    berth_id: str, session: SessionDep, _: HarbormasterDep
+    berth_id: str, session: SessionDep, _: HarbormasterForBerthDep
 ):
     berth = await session.get(Berth, berth_id)
     if not berth:

--- a/backend/app/routers/gateways.py
+++ b/backend/app/routers/gateways.py
@@ -1,7 +1,7 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query
 from sqlalchemy import select
 
-from app.dependencies import HarbormasterDep, SessionDep
+from app.dependencies import CurrentUserDep, SessionDep, user_managed_harbor_ids
 from app.models import Dock, Gateway
 from app.schemas import GatewayOut
 
@@ -15,7 +15,7 @@ router = APIRouter(prefix="/api/gateways", tags=["gateways"])
     summary="List gateways visible to the harbormaster",
 )
 async def list_gateways(
-    _: HarbormasterDep,
+    user: CurrentUserDep,
     session: SessionDep,
     harbor_id: str | None = Query(None, description="Filter by harbor"),
     dock_id: str | None = Query(None, description="Filter by dock"),
@@ -25,14 +25,20 @@ async def list_gateways(
         pattern="^(online|offline)$",
     ),
 ) -> list[GatewayOut]:
-    stmt = select(Gateway)
+    if user.role != "harbormaster":
+        raise HTTPException(status_code=403, detail="Harbormaster role required")
+    managed = await user_managed_harbor_ids(user, session)
+    if not managed:
+        return []
+    stmt = (
+        select(Gateway)
+        .join(Dock, Dock.dock_id == Gateway.dock_id)
+        .where(Dock.harbor_id.in_(managed))
+    )
     if dock_id:
         stmt = stmt.where(Gateway.dock_id == dock_id)
     if harbor_id:
-        # gateway has no harbor_id, scope via dock
-        stmt = stmt.join(Dock, Dock.dock_id == Gateway.dock_id).where(
-            Dock.harbor_id == harbor_id
-        )
+        stmt = stmt.where(Dock.harbor_id == harbor_id)
     if status:
         stmt = stmt.where(Gateway.status == status)
     stmt = stmt.order_by(Gateway.gateway_id)

--- a/backend/app/routers/nodes.py
+++ b/backend/app/routers/nodes.py
@@ -5,8 +5,13 @@ from typing import Annotated, Literal
 from fastapi import APIRouter, HTTPException, Query
 from sqlalchemy import select
 
-from app.dependencies import HarbormasterDep, SessionDep
-from app.models import Berth, Event, Node
+from app.dependencies import (
+    CurrentUserDep,
+    HarbormasterForNodeDep,
+    SessionDep,
+    user_managed_harbor_ids,
+)
+from app.models import Berth, Dock, Event, Node
 from app.mqtt import publish_decommission_req
 from app.schemas import NodeDetailOut, NodeHealthOut
 
@@ -59,7 +64,7 @@ def _to_health_out(node: Node, berth: Berth | None, now: datetime) -> dict:
     summary="List nodes with derived health",
 )
 async def list_nodes(
-    _: HarbormasterDep,
+    user: CurrentUserDep,
     session: SessionDep,
     gateway_id: Annotated[str | None, Query(description="Filter by gateway")] = None,
     berth_id: Annotated[str | None, Query(description="Filter by berth")] = None,
@@ -67,7 +72,17 @@ async def list_nodes(
         HealthLiteral | None, Query(description="Filter by health")
     ] = None,
 ) -> list[dict]:
-    stmt = select(Node)
+    if user.role != "harbormaster":
+        raise HTTPException(status_code=403, detail="Harbormaster role required")
+    managed = await user_managed_harbor_ids(user, session)
+    if not managed:
+        return []
+    stmt = (
+        select(Node)
+        .join(Berth, Berth.berth_id == Node.berth_id)
+        .join(Dock, Dock.dock_id == Berth.dock_id)
+        .where(Dock.harbor_id.in_(managed))
+    )
     if gateway_id:
         stmt = stmt.where(Node.gateway_id == gateway_id)
     if berth_id:
@@ -98,7 +113,7 @@ async def list_nodes(
 )
 async def get_node(
     node_id: str,
-    _: HarbormasterDep,
+    _: HarbormasterForNodeDep,
     session: SessionDep,
     events_limit: Annotated[int, Query(ge=1, le=500)] = RECENT_EVENTS_LIMIT,
 ) -> dict:
@@ -129,7 +144,7 @@ async def get_node(
 )
 async def decommission_node(
     node_id: str,
-    _: HarbormasterDep,
+    _: HarbormasterForNodeDep,
     session: SessionDep,
 ) -> dict:
     node = await session.get(Node, node_id)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -158,9 +158,7 @@ async def harbor_master(session: AsyncSession, harbor_h1) -> User:
     )
     session.add(user)
     await session.flush()
-    session.add(
-        UserHarborRole(user_id="hm1", harbor_id="h1", role="harbormaster")
-    )
+    session.add(UserHarborRole(user_id="hm1", harbor_id="h1", role="harbormaster"))
     await session.commit()
     return user
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -20,7 +20,7 @@ from alembic import command
 from app.config import get_settings
 from app.db import Base, get_session
 from app.main import app
-from app.models import Berth, Dock, Gateway, Harbor, User
+from app.models import Berth, Dock, Gateway, Harbor, User, UserHarborRole
 from tests._helpers import hash_password, make_factory_keys
 
 TEST_DATABASE_URL = os.environ.get(
@@ -121,10 +121,15 @@ async def session(engine) -> AsyncIterator[AsyncSession]:
 
 
 @pytest_asyncio.fixture
-async def seeded_berth(session: AsyncSession):
+async def harbor_h1(session: AsyncSession):
+    session.add(Harbor(harbor_id="h1", name="Harbor 1"))
+    await session.commit()
+
+
+@pytest_asyncio.fixture
+async def seeded_berth(session: AsyncSession, harbor_h1):
     session.add_all(
         [
-            Harbor(harbor_id="h1", name="Harbor 1"),
             Dock(dock_id="d1", harbor_id="h1", name="Dock 1"),
             Berth(berth_id="b1", dock_id="d1", status="free"),
         ]
@@ -142,7 +147,7 @@ async def harbor_world(session: AsyncSession, seeded_berth):
 
 
 @pytest_asyncio.fixture
-async def harbor_master(session: AsyncSession) -> User:
+async def harbor_master(session: AsyncSession, harbor_h1) -> User:
     user = User(
         user_id="hm1",
         firstname="Hilda",
@@ -152,6 +157,10 @@ async def harbor_master(session: AsyncSession) -> User:
         role="harbormaster",
     )
     session.add(user)
+    await session.flush()
+    session.add(
+        UserHarborRole(user_id="hm1", harbor_id="h1", role="harbormaster")
+    )
     await session.commit()
     return user
 

--- a/backend/tests/test_adopt_api.py
+++ b/backend/tests/test_adopt_api.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.adoption.claims import ALGORITHM
-from app.models import AdoptionRequest, Dock, Gateway, Node, User
+from app.models import AdoptionRequest, Berth, Dock, Gateway, Harbor, Node, User
 from tests._helpers import (
     make_auth_token as _auth_token,
 )
@@ -318,10 +318,32 @@ async def test_get_adoption_404_unknown(
 
 
 async def test_get_adoption_requires_harbormaster(
-    client: AsyncClient, boat_owner: User, harbor_world
+    client: AsyncClient,
+    session: AsyncSession,
+    boat_owner: User,
+    harbor_world,
 ):
+    # seed a real request so resolver doesn't 404 before role check fires
+    from datetime import UTC, datetime, timedelta
+
+    now = datetime.now(UTC)
+    session.add(
+        AdoptionRequest(
+            request_id="req-x",
+            mesh_uuid="dddd" * 8,
+            serial_number="DP-N-X",
+            claim_jti="x-jti",
+            gateway_id="gw1",
+            berth_id="b1",
+            expires_at=now + timedelta(seconds=60),
+            status="pending",
+            created_by_user_id=boat_owner.user_id,
+            created_at=now,
+        )
+    )
+    await session.commit()
     r = await client.get(
-        "/api/adoptions/anything",
+        "/api/adoptions/req-x",
         headers={"Authorization": f"Bearer {_auth_token(boat_owner.user_id)}"},
     )
     assert r.status_code == 403
@@ -330,6 +352,43 @@ async def test_get_adoption_requires_harbormaster(
 async def test_get_adoption_requires_auth(client: AsyncClient):
     r = await client.get("/api/adoptions/anything")
     assert r.status_code == 401
+
+
+async def test_adopt_rejects_foreign_harbor(
+    client: AsyncClient,
+    session: AsyncSession,
+    harbor_master: User,
+    harbor_world,
+    factory_pubkey,
+):
+    session.add_all(
+        [
+            Harbor(harbor_id="h2", name="Other Harbor"),
+            Dock(dock_id="d-foreign", harbor_id="h2", name="DF"),
+        ]
+    )
+    await session.commit()
+    session.add_all(
+        [
+            Berth(berth_id="b-foreign", dock_id="d-foreign", status="free"),
+            Gateway(
+                gateway_id="gw-foreign",
+                dock_id="d-foreign",
+                name="GF",
+                status="online",
+            ),
+        ]
+    )
+    await session.commit()
+
+    qr = _make_qr_payload(factory_pubkey)
+    r = await client.post(
+        "/api/adoptions",
+        json=_adopt_body(qr, berth_id="b-foreign", gateway_id="gw-foreign"),
+        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"] == "Not authorized for this harbor"
 
 
 async def test_adopt_publishes_provision_req(

--- a/backend/tests/test_adoption_stream.py
+++ b/backend/tests/test_adoption_stream.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app import broadcaster
 from app.adoption.finalize import complete_adoption_err, complete_adoption_ok
 from app.models import AdoptionRequest, User
+from tests._helpers import make_auth_token as _auth_token
 
 
 @pytest_asyncio.fixture
@@ -38,14 +39,25 @@ async def pending_request(
     return req
 
 
-async def test_stream_404_for_unknown_request(client: AsyncClient, harbor_world):
-    r = await client.get("/api/adoptions/nope/stream")
+async def test_stream_404_for_unknown_request(
+    client: AsyncClient, harbor_master: User, harbor_world
+):
+    r = await client.get(
+        "/api/adoptions/nope/stream",
+        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+    )
     assert r.status_code == 404
+
+
+async def test_stream_requires_auth(client: AsyncClient, harbor_world):
+    r = await client.get("/api/adoptions/anything/stream")
+    assert r.status_code == 401
 
 
 async def test_stream_emits_snapshot_when_already_terminal(
     client: AsyncClient,
     session: AsyncSession,
+    harbor_master: User,
     pending_request: AdoptionRequest,
 ):
     # terminal before connect so handler returns after snapshot, no loop hang
@@ -56,7 +68,10 @@ async def test_stream_emits_snapshot_when_already_terminal(
         dev_key_fp="9f3a8b2c4d1e7f60",
     )
 
-    async with client.stream("GET", "/api/adoptions/req-pending/stream") as stream:
+    headers = {"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"}
+    async with client.stream(
+        "GET", "/api/adoptions/req-pending/stream", headers=headers
+    ) as stream:
         assert stream.status_code == 200
         body = ""
         async for chunk in stream.aiter_text():

--- a/backend/tests/test_assignment_api.py
+++ b/backend/tests/test_assignment_api.py
@@ -2,7 +2,7 @@ import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Assignment, User
+from app.models import Assignment, Berth, Dock, Harbor, User
 from tests._helpers import hash_password, make_auth_token
 
 
@@ -111,3 +111,47 @@ async def test_assign_unknown_berth_404(client, harbor_master, boat_owner):
         headers=_bearer(harbor_master.user_id),
     )
     assert r.status_code == 404
+
+
+@pytest_asyncio.fixture
+async def foreign_berth(session: AsyncSession):
+    session.add_all(
+        [
+            Harbor(harbor_id="h2", name="Other Harbor"),
+            Dock(dock_id="d2", harbor_id="h2", name="Other Dock"),
+            Berth(berth_id="b2", dock_id="d2", status="free"),
+        ]
+    )
+    await session.commit()
+
+
+async def test_assign_foreign_harbor_returns_403(
+    client, harbor_master, boat_owner, foreign_berth
+):
+    r = await client.put(
+        "/api/berths/b2/assignment",
+        json={"user_id": boat_owner.user_id},
+        headers=_bearer(harbor_master.user_id),
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"] == "Not authorized for this harbor"
+
+
+async def test_remove_foreign_assignment_returns_403(
+    client, harbor_master, foreign_berth
+):
+    r = await client.delete(
+        "/api/berths/b2/assignment",
+        headers=_bearer(harbor_master.user_id),
+    )
+    assert r.status_code == 403
+
+
+async def test_list_foreign_berth_events_returns_403(
+    client, harbor_master, foreign_berth
+):
+    r = await client.get(
+        "/api/berths/b2/events",
+        headers=_bearer(harbor_master.user_id),
+    )
+    assert r.status_code == 403

--- a/backend/tests/test_dependencies.py
+++ b/backend/tests/test_dependencies.py
@@ -9,35 +9,9 @@ from app.dependencies import (
     harbor_id_from_gateway,
     harbor_id_from_node,
     require_harbor_authority,
-    require_harbormaster,
     user_managed_harbor_ids,
 )
 from app.models import Harbor, User
-
-
-def _make_user(role: str) -> User:
-    return User(
-        user_id="u1",
-        firstname="X",
-        lastname="Y",
-        email="x@y.com",
-        password_hash="h",
-        role=role,
-    )
-
-
-async def test_require_harbormaster_raises_for_boat_owner():
-    user = _make_user("boat_owner")
-    with pytest.raises(HTTPException) as exc:
-        await require_harbormaster(user)
-    assert exc.value.status_code == 403
-    assert exc.value.detail == "Harbormaster role required"
-
-
-async def test_require_harbormaster_returns_user_for_harbormaster():
-    user = _make_user("harbormaster")
-    result = await require_harbormaster(user)
-    assert result is user
 
 
 async def test_require_harbor_authority_passes_for_member(

--- a/backend/tests/test_dependencies.py
+++ b/backend/tests/test_dependencies.py
@@ -1,8 +1,18 @@
 import pytest
 from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies import require_harbormaster
-from app.models import User
+from app.dependencies import (
+    harbor_id_from_adoption_request,
+    harbor_id_from_berth,
+    harbor_id_from_dock,
+    harbor_id_from_gateway,
+    harbor_id_from_node,
+    require_harbor_authority,
+    require_harbormaster,
+    user_managed_harbor_ids,
+)
+from app.models import Harbor, User
 
 
 def _make_user(role: str) -> User:
@@ -28,3 +38,85 @@ async def test_require_harbormaster_returns_user_for_harbormaster():
     user = _make_user("harbormaster")
     result = await require_harbormaster(user)
     assert result is user
+
+
+async def test_require_harbor_authority_passes_for_member(
+    session: AsyncSession, harbor_master: User
+):
+    result = await require_harbor_authority(harbor_master, "h1", session)
+    assert result is harbor_master
+
+
+async def test_require_harbor_authority_403_for_non_member(
+    session: AsyncSession, harbor_master: User
+):
+    session.add(Harbor(harbor_id="h2", name="Other"))
+    await session.commit()
+    with pytest.raises(HTTPException) as exc:
+        await require_harbor_authority(harbor_master, "h2", session)
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Not authorized for this harbor"
+
+
+async def test_require_harbor_authority_403_for_boat_owner(
+    session: AsyncSession, boat_owner: User, harbor_h1
+):
+    with pytest.raises(HTTPException) as exc:
+        await require_harbor_authority(boat_owner, "h1", session)
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Harbormaster role required"
+
+
+async def test_user_managed_harbor_ids_returns_membership_set(
+    session: AsyncSession, harbor_master: User
+):
+    assert await user_managed_harbor_ids(harbor_master, session) == {"h1"}
+
+
+async def test_user_managed_harbor_ids_empty_for_boat_owner(
+    session: AsyncSession, boat_owner: User
+):
+    assert await user_managed_harbor_ids(boat_owner, session) == set()
+
+
+async def test_harbor_id_from_berth(session: AsyncSession, seeded_berth):
+    assert await harbor_id_from_berth("b1", session) == "h1"
+
+
+async def test_harbor_id_from_berth_404(session: AsyncSession):
+    with pytest.raises(HTTPException) as exc:
+        await harbor_id_from_berth("nope", session)
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Berth not found"
+
+
+async def test_harbor_id_from_dock(session: AsyncSession, seeded_berth):
+    assert await harbor_id_from_dock("d1", session) == "h1"
+
+
+async def test_harbor_id_from_dock_404(session: AsyncSession):
+    with pytest.raises(HTTPException) as exc:
+        await harbor_id_from_dock("nope", session)
+    assert exc.value.status_code == 404
+
+
+async def test_harbor_id_from_gateway(session: AsyncSession, harbor_world):
+    assert await harbor_id_from_gateway("gw1", session) == "h1"
+
+
+async def test_harbor_id_from_gateway_404(session: AsyncSession):
+    with pytest.raises(HTTPException) as exc:
+        await harbor_id_from_gateway("nope", session)
+    assert exc.value.status_code == 404
+
+
+async def test_harbor_id_from_node_404(session: AsyncSession):
+    with pytest.raises(HTTPException) as exc:
+        await harbor_id_from_node("nope", session)
+    assert exc.value.status_code == 404
+
+
+async def test_harbor_id_from_adoption_request_404(session: AsyncSession):
+    with pytest.raises(HTTPException) as exc:
+        await harbor_id_from_adoption_request("nope", session)
+    assert exc.value.status_code == 404

--- a/backend/tests/test_gateways_api.py
+++ b/backend/tests/test_gateways_api.py
@@ -7,14 +7,9 @@ from tests._helpers import make_auth_token as _auth_token
 
 
 @pytest_asyncio.fixture
-async def gateways_world(session: AsyncSession):
+async def gateways_world(session: AsyncSession, harbor_h1):
     # gateway has no relationship() to dock, flush order not enforced, stage commits
-    session.add_all(
-        [
-            Harbor(harbor_id="h1", name="Harbor 1"),
-            Harbor(harbor_id="h2", name="Harbor 2"),
-        ]
-    )
+    session.add(Harbor(harbor_id="h2", name="Harbor 2"))
     await session.commit()
     session.add_all(
         [

--- a/backend/tests/test_gateways_api.py
+++ b/backend/tests/test_gateways_api.py
@@ -2,7 +2,7 @@ import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Dock, Gateway, Harbor, User
+from app.models import Dock, Gateway, Harbor, User, UserHarborRole
 from tests._helpers import make_auth_token as _auth_token
 
 
@@ -44,7 +44,7 @@ async def test_list_gateways_rejects_boat_owner(
     assert r.status_code == 403
 
 
-async def test_list_gateways_returns_all_for_harbormaster(
+async def test_list_gateways_excludes_unmanaged_harbor(
     client: AsyncClient, harbor_master: User, gateways_world
 ):
     r = await client.get(
@@ -53,12 +53,29 @@ async def test_list_gateways_returns_all_for_harbormaster(
     )
     assert r.status_code == 200
     body = r.json()
-    assert [g["gateway_id"] for g in body] == ["gw-a", "gw-b", "gw-c"]
-    assert body[0]["dock_id"] == "d1"
-    assert body[0]["status"] == "online"
+    # gw-c sits in h2 and hm1 manages only h1
+    assert [g["gateway_id"] for g in body] == ["gw-a", "gw-b"]
 
 
-async def test_list_gateways_filters_by_harbor(
+async def test_list_gateways_includes_extra_managed_harbor(
+    client: AsyncClient,
+    session: AsyncSession,
+    harbor_master: User,
+    gateways_world,
+):
+    session.add(
+        UserHarborRole(user_id="hm1", harbor_id="h2", role="harbormaster")
+    )
+    await session.commit()
+    r = await client.get(
+        "/api/gateways",
+        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+    )
+    assert r.status_code == 200
+    assert [g["gateway_id"] for g in r.json()] == ["gw-a", "gw-b", "gw-c"]
+
+
+async def test_list_gateways_unmanaged_harbor_filter_returns_empty(
     client: AsyncClient, harbor_master: User, gateways_world
 ):
     r = await client.get(
@@ -66,8 +83,7 @@ async def test_list_gateways_filters_by_harbor(
         headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
     )
     assert r.status_code == 200
-    body = r.json()
-    assert [g["gateway_id"] for g in body] == ["gw-c"]
+    assert r.json() == []
 
 
 async def test_list_gateways_filters_by_dock(
@@ -78,11 +94,10 @@ async def test_list_gateways_filters_by_dock(
         headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
     )
     assert r.status_code == 200
-    body = r.json()
-    assert [g["gateway_id"] for g in body] == ["gw-b"]
+    assert [g["gateway_id"] for g in r.json()] == ["gw-b"]
 
 
-async def test_list_gateways_filters_by_status(
+async def test_list_gateways_filters_by_status_within_scope(
     client: AsyncClient, harbor_master: User, gateways_world
 ):
     r = await client.get(
@@ -90,8 +105,8 @@ async def test_list_gateways_filters_by_status(
         headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
     )
     assert r.status_code == 200
-    body = r.json()
-    assert [g["gateway_id"] for g in body] == ["gw-a", "gw-c"]
+    # gw-c is online but in h2 so it stays excluded
+    assert [g["gateway_id"] for g in r.json()] == ["gw-a"]
 
 
 async def test_list_gateways_rejects_bad_status(

--- a/backend/tests/test_gateways_api.py
+++ b/backend/tests/test_gateways_api.py
@@ -63,9 +63,7 @@ async def test_list_gateways_includes_extra_managed_harbor(
     harbor_master: User,
     gateways_world,
 ):
-    session.add(
-        UserHarborRole(user_id="hm1", harbor_id="h2", role="harbormaster")
-    )
+    session.add(UserHarborRole(user_id="hm1", harbor_id="h2", role="harbormaster"))
     await session.commit()
     r = await client.get(
         "/api/gateways",

--- a/backend/tests/test_harbors_api.py
+++ b/backend/tests/test_harbors_api.py
@@ -7,13 +7,11 @@ from tests._helpers import make_auth_token as _auth_token
 
 
 @pytest_asyncio.fixture
-async def harbors_world(session: AsyncSession):
-    session.add_all(
-        [
-            Harbor(harbor_id="h2", name="Saltsjöbaden Marina"),
-            Harbor(harbor_id="h1", name="Lidingö Harbor"),
-        ]
-    )
+async def harbors_world(session: AsyncSession, harbor_h1):
+    # shared fixture seeds h1 with default name, override for ordering check
+    h1 = await session.get(Harbor, "h1")
+    h1.name = "Lidingö Harbor"
+    session.add(Harbor(harbor_id="h2", name="Saltsjöbaden Marina"))
     await session.commit()
 
 

--- a/backend/tests/test_nodes_api.py
+++ b/backend/tests/test_nodes_api.py
@@ -4,7 +4,7 @@ import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Berth, Dock, Event, Gateway, Node, User
+from app.models import Berth, Dock, Event, Gateway, Harbor, Node, User
 from tests._helpers import make_auth_token as _auth_token
 
 
@@ -291,3 +291,69 @@ async def test_decommission_rejects_boat_owner(
         headers={"Authorization": f"Bearer {_auth_token(boat_owner.user_id)}"},
     )
     assert r.status_code == 403
+
+
+@pytest_asyncio.fixture
+async def foreign_node(session: AsyncSession, fleet):
+    session.add_all(
+        [
+            Harbor(harbor_id="h2", name="Other Harbor"),
+            Dock(dock_id="d2", harbor_id="h2", name="D2"),
+        ]
+    )
+    await session.commit()
+    session.add_all(
+        [
+            Berth(berth_id="b-foreign", dock_id="d2", status="free"),
+            Gateway(
+                gateway_id="gw-foreign", dock_id="d2", name="GF", status="online"
+            ),
+        ]
+    )
+    await session.commit()
+    session.add(
+        _node(
+            "n-foreign",
+            "b-foreign",
+            "gw-foreign",
+            user_id="hm1",
+            adopted_at=datetime.now(UTC),
+        )
+    )
+    await session.commit()
+
+
+async def test_list_nodes_excludes_unmanaged_harbor(
+    client: AsyncClient, harbor_master: User, foreign_node
+):
+    r = await client.get(
+        "/api/nodes",
+        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+    )
+    assert r.status_code == 200
+    ids = [n["node_id"] for n in r.json()]
+    assert "n-foreign" not in ids
+
+
+async def test_get_foreign_node_returns_403(
+    client: AsyncClient, harbor_master: User, foreign_node
+):
+    r = await client.get(
+        "/api/nodes/n-foreign",
+        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+    )
+    assert r.status_code == 403
+
+
+async def test_decommission_foreign_node_returns_403(
+    client: AsyncClient,
+    harbor_master: User,
+    foreign_node,
+    published_decommission_reqs: list[dict],
+):
+    r = await client.post(
+        "/api/nodes/n-foreign/decommission",
+        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+    )
+    assert r.status_code == 403
+    assert published_decommission_reqs == []

--- a/backend/tests/test_nodes_api.py
+++ b/backend/tests/test_nodes_api.py
@@ -4,7 +4,7 @@ import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Berth, Dock, Event, Gateway, Harbor, Node, User
+from app.models import Berth, Dock, Event, Gateway, Node, User
 from tests._helpers import make_auth_token as _auth_token
 
 
@@ -26,8 +26,6 @@ def _node(node_id: str, berth_id: str, gateway_id: str, *, user_id: str, **over)
 @pytest_asyncio.fixture
 async def fleet(session: AsyncSession, harbor_master: User):
     # FK ordering, gateway and node have no relationship() so flush order not enforced
-    session.add_all([Harbor(harbor_id="h1", name="H1")])
-    await session.commit()
     session.add_all([Dock(dock_id="d1", harbor_id="h1", name="D1")])
     await session.commit()
     now = datetime.now(UTC)

--- a/backend/tests/test_nodes_api.py
+++ b/backend/tests/test_nodes_api.py
@@ -305,9 +305,7 @@ async def foreign_node(session: AsyncSession, fleet):
     session.add_all(
         [
             Berth(berth_id="b-foreign", dock_id="d2", status="free"),
-            Gateway(
-                gateway_id="gw-foreign", dock_id="d2", name="GF", status="online"
-            ),
+            Gateway(gateway_id="gw-foreign", dock_id="d2", name="GF", status="online"),
         ]
     )
     await session.commit()

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -1038,6 +1038,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
+      security:
+      - HTTPBearer: []
       summary: Subscribe to adoption progress via Server-Sent Events
       tags:
       - adoptions


### PR DESCRIPTION
## Summary

Enforce per-harbor authorization on every harbormaster-gated endpoint.

## Changes

- New `user_harbor_roles(user_id, harbor_id, role)` table, alembic migration backfills existing harbormasters.
- `require_harbor_authority` dep + 5 resolvers (berth, dock, gateway, node, adoption_request) and matching `HarbormasterFor*Dep` aliases.
- `user_managed_harbor_ids` helper for list-endpoint scoping.
- Berth router: `assignBerth`, `removeBerthAssignment`, `listBerthEvents` now require harbor membership.
- Gateway list: filtered to managed harbors, `harbor_id` query scoped within.
- Node router: `getNode`, `decommissionNode` require membership, `listNodes` filtered.
- Adoption router: `createAdoption` checks role + harbor before any other lookups, `getAdoption` + `streamAdoption` require membership. Stream previously had no auth at all.
- Dropped unused `require_harbormaster` / `HarbormasterDep` (no callers after the migration).
- Cross-harbor 403 tests on every scoped endpoint, plus multi-harbor membership coverage on the gateway list.
- OpenAPI regenerated (`security: HTTPBearer` added to the stream endpoint).

## Checklist

- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [x] All existing tests pass
- [x] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
