### PR TITLE
feat(auth): cookie sessions, refresh tokens, route guards

### DIFF
--- a/backend/alembic/versions/b4ed7129d0bf_add_refresh_tokens_table.py
+++ b/backend/alembic/versions/b4ed7129d0bf_add_refresh_tokens_table.py
@@ -1,0 +1,57 @@
+"""add refresh_tokens table
+
+Revision ID: b4ed7129d0bf
+Revises: 43e642039c65
+Create Date: 2026-05-06 01:09:56.938826
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b4ed7129d0bf"
+down_revision: str | Sequence[str] | None = "43e642039c65"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "refresh_tokens",
+        sa.Column("jti", sa.String(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.String(),
+            sa.ForeignKey("users.user_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "issued_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "replaced_by_jti",
+            sa.String(),
+            sa.ForeignKey("refresh_tokens.jti", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_refresh_tokens_user_id", "refresh_tokens", ["user_id"]
+    )
+    op.create_index(
+        "ix_refresh_tokens_expires_at", "refresh_tokens", ["expires_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_refresh_tokens_expires_at", "refresh_tokens")
+    op.drop_index("ix_refresh_tokens_user_id", "refresh_tokens")
+    op.drop_table("refresh_tokens")

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -138,13 +138,9 @@ def clear_session_cookies(response: Response) -> None:
 
 def _decode_access(token: str) -> dict:
     try:
-        payload = jwt.decode(
-            token, get_settings().secret_key, algorithms=[ALGORITHM]
-        )
+        payload = jwt.decode(token, get_settings().secret_key, algorithms=[ALGORITHM])
     except jwt.PyJWTError as err:
-        raise HTTPException(
-            status_code=401, detail="Invalid or expired token"
-        ) from err
+        raise HTTPException(status_code=401, detail="Invalid or expired token") from err
     if payload.get("type") not in (None, "access"):
         raise HTTPException(status_code=401, detail="Invalid or expired token")
     return payload
@@ -161,9 +157,7 @@ async def get_current_user(
         user_id: str = payload["sub"]
         token_version: int = payload["ver"]
     except KeyError as err:
-        raise HTTPException(
-            status_code=401, detail="Invalid or expired token"
-        ) from err
+        raise HTTPException(status_code=401, detail="Invalid or expired token") from err
 
     user = await session.get(User, user_id)
     if user is None or user.token_version != token_version:

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -6,11 +6,7 @@ from typing import Annotated
 
 import jwt
 from fastapi import Depends, HTTPException, Request, Response
-from fastapi.security import (
-    APIKeyCookie,
-    HTTPAuthorizationCredentials,
-    HTTPBearer,
-)
+from fastapi.security import APIKeyCookie
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -25,8 +21,7 @@ REFRESH_COOKIE = "dockpulse_refresh"
 CSRF_COOKIE = "dockpulse_csrf"
 CSRF_HEADER = "X-CSRF-Token"
 
-# both auto_error=False so a request can authenticate by either transport
-_bearer = HTTPBearer(auto_error=False)
+# auto_error=False so we control the 401 message and detail uniformly
 _cookie_scheme = APIKeyCookie(name=ACCESS_COOKIE, auto_error=False)
 _logger = logging.getLogger(__name__)
 
@@ -157,15 +152,11 @@ def _decode_access(token: str) -> dict:
 
 async def get_current_user(
     session: Annotated[AsyncSession, Depends(get_session)],
-    credentials: Annotated[
-        HTTPAuthorizationCredentials | None, Depends(_bearer)
-    ] = None,
     cookie_token: Annotated[str | None, Depends(_cookie_scheme)] = None,
 ) -> User:
-    token = cookie_token or (credentials.credentials if credentials else None)
-    if not token:
+    if not cookie_token:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
-    payload = _decode_access(token)
+    payload = _decode_access(cookie_token)
     try:
         user_id: str = payload["sub"]
         token_version: int = payload["ver"]

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,46 +1,198 @@
+import logging
+import secrets
+import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
 import jwt
-from fastapi import Depends, HTTPException
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi import Cookie, Depends, Header, HTTPException, Request, Response
+from fastapi.security import (
+    APIKeyCookie,
+    HTTPAuthorizationCredentials,
+    HTTPBearer,
+)
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
 from app.db import get_session
-from app.models import User
+from app.models import RefreshToken, User
 
 ALGORITHM = "HS256"
-ACCESS_TOKEN_TTL = timedelta(hours=1)
 
-_bearer = HTTPBearer()
+ACCESS_COOKIE = "dockpulse_access"
+REFRESH_COOKIE = "dockpulse_refresh"
+CSRF_COOKIE = "dockpulse_csrf"
+CSRF_HEADER = "X-CSRF-Token"
+
+# both auto_error=False so a request can authenticate by either transport
+_bearer = HTTPBearer(auto_error=False)
+_cookie_scheme = APIKeyCookie(name=ACCESS_COOKIE, auto_error=False)
+_logger = logging.getLogger(__name__)
 
 
-def create_access_token(user: User, expires_in: timedelta = ACCESS_TOKEN_TTL) -> str:
+def _access_ttl() -> timedelta:
+    return timedelta(minutes=get_settings().access_token_ttl_minutes)
+
+
+def _refresh_ttl() -> timedelta:
+    return timedelta(days=get_settings().refresh_token_ttl_days)
+
+
+def create_access_token(user: User, expires_in: timedelta | None = None) -> str:
+    ttl = expires_in or _access_ttl()
     payload = {
         "sub": user.user_id,
         "ver": user.token_version,
-        "exp": datetime.now(UTC) + expires_in,
+        "exp": datetime.now(UTC) + ttl,
+        "type": "access",
     }
     return jwt.encode(payload, get_settings().secret_key, algorithm=ALGORITHM)
 
 
-async def get_current_user(
-    credentials: Annotated[HTTPAuthorizationCredentials, Depends(_bearer)],
-    session: Annotated[AsyncSession, Depends(get_session)],
-) -> User:
+async def create_refresh_token(
+    user: User,
+    session: AsyncSession,
+    *,
+    replaces_jti: str | None = None,
+) -> tuple[str, datetime]:
+    jti = uuid.uuid4().hex
+    now = datetime.now(UTC)
+    expires_at = now + _refresh_ttl()
+    session.add(
+        RefreshToken(
+            jti=jti,
+            user_id=user.user_id,
+            issued_at=now,
+            expires_at=expires_at,
+            replaced_by_jti=None,
+        )
+    )
+    if replaces_jti is not None:
+        await session.execute(
+            update(RefreshToken)
+            .where(RefreshToken.jti == replaces_jti)
+            .values(revoked_at=now, replaced_by_jti=jti)
+        )
+    payload = {
+        "sub": user.user_id,
+        "jti": jti,
+        "exp": expires_at,
+        "type": "refresh",
+    }
+    token = jwt.encode(payload, get_settings().secret_key, algorithm=ALGORITHM)
+    return token, expires_at
+
+
+def generate_csrf_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def set_session_cookies(
+    response: Response,
+    *,
+    access_token: str,
+    refresh_token: str,
+    csrf_token: str,
+) -> None:
+    settings = get_settings()
+    secure = settings.cookies_require_https
+    domain = settings.cookie_domain
+    common = {
+        "secure": secure,
+        "samesite": "lax",
+        "domain": domain,
+        "path": "/",
+    }
+    response.set_cookie(
+        ACCESS_COOKIE,
+        access_token,
+        httponly=True,
+        max_age=int(_access_ttl().total_seconds()),
+        **common,
+    )
+    response.set_cookie(
+        REFRESH_COOKIE,
+        refresh_token,
+        httponly=True,
+        max_age=int(_refresh_ttl().total_seconds()),
+        **common,
+    )
+    # csrf cookie must be js-readable for the double-submit echo
+    response.set_cookie(
+        CSRF_COOKIE,
+        csrf_token,
+        httponly=False,
+        max_age=int(_refresh_ttl().total_seconds()),
+        **common,
+    )
+
+
+def clear_session_cookies(response: Response) -> None:
+    settings = get_settings()
+    common = {
+        "secure": settings.cookies_require_https,
+        "samesite": "lax",
+        "domain": settings.cookie_domain,
+        "path": "/",
+    }
+    response.delete_cookie(ACCESS_COOKIE, **common)
+    response.delete_cookie(REFRESH_COOKIE, **common)
+    response.delete_cookie(CSRF_COOKIE, **common)
+
+
+def _decode_access(token: str) -> dict:
     try:
         payload = jwt.decode(
-            credentials.credentials,
-            get_settings().secret_key,
-            algorithms=[ALGORITHM],
+            token, get_settings().secret_key, algorithms=[ALGORITHM]
         )
+    except jwt.PyJWTError as err:
+        raise HTTPException(
+            status_code=401, detail="Invalid or expired token"
+        ) from err
+    if payload.get("type") not in (None, "access"):
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    return payload
+
+
+async def get_current_user(
+    session: Annotated[AsyncSession, Depends(get_session)],
+    credentials: Annotated[
+        HTTPAuthorizationCredentials | None, Depends(_bearer)
+    ] = None,
+    cookie_token: Annotated[str | None, Depends(_cookie_scheme)] = None,
+) -> User:
+    token = cookie_token or (credentials.credentials if credentials else None)
+    if not token:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    payload = _decode_access(token)
+    try:
         user_id: str = payload["sub"]
         token_version: int = payload["ver"]
-    except (jwt.PyJWTError, KeyError) as err:
-        raise HTTPException(status_code=401, detail="Invalid or expired token") from err
+    except KeyError as err:
+        raise HTTPException(
+            status_code=401, detail="Invalid or expired token"
+        ) from err
 
     user = await session.get(User, user_id)
     if user is None or user.token_version != token_version:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
     return user
+
+
+async def require_csrf(
+    request: Request,
+    csrf_cookie: Annotated[str | None, Cookie(alias=CSRF_COOKIE)] = None,
+    csrf_header: Annotated[str | None, Header(alias=CSRF_HEADER)] = None,
+) -> None:
+    # log-only during the rollout, commit 3 flips this to enforce
+    if request.method in {"GET", "HEAD", "OPTIONS"}:
+        return
+    if csrf_cookie is None:
+        return
+    if csrf_header is None or not secrets.compare_digest(csrf_header, csrf_cookie):
+        _logger.warning(
+            "csrf mismatch on %s %s, would reject in enforce mode",
+            request.method,
+            request.url.path,
+        )

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
 import jwt
-from fastapi import Cookie, Depends, Header, HTTPException, Request, Response
+from fastapi import Depends, HTTPException, Request, Response
 from fastapi.security import (
     APIKeyCookie,
     HTTPAuthorizationCredentials,
@@ -180,19 +180,14 @@ async def get_current_user(
     return user
 
 
-async def require_csrf(
-    request: Request,
-    csrf_cookie: Annotated[str | None, Cookie(alias=CSRF_COOKIE)] = None,
-    csrf_header: Annotated[str | None, Header(alias=CSRF_HEADER)] = None,
-) -> None:
-    # log-only during the rollout, commit 3 flips this to enforce
+async def require_csrf(request: Request) -> None:
+    # raw header/cookie reads so this dep doesn't pollute openapi parameters
     if request.method in {"GET", "HEAD", "OPTIONS"}:
         return
+    csrf_cookie = request.cookies.get(CSRF_COOKIE)
+    # anonymous flows like /login arrive without the cookie, no token to compare
     if csrf_cookie is None:
         return
+    csrf_header = request.headers.get(CSRF_HEADER)
     if csrf_header is None or not secrets.compare_digest(csrf_header, csrf_cookie):
-        _logger.warning(
-            "csrf mismatch on %s %s, would reject in enforce mode",
-            request.method,
-            request.url.path,
-        )
+        raise HTTPException(status_code=403, detail="CSRF token mismatch")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -46,6 +46,19 @@ class Settings(BaseSettings):
     rate_limit_register: str = "5/hour"
     # global kill-switch so tests don't have to override every endpoint
     rate_limit_enabled: bool = True
+    # short access ttl narrows xss / leaked-token blast radius
+    access_token_ttl_minutes: int = 15
+    # refresh ttl is rolling, rotation issues a fresh full-length token
+    refresh_token_ttl_days: int = 14
+    # None lets cookie_secure derive from app_env, override for tunnels in staging
+    cookie_secure: bool | None = None
+    cookie_domain: str | None = None
+
+    @property
+    def cookies_require_https(self) -> bool:
+        if self.cookie_secure is not None:
+            return self.cookie_secure
+        return self.app_env == "prod"
 
     @field_validator("secret_key")
     @classmethod

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,7 @@ import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse
@@ -17,6 +17,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from app.adoption.sweeper import sweeper_loop
+from app.auth import require_csrf
 from app.config import get_settings
 from app.db import get_engine
 from app.logging_config import request_id_var, setup_logging
@@ -141,6 +142,8 @@ app = FastAPI(
     openapi_tags=TAGS_METADATA,
     servers=SERVERS,
     lifespan=lifespan,
+    # double-submit csrf check on every non-safe method, dep no-ops on GET/HEAD/OPTIONS
+    dependencies=[Depends(require_csrf)],
 )
 
 app.state.limiter = limiter

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -271,3 +271,24 @@ class UserHarborRole(Base):
         index=True,
     )
     role: Mapped[str] = mapped_column(String, primary_key=True)
+
+
+class RefreshToken(Base):
+    __tablename__ = "refresh_tokens"
+
+    jti: Mapped[str] = mapped_column(String, primary_key=True)
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("users.user_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    issued_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    replaced_by_jti: Mapped[str | None] = mapped_column(
+        ForeignKey("refresh_tokens.jti", ondelete="SET NULL")
+    )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -21,7 +21,7 @@ from app.config import get_settings
 from app.dependencies import CurrentUserDep, SessionDep
 from app.models import RefreshToken, User
 from app.rate_limit import limiter
-from app.schemas import LoginIn, TokenOut, UserCreate, UserOut
+from app.schemas import LoginIn, UserCreate, UserOut
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
@@ -41,19 +41,16 @@ async def _issue_session(
     session: SessionDep,
     *,
     replaces_jti: str | None = None,
-) -> str:
+) -> None:
     refresh_token, _ = await create_refresh_token(
         user, session, replaces_jti=replaces_jti
     )
-    access_token = create_access_token(user)
-    csrf_token = generate_csrf_token()
     set_session_cookies(
         response,
-        access_token=access_token,
+        access_token=create_access_token(user),
         refresh_token=refresh_token,
-        csrf_token=csrf_token,
+        csrf_token=generate_csrf_token(),
     )
-    return access_token
 
 
 @router.post(
@@ -86,9 +83,9 @@ async def register(request: Request, body: UserCreate, session: SessionDep):
 
 @router.post(
     "/login",
-    response_model=TokenOut,
+    response_model=UserOut,
     operation_id="login",
-    summary="Log in and obtain an access token",
+    summary="Log in and set session cookies",
 )
 @limiter.limit(lambda: get_settings().rate_limit_login)
 async def login(
@@ -105,10 +102,9 @@ async def login(
     if user is None:
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
-    access_token = await _issue_session(user, response, session)
+    await _issue_session(user, response, session)
     await session.commit()
-    # access_token in body is back-compat for header-based callers, drop in step 5
-    return TokenOut(access_token=access_token)
+    return user
 
 
 @router.get(

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -135,9 +135,7 @@ async def refresh_session(
             refresh_cookie, get_settings().secret_key, algorithms=[ALGORITHM]
         )
     except jwt.PyJWTError as err:
-        raise HTTPException(
-            status_code=401, detail="Invalid refresh token"
-        ) from err
+        raise HTTPException(status_code=401, detail="Invalid refresh token") from err
     if payload.get("type") != "refresh":
         raise HTTPException(status_code=401, detail="Invalid refresh token")
     jti = payload.get("jti")
@@ -178,9 +176,7 @@ async def refresh_session(
     operation_id="logout",
     summary="Invalidate all tokens for the current user",
 )
-async def logout(
-    current_user: CurrentUserDep, session: SessionDep, response: Response
-):
+async def logout(current_user: CurrentUserDep, session: SessionDep, response: Response):
     current_user.token_version += 1
     session.add(current_user)
     await _revoke_all_refresh_tokens_for(current_user.user_id, session)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,14 +1,25 @@
 import uuid
+from datetime import UTC, datetime
+from typing import Annotated
 
+import jwt
 from argon2 import PasswordHasher
 from argon2.exceptions import VerifyMismatchError
-from fastapi import APIRouter, HTTPException, Request
-from sqlalchemy import select
+from fastapi import APIRouter, Cookie, HTTPException, Request, Response
+from sqlalchemy import select, update
 
-from app.auth import create_access_token
+from app.auth import (
+    ALGORITHM,
+    REFRESH_COOKIE,
+    clear_session_cookies,
+    create_access_token,
+    create_refresh_token,
+    generate_csrf_token,
+    set_session_cookies,
+)
 from app.config import get_settings
 from app.dependencies import CurrentUserDep, SessionDep
-from app.models import User
+from app.models import RefreshToken, User
 from app.rate_limit import limiter
 from app.schemas import LoginIn, TokenOut, UserCreate, UserOut
 
@@ -22,6 +33,27 @@ _DUMMY_HASH = _ph.hash("dummy-password-for-timing-equalization")
 
 def _hash_password(password: str) -> str:
     return _ph.hash(password)
+
+
+async def _issue_session(
+    user: User,
+    response: Response,
+    session: SessionDep,
+    *,
+    replaces_jti: str | None = None,
+) -> str:
+    refresh_token, _ = await create_refresh_token(
+        user, session, replaces_jti=replaces_jti
+    )
+    access_token = create_access_token(user)
+    csrf_token = generate_csrf_token()
+    set_session_cookies(
+        response,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        csrf_token=csrf_token,
+    )
+    return access_token
 
 
 @router.post(
@@ -59,7 +91,9 @@ async def register(request: Request, body: UserCreate, session: SessionDep):
     summary="Log in and obtain an access token",
 )
 @limiter.limit(lambda: get_settings().rate_limit_login)
-async def login(request: Request, body: LoginIn, session: SessionDep):
+async def login(
+    request: Request, body: LoginIn, session: SessionDep, response: Response
+):
     result = await session.execute(select(User).where(User.email == body.email))
     user = result.scalar_one_or_none()
 
@@ -71,7 +105,75 @@ async def login(request: Request, body: LoginIn, session: SessionDep):
     if user is None:
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
-    return TokenOut(access_token=create_access_token(user))
+    access_token = await _issue_session(user, response, session)
+    await session.commit()
+    # access_token in body is back-compat for header-based callers, drop in step 5
+    return TokenOut(access_token=access_token)
+
+
+@router.get(
+    "/me",
+    response_model=UserOut,
+    operation_id="getCurrentUser",
+    summary="Return the authenticated user",
+)
+async def me(current_user: CurrentUserDep) -> User:
+    return current_user
+
+
+@router.post(
+    "/refresh",
+    status_code=204,
+    operation_id="refreshSession",
+    summary="Rotate the refresh cookie and reissue the access cookie",
+)
+async def refresh_session(
+    response: Response,
+    session: SessionDep,
+    refresh_cookie: Annotated[str | None, Cookie(alias=REFRESH_COOKIE)] = None,
+):
+    if refresh_cookie is None:
+        raise HTTPException(status_code=401, detail="Missing refresh cookie")
+    try:
+        payload = jwt.decode(
+            refresh_cookie, get_settings().secret_key, algorithms=[ALGORITHM]
+        )
+    except jwt.PyJWTError as err:
+        raise HTTPException(
+            status_code=401, detail="Invalid refresh token"
+        ) from err
+    if payload.get("type") != "refresh":
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+    jti = payload.get("jti")
+    user_id = payload.get("sub")
+    if not isinstance(jti, str) or not isinstance(user_id, str):
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+    row = await session.get(RefreshToken, jti)
+    if row is None or row.user_id != user_id:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+    if row.revoked_at is not None:
+        # reuse of a rotated token, treat as theft and burn the family
+        await _revoke_all_refresh_tokens_for(user_id, session)
+        await session.execute(
+            update(User)
+            .where(User.user_id == user_id)
+            .values(token_version=User.token_version + 1)
+        )
+        await session.commit()
+        clear_session_cookies(response)
+        raise HTTPException(status_code=401, detail="Refresh token reused")
+
+    if row.expires_at <= datetime.now(UTC):
+        raise HTTPException(status_code=401, detail="Refresh token expired")
+
+    user = await session.get(User, user_id)
+    if user is None:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+    await _issue_session(user, response, session, replaces_jti=jti)
+    await session.commit()
 
 
 @router.post(
@@ -80,7 +182,19 @@ async def login(request: Request, body: LoginIn, session: SessionDep):
     operation_id="logout",
     summary="Invalidate all tokens for the current user",
 )
-async def logout(current_user: CurrentUserDep, session: SessionDep):
+async def logout(
+    current_user: CurrentUserDep, session: SessionDep, response: Response
+):
     current_user.token_version += 1
     session.add(current_user)
+    await _revoke_all_refresh_tokens_for(current_user.user_id, session)
     await session.commit()
+    clear_session_cookies(response)
+
+
+async def _revoke_all_refresh_tokens_for(user_id: str, session: SessionDep) -> None:
+    await session.execute(
+        update(RefreshToken)
+        .where(RefreshToken.user_id == user_id, RefreshToken.revoked_at.is_(None))
+        .values(revoked_at=datetime.now(UTC))
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -256,11 +256,6 @@ class LoginIn(BaseModel):
     password: SecretStr
 
 
-class TokenOut(BaseModel):
-    access_token: str
-    token_type: Literal["bearer"] = "bearer"
-
-
 # --- system ---
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -50,6 +50,9 @@ asyncio_default_test_loop_scope = "session"
 pythonpath = ["."]
 testpaths = ["tests"]
 addopts = "--cov --cov-report=term-missing"
+filterwarnings = [
+  "ignore:Setting per-request cookies.*:DeprecationWarning",
+]
 
 [tool.coverage.run]
 source = ["app"]

--- a/backend/tests/_helpers.py
+++ b/backend/tests/_helpers.py
@@ -40,6 +40,14 @@ def make_auth_token(user_id: str, token_version: int = 0) -> str:
     )
 
 
+def auth_cookies(user_id: str, token_version: int = 0) -> dict[str, str]:
+    # csrf value is arbitrary, conftest event hook echoes the cookie back as a header
+    return {
+        "dockpulse_access": make_auth_token(user_id, token_version),
+        "dockpulse_csrf": "test-csrf",
+    }
+
+
 def make_factory_keys() -> tuple[str, str]:
     priv = Ed25519PrivateKey.generate()
     priv_pem = priv.private_bytes(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -192,6 +192,23 @@ def factory_pubkey(monkeypatch) -> str:
     return priv_pem
 
 
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+async def _attach_csrf_header(request) -> None:
+    # mirror the frontend double-submit echo so tests don't repeat it
+    if request.method in _SAFE_METHODS:
+        return
+    if "X-CSRF-Token" in request.headers:
+        return
+    cookie_header = request.headers.get("cookie", "")
+    for chunk in cookie_header.split(";"):
+        name, _, value = chunk.strip().partition("=")
+        if name == "dockpulse_csrf" and value:
+            request.headers["X-CSRF-Token"] = value
+            return
+
+
 @pytest_asyncio.fixture
 async def client(session: AsyncSession) -> AsyncIterator[AsyncClient]:
     async def _override() -> AsyncIterator[AsyncSession]:
@@ -199,6 +216,10 @@ async def client(session: AsyncSession) -> AsyncIterator[AsyncClient]:
 
     app.dependency_overrides[get_session] = _override
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as c:
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        event_hooks={"request": [_attach_csrf_header]},
+    ) as c:
         yield c
     app.dependency_overrides.clear()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,6 +7,8 @@ os.environ.setdefault("APP_ENV", "prod")
 os.environ.setdefault("SECRET_KEY", "test-secret-key-not-for-prod-32bytesx")
 # rate limiter is process-global, disable here and the dedicated test re-enables
 os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
+# httpx test client uses http://, Secure cookies would be silently dropped
+os.environ.setdefault("COOKIE_SECURE", "false")
 
 from collections.abc import AsyncIterator
 from pathlib import Path

--- a/backend/tests/test_adopt_api.py
+++ b/backend/tests/test_adopt_api.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.adoption.claims import ALGORITHM
 from app.models import AdoptionRequest, Berth, Dock, Gateway, Harbor, Node, User
 from tests._helpers import (
-    make_auth_token as _auth_token,
+    auth_cookies as _creds,
 )
 from tests._helpers import (
     make_factory_keys,
@@ -38,7 +38,7 @@ async def test_adopt_happy_path_creates_pending_request(
     r = await client.post(
         "/api/adoptions",
         json=_adopt_body(qr),
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 202
     body = r.json()
@@ -71,7 +71,7 @@ async def test_adopt_rejects_boat_owner(
     r = await client.post(
         "/api/adoptions",
         json=_adopt_body(qr),
-        headers={"Authorization": f"Bearer {_auth_token(boat_owner.user_id)}"},
+        cookies=_creds(boat_owner.user_id),
     )
     assert r.status_code == 403
 
@@ -140,7 +140,7 @@ async def test_adopt_rejects_malformed_qr(
     r = await client.post(
         "/api/adoptions",
         json=_adopt_body(qr_factory(factory_pubkey)),
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 400
     rows = (await session.execute(select(AdoptionRequest))).scalars().all()
@@ -154,7 +154,7 @@ async def test_adopt_returns_404_for_unknown_gateway(
     r = await client.post(
         "/api/adoptions",
         json=_adopt_body(qr, gateway_id="nope"),
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 404
 
@@ -166,7 +166,7 @@ async def test_adopt_returns_404_for_unknown_berth(
     r = await client.post(
         "/api/adoptions",
         json=_adopt_body(qr, berth_id="nope"),
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 404
 
@@ -189,7 +189,7 @@ async def test_adopt_rejects_gateway_dock_mismatch(
     r = await client.post(
         "/api/adoptions",
         json=_adopt_body(qr, berth_id="b2"),
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 400
 
@@ -223,7 +223,7 @@ async def test_adopt_rejects_berth_with_active_node(
     r = await client.post(
         "/api/adoptions",
         json=_adopt_body(qr),
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 409
 
@@ -232,12 +232,12 @@ async def test_adopt_rejects_reused_jti(
     client: AsyncClient, harbor_master: User, harbor_world, factory_pubkey
 ):
     qr = _make_qr_payload(factory_pubkey, jti="reused-jti")
-    headers = {"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"}
+    creds = _creds(harbor_master.user_id)
 
-    first = await client.post("/api/adoptions", json=_adopt_body(qr), headers=headers)
+    first = await client.post("/api/adoptions", json=_adopt_body(qr), cookies=creds)
     assert first.status_code == 202
 
-    second = await client.post("/api/adoptions", json=_adopt_body(qr), headers=headers)
+    second = await client.post("/api/adoptions", json=_adopt_body(qr), cookies=creds)
     assert second.status_code == 409
 
 
@@ -252,7 +252,7 @@ async def test_adopt_persists_creator(
     r = await client.post(
         "/api/adoptions",
         json=_adopt_body(qr),
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 202
 
@@ -278,7 +278,7 @@ async def test_adopt_rejects_offline_gateway(
     r = await client.post(
         "/api/adoptions",
         json=_adopt_body(qr),
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 409
 
@@ -293,14 +293,14 @@ async def test_get_adoption_returns_request(
     create = await client.post(
         "/api/adoptions",
         json=_adopt_body(qr),
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert create.status_code == 202
     request_id = create.json()["request_id"]
 
     r = await client.get(
         f"/api/adoptions/{request_id}",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 200
     assert r.json()["request_id"] == request_id
@@ -312,7 +312,7 @@ async def test_get_adoption_404_unknown(
 ):
     r = await client.get(
         "/api/adoptions/missing",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 404
 
@@ -344,7 +344,7 @@ async def test_get_adoption_requires_harbormaster(
     await session.commit()
     r = await client.get(
         "/api/adoptions/req-x",
-        headers={"Authorization": f"Bearer {_auth_token(boat_owner.user_id)}"},
+        cookies=_creds(boat_owner.user_id),
     )
     assert r.status_code == 403
 
@@ -385,7 +385,7 @@ async def test_adopt_rejects_foreign_harbor(
     r = await client.post(
         "/api/adoptions",
         json=_adopt_body(qr, berth_id="b-foreign", gateway_id="gw-foreign"),
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 403
     assert r.json()["detail"] == "Not authorized for this harbor"
@@ -402,7 +402,7 @@ async def test_adopt_publishes_provision_req(
     r = await client.post(
         "/api/adoptions",
         json=_adopt_body(qr),
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 202
     assert len(published_provision_reqs) == 1

--- a/backend/tests/test_adoption_stream.py
+++ b/backend/tests/test_adoption_stream.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app import broadcaster
 from app.adoption.finalize import complete_adoption_err, complete_adoption_ok
 from app.models import AdoptionRequest, User
-from tests._helpers import make_auth_token as _auth_token
+from tests._helpers import auth_cookies as _creds
 
 
 @pytest_asyncio.fixture
@@ -44,7 +44,7 @@ async def test_stream_404_for_unknown_request(
 ):
     r = await client.get(
         "/api/adoptions/nope/stream",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 404
 
@@ -68,9 +68,9 @@ async def test_stream_emits_snapshot_when_already_terminal(
         dev_key_fp="9f3a8b2c4d1e7f60",
     )
 
-    headers = {"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"}
+    creds = _creds(harbor_master.user_id)
     async with client.stream(
-        "GET", "/api/adoptions/req-pending/stream", headers=headers
+        "GET", "/api/adoptions/req-pending/stream", cookies=creds
     ) as stream:
         assert stream.status_code == 200
         body = ""

--- a/backend/tests/test_assignment_api.py
+++ b/backend/tests/test_assignment_api.py
@@ -3,11 +3,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Assignment, Berth, Dock, Harbor, User
-from tests._helpers import hash_password, make_auth_token
-
-
-def _bearer(user_id: str) -> dict[str, str]:
-    return {"Authorization": f"Bearer {make_auth_token(user_id)}"}
+from tests._helpers import auth_cookies, hash_password
 
 
 @pytest_asyncio.fixture
@@ -31,7 +27,7 @@ async def test_assign_then_get_returns_assignment(
     r = await client.put(
         "/api/berths/b1/assignment",
         json={"user_id": boat_owner.user_id},
-        headers=_bearer(harbor_master.user_id),
+        cookies=auth_cookies(harbor_master.user_id),
     )
     assert r.status_code == 200, r.text
     body = r.json()
@@ -46,17 +42,17 @@ async def test_assign_then_get_returns_assignment(
 async def test_assign_replaces_previous_user(
     client, session, seeded_berth, harbor_master, boat_owner, second_owner
 ):
-    headers = _bearer(harbor_master.user_id)
+    creds = auth_cookies(harbor_master.user_id)
 
     await client.put(
         "/api/berths/b1/assignment",
         json={"user_id": boat_owner.user_id},
-        headers=headers,
+        cookies=creds,
     )
     r = await client.put(
         "/api/berths/b1/assignment",
         json={"user_id": second_owner.user_id},
-        headers=headers,
+        cookies=creds,
     )
     assert r.status_code == 200, r.text
     assert r.json()["assignment"]["user_id"] == second_owner.user_id
@@ -69,14 +65,14 @@ async def test_assign_replaces_previous_user(
 async def test_remove_assignment_clears_state(
     client, session, seeded_berth, harbor_master, boat_owner
 ):
-    headers = _bearer(harbor_master.user_id)
+    creds = auth_cookies(harbor_master.user_id)
     await client.put(
         "/api/berths/b1/assignment",
         json={"user_id": boat_owner.user_id},
-        headers=headers,
+        cookies=creds,
     )
 
-    r = await client.delete("/api/berths/b1/assignment", headers=headers)
+    r = await client.delete("/api/berths/b1/assignment", cookies=creds)
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["status"] == "free"
@@ -90,7 +86,7 @@ async def test_assign_requires_harbormaster(client, seeded_berth, boat_owner):
     r = await client.put(
         "/api/berths/b1/assignment",
         json={"user_id": boat_owner.user_id},
-        headers=_bearer(boat_owner.user_id),
+        cookies=auth_cookies(boat_owner.user_id),
     )
     assert r.status_code == 403
 
@@ -99,7 +95,7 @@ async def test_assign_unknown_user_404(client, seeded_berth, harbor_master):
     r = await client.put(
         "/api/berths/b1/assignment",
         json={"user_id": "nope"},
-        headers=_bearer(harbor_master.user_id),
+        cookies=auth_cookies(harbor_master.user_id),
     )
     assert r.status_code == 404
 
@@ -108,7 +104,7 @@ async def test_assign_unknown_berth_404(client, harbor_master, boat_owner):
     r = await client.put(
         "/api/berths/nope/assignment",
         json={"user_id": boat_owner.user_id},
-        headers=_bearer(harbor_master.user_id),
+        cookies=auth_cookies(harbor_master.user_id),
     )
     assert r.status_code == 404
 
@@ -131,7 +127,7 @@ async def test_assign_foreign_harbor_returns_403(
     r = await client.put(
         "/api/berths/b2/assignment",
         json={"user_id": boat_owner.user_id},
-        headers=_bearer(harbor_master.user_id),
+        cookies=auth_cookies(harbor_master.user_id),
     )
     assert r.status_code == 403
     assert r.json()["detail"] == "Not authorized for this harbor"
@@ -142,7 +138,7 @@ async def test_remove_foreign_assignment_returns_403(
 ):
     r = await client.delete(
         "/api/berths/b2/assignment",
-        headers=_bearer(harbor_master.user_id),
+        cookies=auth_cookies(harbor_master.user_id),
     )
     assert r.status_code == 403
 
@@ -152,6 +148,6 @@ async def test_list_foreign_berth_events_returns_403(
 ):
     r = await client.get(
         "/api/berths/b2/events",
-        headers=_bearer(harbor_master.user_id),
+        cookies=auth_cookies(harbor_master.user_id),
     )
     assert r.status_code == 403

--- a/backend/tests/test_berths_api.py
+++ b/backend/tests/test_berths_api.py
@@ -1,5 +1,5 @@
 from app.events import process_sensor_reading
-from tests._helpers import make_auth_token
+from tests._helpers import auth_cookies
 
 
 async def test_api_reflects_mqtt_reading(client, session, seeded_berth):
@@ -42,9 +42,8 @@ async def test_api_unknown_berth_404(client):
 
 
 async def test_list_berth_events_empty(client, seeded_berth, harbor_master):
-    token = make_auth_token(harbor_master.user_id)
     r = await client.get(
-        "/api/berths/b1/events", headers={"Authorization": f"Bearer {token}"}
+        "/api/berths/b1/events", cookies=auth_cookies(harbor_master.user_id)
     )
     assert r.status_code == 200
     assert r.json() == []
@@ -56,9 +55,8 @@ async def test_list_berth_events_returns_events(
     await process_sensor_reading(
         session, berth_id="b1", node_id="n1", occupied=True, sensor_raw=500
     )
-    token = make_auth_token(harbor_master.user_id)
     r = await client.get(
-        "/api/berths/b1/events", headers={"Authorization": f"Bearer {token}"}
+        "/api/berths/b1/events", cookies=auth_cookies(harbor_master.user_id)
     )
     assert r.status_code == 200
     data = r.json()
@@ -73,9 +71,8 @@ async def test_list_berth_events_requires_auth(client, seeded_berth):
 
 
 async def test_list_berth_events_unknown_berth(client, harbor_master):
-    token = make_auth_token(harbor_master.user_id)
     r = await client.get(
         "/api/berths/does-not-exist/events",
-        headers={"Authorization": f"Bearer {token}"},
+        cookies=auth_cookies(harbor_master.user_id),
     )
     assert r.status_code == 404

--- a/backend/tests/test_cookie_auth.py
+++ b/backend/tests/test_cookie_auth.py
@@ -1,0 +1,180 @@
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import (
+    ACCESS_COOKIE,
+    ALGORITHM,
+    CSRF_COOKIE,
+    REFRESH_COOKIE,
+)
+from app.config import get_settings
+from app.models import RefreshToken, User
+from tests._helpers import hash_password
+
+
+async def _register_user(session: AsyncSession) -> User:
+    user = User(
+        user_id="u-cookie",
+        firstname="Cora",
+        lastname="Cookie",
+        email="cora@example.com",
+        password_hash=hash_password("supersecret"),
+        role="boat_owner",
+    )
+    session.add(user)
+    await session.commit()
+    return user
+
+
+async def test_login_sets_session_cookies(
+    client: AsyncClient, session: AsyncSession
+):
+    await _register_user(session)
+    r = await client.post(
+        "/api/auth/login",
+        json={"email": "cora@example.com", "password": "supersecret"},
+    )
+    assert r.status_code == 200
+    assert ACCESS_COOKIE in r.cookies
+    assert REFRESH_COOKIE in r.cookies
+    assert CSRF_COOKIE in r.cookies
+    assert r.cookies[CSRF_COOKIE]
+
+
+async def test_login_persists_refresh_token_row(
+    client: AsyncClient, session: AsyncSession
+):
+    await _register_user(session)
+    await client.post(
+        "/api/auth/login",
+        json={"email": "cora@example.com", "password": "supersecret"},
+    )
+    rows = (await session.execute(select(RefreshToken))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].user_id == "u-cookie"
+    assert rows[0].revoked_at is None
+
+
+async def test_me_works_with_cookie_only(
+    client: AsyncClient, session: AsyncSession
+):
+    await _register_user(session)
+    await client.post(
+        "/api/auth/login",
+        json={"email": "cora@example.com", "password": "supersecret"},
+    )
+    r = await client.get("/api/auth/me")
+    assert r.status_code == 200
+    assert r.json()["email"] == "cora@example.com"
+
+
+async def test_refresh_rotates_cookies_and_revokes_old_jti(
+    client: AsyncClient, session: AsyncSession
+):
+    await _register_user(session)
+    await client.post(
+        "/api/auth/login",
+        json={"email": "cora@example.com", "password": "supersecret"},
+    )
+    old_refresh = client.cookies[REFRESH_COOKIE]
+
+    r = await client.post("/api/auth/refresh")
+    assert r.status_code == 204
+
+    new_refresh = client.cookies[REFRESH_COOKIE]
+    assert new_refresh != old_refresh
+
+    rows = (
+        await session.execute(
+            select(RefreshToken).order_by(RefreshToken.issued_at)
+        )
+    ).scalars().all()
+    assert len(rows) == 2
+    assert rows[0].revoked_at is not None
+    assert rows[1].revoked_at is None
+    assert rows[0].replaced_by_jti == rows[1].jti
+
+
+async def test_refresh_reuse_burns_family_and_bumps_token_version(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await _register_user(session)
+    starting_version = user.token_version
+    await client.post(
+        "/api/auth/login",
+        json={"email": "cora@example.com", "password": "supersecret"},
+    )
+    leaked_refresh = client.cookies[REFRESH_COOKIE]
+
+    # legitimate rotation
+    await client.post("/api/auth/refresh")
+
+    # attacker replays the leaked refresh on a fresh client
+    attacker = AsyncClient(
+        transport=client._transport, base_url=client.base_url
+    )
+    attacker.cookies.set(REFRESH_COOKIE, leaked_refresh)
+    r = await attacker.post("/api/auth/refresh")
+    await attacker.aclose()
+    assert r.status_code == 401
+
+    await session.refresh(user)
+    assert user.token_version == starting_version + 1
+    rows = (await session.execute(select(RefreshToken))).scalars().all()
+    assert all(row.revoked_at is not None for row in rows)
+
+
+async def test_refresh_with_expired_token_returns_401(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await _register_user(session)
+    settings = get_settings()
+    expired_jti = "expired-jti"
+    session.add(
+        RefreshToken(
+            jti=expired_jti,
+            user_id=user.user_id,
+            issued_at=datetime.now(UTC) - timedelta(days=30),
+            expires_at=datetime.now(UTC) - timedelta(days=1),
+        )
+    )
+    await session.commit()
+    expired_jwt = jwt.encode(
+        {
+            "sub": user.user_id,
+            "jti": expired_jti,
+            "exp": datetime.now(UTC) + timedelta(days=1),
+            "type": "refresh",
+        },
+        settings.secret_key,
+        algorithm=ALGORITHM,
+    )
+    client.cookies.set(REFRESH_COOKIE, expired_jwt)
+    r = await client.post("/api/auth/refresh")
+    assert r.status_code == 401
+
+
+async def test_refresh_without_cookie_returns_401(client: AsyncClient):
+    r = await client.post("/api/auth/refresh")
+    assert r.status_code == 401
+
+
+async def test_logout_clears_cookies_and_revokes_refresh(
+    client: AsyncClient, session: AsyncSession
+):
+    await _register_user(session)
+    await client.post(
+        "/api/auth/login",
+        json={"email": "cora@example.com", "password": "supersecret"},
+    )
+    r = await client.post("/api/auth/logout")
+    assert r.status_code == 204
+
+    # cleared cookies leave empty values in the jar
+    assert client.cookies.get(ACCESS_COOKIE, "") == ""
+    rows = (await session.execute(select(RefreshToken))).scalars().all()
+    assert all(row.revoked_at is not None for row in rows)

--- a/backend/tests/test_cookie_auth.py
+++ b/backend/tests/test_cookie_auth.py
@@ -163,6 +163,35 @@ async def test_refresh_without_cookie_returns_401(client: AsyncClient):
     assert r.status_code == 401
 
 
+async def test_state_changing_request_without_csrf_header_is_rejected(
+    client: AsyncClient, session: AsyncSession
+):
+    await _register_user(session)
+    await client.post(
+        "/api/auth/login",
+        json={"email": "cora@example.com", "password": "supersecret"},
+    )
+    # bypass the conftest event-hook that would echo the cookie
+    raw = await client.post(
+        "/api/auth/refresh",
+        headers={"X-CSRF-Token": "wrong-value"},
+    )
+    assert raw.status_code == 403
+    assert raw.json()["detail"] == "CSRF token mismatch"
+
+
+async def test_csrf_skipped_on_login_when_no_cookie(
+    client: AsyncClient, session: AsyncSession
+):
+    await _register_user(session)
+    # first login has no csrf cookie yet, dep must skip rather than reject
+    r = await client.post(
+        "/api/auth/login",
+        json={"email": "cora@example.com", "password": "supersecret"},
+    )
+    assert r.status_code == 200
+
+
 async def test_logout_clears_cookies_and_revokes_refresh(
     client: AsyncClient, session: AsyncSession
 ):

--- a/backend/tests/test_cookie_auth.py
+++ b/backend/tests/test_cookie_auth.py
@@ -30,9 +30,7 @@ async def _register_user(session: AsyncSession) -> User:
     return user
 
 
-async def test_login_sets_session_cookies(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_login_sets_session_cookies(client: AsyncClient, session: AsyncSession):
     await _register_user(session)
     r = await client.post(
         "/api/auth/login",
@@ -59,9 +57,7 @@ async def test_login_persists_refresh_token_row(
     assert rows[0].revoked_at is None
 
 
-async def test_me_works_with_cookie_only(
-    client: AsyncClient, session: AsyncSession
-):
+async def test_me_works_with_cookie_only(client: AsyncClient, session: AsyncSession):
     await _register_user(session)
     await client.post(
         "/api/auth/login",
@@ -89,10 +85,10 @@ async def test_refresh_rotates_cookies_and_revokes_old_jti(
     assert new_refresh != old_refresh
 
     rows = (
-        await session.execute(
-            select(RefreshToken).order_by(RefreshToken.issued_at)
-        )
-    ).scalars().all()
+        (await session.execute(select(RefreshToken).order_by(RefreshToken.issued_at)))
+        .scalars()
+        .all()
+    )
     assert len(rows) == 2
     assert rows[0].revoked_at is not None
     assert rows[1].revoked_at is None
@@ -114,9 +110,7 @@ async def test_refresh_reuse_burns_family_and_bumps_token_version(
     await client.post("/api/auth/refresh")
 
     # attacker replays the leaked refresh on a fresh client
-    attacker = AsyncClient(
-        transport=client._transport, base_url=client.base_url
-    )
+    attacker = AsyncClient(transport=client._transport, base_url=client.base_url)
     attacker.cookies.set(REFRESH_COOKIE, leaked_refresh)
     r = await attacker.post("/api/auth/refresh")
     await attacker.aclose()

--- a/backend/tests/test_gateways_api.py
+++ b/backend/tests/test_gateways_api.py
@@ -3,7 +3,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Dock, Gateway, Harbor, User, UserHarborRole
-from tests._helpers import make_auth_token as _auth_token
+from tests._helpers import auth_cookies as _creds
 
 
 @pytest_asyncio.fixture
@@ -39,7 +39,7 @@ async def test_list_gateways_rejects_boat_owner(
 ):
     r = await client.get(
         "/api/gateways",
-        headers={"Authorization": f"Bearer {_auth_token(boat_owner.user_id)}"},
+        cookies=_creds(boat_owner.user_id),
     )
     assert r.status_code == 403
 
@@ -49,7 +49,7 @@ async def test_list_gateways_excludes_unmanaged_harbor(
 ):
     r = await client.get(
         "/api/gateways",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 200
     body = r.json()
@@ -67,7 +67,7 @@ async def test_list_gateways_includes_extra_managed_harbor(
     await session.commit()
     r = await client.get(
         "/api/gateways",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 200
     assert [g["gateway_id"] for g in r.json()] == ["gw-a", "gw-b", "gw-c"]
@@ -78,7 +78,7 @@ async def test_list_gateways_unmanaged_harbor_filter_returns_empty(
 ):
     r = await client.get(
         "/api/gateways?harbor_id=h2",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 200
     assert r.json() == []
@@ -89,7 +89,7 @@ async def test_list_gateways_filters_by_dock(
 ):
     r = await client.get(
         "/api/gateways?dock_id=d2",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 200
     assert [g["gateway_id"] for g in r.json()] == ["gw-b"]
@@ -100,7 +100,7 @@ async def test_list_gateways_filters_by_status_within_scope(
 ):
     r = await client.get(
         "/api/gateways?status=online",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 200
     # gw-c is online but in h2 so it stays excluded
@@ -112,6 +112,6 @@ async def test_list_gateways_rejects_bad_status(
 ):
     r = await client.get(
         "/api/gateways?status=bogus",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 422

--- a/backend/tests/test_harbors_api.py
+++ b/backend/tests/test_harbors_api.py
@@ -3,7 +3,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Harbor, User
-from tests._helpers import make_auth_token as _auth_token
+from tests._helpers import auth_cookies as _creds
 
 
 @pytest_asyncio.fixture
@@ -25,7 +25,7 @@ async def test_list_harbors_returns_all_for_boat_owner(
 ):
     r = await client.get(
         "/api/harbors",
-        headers={"Authorization": f"Bearer {_auth_token(boat_owner.user_id)}"},
+        cookies=_creds(boat_owner.user_id),
     )
     assert r.status_code == 200
     body = r.json()
@@ -39,7 +39,7 @@ async def test_list_harbors_returns_all_for_harbormaster(
 ):
     r = await client.get(
         "/api/harbors",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 200
     assert [h["harbor_id"] for h in r.json()] == ["h1", "h2"]

--- a/backend/tests/test_nodes_api.py
+++ b/backend/tests/test_nodes_api.py
@@ -5,7 +5,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Berth, Dock, Event, Gateway, Harbor, Node, User
-from tests._helpers import make_auth_token as _auth_token
+from tests._helpers import auth_cookies as _creds
 
 
 def _node(node_id: str, berth_id: str, gateway_id: str, *, user_id: str, **over):
@@ -104,7 +104,7 @@ async def test_list_nodes_rejects_boat_owner(
 ):
     r = await client.get(
         "/api/nodes",
-        headers={"Authorization": f"Bearer {_auth_token(boat_owner.user_id)}"},
+        cookies=_creds(boat_owner.user_id),
     )
     assert r.status_code == 403
 
@@ -114,7 +114,7 @@ async def test_list_nodes_returns_all_with_derived_health(
 ):
     r = await client.get(
         "/api/nodes",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 200
     by_id = {row["node_id"]: row for row in r.json()}
@@ -133,7 +133,7 @@ async def test_list_nodes_filters_by_health(
 ):
     r = await client.get(
         "/api/nodes?health=offline",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 200
     ids = sorted(row["node_id"] for row in r.json())
@@ -164,7 +164,7 @@ async def test_list_nodes_filters_by_gateway(
     await session.commit()
     r = await client.get(
         "/api/nodes?gateway_id=gw2",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert [row["node_id"] for row in r.json()] == ["n-other"]
 
@@ -197,7 +197,7 @@ async def test_get_node_returns_detail_with_events(
 
     r = await client.get(
         "/api/nodes/n-online",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 200
     body = r.json()
@@ -209,7 +209,7 @@ async def test_get_node_returns_detail_with_events(
 async def test_get_node_404_unknown(client: AsyncClient, harbor_master: User, fleet):
     r = await client.get(
         "/api/nodes/nope",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 404
 
@@ -219,7 +219,7 @@ async def test_decommission_node_flips_status(
 ):
     r = await client.post(
         "/api/nodes/n-online/decommission",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 200
     assert r.json()["health"] == "decommissioned"
@@ -231,9 +231,9 @@ async def test_decommission_node_flips_status(
 
 
 async def test_decommission_idempotent(client: AsyncClient, harbor_master: User, fleet):
-    headers = {"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"}
-    first = await client.post("/api/nodes/n-decom/decommission", headers=headers)
-    second = await client.post("/api/nodes/n-decom/decommission", headers=headers)
+    creds = _creds(harbor_master.user_id)
+    first = await client.post("/api/nodes/n-decom/decommission", cookies=creds)
+    second = await client.post("/api/nodes/n-decom/decommission", cookies=creds)
     assert first.status_code == 200
     assert second.status_code == 200
     assert second.json()["health"] == "decommissioned"
@@ -245,10 +245,10 @@ async def test_decommission_publishes_mqtt_once(
     fleet,
     published_decommission_reqs: list[dict],
 ):
-    headers = {"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"}
-    await client.post("/api/nodes/n-online/decommission", headers=headers)
+    creds = _creds(harbor_master.user_id)
+    await client.post("/api/nodes/n-online/decommission", cookies=creds)
     # second call is a no-op, must not republish
-    await client.post("/api/nodes/n-online/decommission", headers=headers)
+    await client.post("/api/nodes/n-online/decommission", cookies=creds)
 
     assert len(published_decommission_reqs) == 1
     call = published_decommission_reqs[0]
@@ -267,7 +267,7 @@ async def test_decommission_already_decommissioned_does_not_publish(
 ):
     r = await client.post(
         "/api/nodes/n-decom/decommission",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 200
     assert published_decommission_reqs == []
@@ -278,7 +278,7 @@ async def test_decommission_404_unknown(
 ):
     r = await client.post(
         "/api/nodes/nope/decommission",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 404
 
@@ -288,7 +288,7 @@ async def test_decommission_rejects_boat_owner(
 ):
     r = await client.post(
         "/api/nodes/n-online/decommission",
-        headers={"Authorization": f"Bearer {_auth_token(boat_owner.user_id)}"},
+        cookies=_creds(boat_owner.user_id),
     )
     assert r.status_code == 403
 
@@ -326,7 +326,7 @@ async def test_list_nodes_excludes_unmanaged_harbor(
 ):
     r = await client.get(
         "/api/nodes",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 200
     ids = [n["node_id"] for n in r.json()]
@@ -338,7 +338,7 @@ async def test_get_foreign_node_returns_403(
 ):
     r = await client.get(
         "/api/nodes/n-foreign",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 403
 
@@ -351,7 +351,7 @@ async def test_decommission_foreign_node_returns_403(
 ):
     r = await client.post(
         "/api/nodes/n-foreign/decommission",
-        headers={"Authorization": f"Bearer {_auth_token(harbor_master.user_id)}"},
+        cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 403
     assert published_decommission_reqs == []

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -216,17 +216,20 @@ async def test_register_rejects_overlong_password(client: AsyncClient):
     assert r.status_code == 422
 
 
-async def test_login_returns_usable_token(client: AsyncClient, test_user: User):
+async def test_login_returns_user_and_session_works(
+    client: AsyncClient, test_user: User
+):
     r = await client.post(
         "/api/auth/login",
         json={"email": test_user.email, "password": "secretpassword"},
     )
     assert r.status_code == 200
     body = r.json()
-    assert body["token_type"] == "bearer"
-    token = body["access_token"]
+    assert body["user_id"] == test_user.user_id
+    assert body["email"] == test_user.email
+    assert "password_hash" not in body
 
-    me = await client.get("/api/users/me", cookies=_creds(token))
+    me = await client.get("/api/users/me")
     assert me.status_code == 200
     assert me.json()["user_id"] == test_user.user_id
 

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -14,6 +14,10 @@ from tests._helpers import (
 )
 
 
+def _creds(token: str) -> dict[str, str]:
+    return {"dockpulse_access": token, "dockpulse_csrf": "test-csrf"}
+
+
 @pytest_asyncio.fixture
 async def test_user(session: AsyncSession) -> User:
     user = User(
@@ -33,7 +37,7 @@ async def test_user(session: AsyncSession) -> User:
 
 async def test_get_me_returns_profile(client: AsyncClient, test_user: User):
     token = make_token(test_user.user_id)
-    r = await client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
+    r = await client.get("/api/users/me", cookies=_creds(token))
     assert r.status_code == 200
     data = r.json()
     assert data["user_id"] == "u1"
@@ -55,7 +59,7 @@ async def test_patch_me_updates_fields(client: AsyncClient, test_user: User):
     r = await client.patch(
         "/api/users/me",
         json={"firstname": "Britta", "boat_club": "GKSS"},
-        headers={"Authorization": f"Bearer {token}"},
+        cookies=_creds(token),
     )
     assert r.status_code == 200
     data = r.json()
@@ -71,7 +75,7 @@ async def test_patch_me_updates_password(
     r = await client.patch(
         "/api/users/me",
         json={"password": "newpassword12", "current_password": "secretpassword"},
-        headers={"Authorization": f"Bearer {token}"},
+        cookies=_creds(token),
     )
     assert r.status_code == 200
     await session.refresh(test_user)
@@ -85,7 +89,7 @@ async def test_patch_me_password_requires_current_password(
     r = await client.patch(
         "/api/users/me",
         json={"password": "newpassword12"},
-        headers={"Authorization": f"Bearer {token}"},
+        cookies=_creds(token),
     )
     assert r.status_code == 422
 
@@ -98,7 +102,7 @@ async def test_patch_me_password_rejects_wrong_current_password(
     r = await client.patch(
         "/api/users/me",
         json={"password": "newpassword12", "current_password": "wrongpassword"},
-        headers={"Authorization": f"Bearer {token}"},
+        cookies=_creds(token),
     )
     assert r.status_code == 401
     await session.refresh(test_user)
@@ -124,7 +128,7 @@ async def test_patch_me_email_conflict(
     r = await client.patch(
         "/api/users/me",
         json={"email": "bo@example.com"},
-        headers={"Authorization": f"Bearer {token}"},
+        cookies=_creds(token),
     )
     assert r.status_code == 409
 
@@ -222,7 +226,7 @@ async def test_login_returns_usable_token(client: AsyncClient, test_user: User):
     assert body["token_type"] == "bearer"
     token = body["access_token"]
 
-    me = await client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
+    me = await client.get("/api/users/me", cookies=_creds(token))
     assert me.status_code == 200
     assert me.json()["user_id"] == test_user.user_id
 
@@ -246,15 +250,15 @@ async def test_login_unknown_email_returns_401(client: AsyncClient):
 async def test_logout_returns_204(client: AsyncClient, test_user: User):
     token = make_token(test_user.user_id)
     r = await client.post(
-        "/api/auth/logout", headers={"Authorization": f"Bearer {token}"}
+        "/api/auth/logout", cookies=_creds(token)
     )
     assert r.status_code == 204
 
 
 async def test_logout_invalidates_token(client: AsyncClient, test_user: User):
     token = make_token(test_user.user_id)
-    await client.post("/api/auth/logout", headers={"Authorization": f"Bearer {token}"})
-    r = await client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
+    await client.post("/api/auth/logout", cookies=_creds(token))
+    r = await client.get("/api/users/me", cookies=_creds(token))
     assert r.status_code == 401
 
 
@@ -268,7 +272,7 @@ async def test_get_notification_prefs_returns_defaults(
 ):
     token = make_token(test_user.user_id)
     r = await client.get(
-        "/api/users/me/notification-prefs", headers={"Authorization": f"Bearer {token}"}
+        "/api/users/me/notification-prefs", cookies=_creds(token)
     )
     assert r.status_code == 200
     data = r.json()
@@ -283,7 +287,7 @@ async def test_patch_notification_prefs_updates_fields(
     r = await client.patch(
         "/api/users/me/notification-prefs",
         json={"notify_arrival": False},
-        headers={"Authorization": f"Bearer {token}"},
+        cookies=_creds(token),
     )
     assert r.status_code == 200
     data = r.json()

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -252,9 +252,7 @@ async def test_login_unknown_email_returns_401(client: AsyncClient):
 
 async def test_logout_returns_204(client: AsyncClient, test_user: User):
     token = make_token(test_user.user_id)
-    r = await client.post(
-        "/api/auth/logout", cookies=_creds(token)
-    )
+    r = await client.post("/api/auth/logout", cookies=_creds(token))
     assert r.status_code == 204
 
 
@@ -274,9 +272,7 @@ async def test_get_notification_prefs_returns_defaults(
     client: AsyncClient, test_user: User
 ):
     token = make_token(test_user.user_id)
-    r = await client.get(
-        "/api/users/me/notification-prefs", cookies=_creds(token)
-    )
+    r = await client.get("/api/users/me/notification-prefs", cookies=_creds(token))
     assert r.status_code == 200
     data = r.json()
     assert data["notify_arrival"] is True

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -700,20 +700,6 @@ components:
           title: Notify Departure
       title: NotificationPrefsPatch
       type: object
-    TokenOut:
-      properties:
-        access_token:
-          title: Access Token
-          type: string
-        token_type:
-          const: bearer
-          default: bearer
-          title: Token Type
-          type: string
-      required:
-      - access_token
-      title: TokenOut
-      type: object
     UserCreate:
       properties:
         boat_club:
@@ -938,9 +924,6 @@ components:
       in: cookie
       name: dockpulse_access
       type: apiKey
-    HTTPBearer:
-      scheme: bearer
-      type: http
 info:
   description: 'REST API for the DockPulse harbor berth availability system.
 
@@ -981,7 +964,6 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Create an adoption request for a scanned node
       tags:
@@ -1010,7 +992,6 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Get an adoption request by id
       tags:
@@ -1045,7 +1026,6 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Subscribe to adoption progress via Server-Sent Events
       tags:
@@ -1064,7 +1044,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenOut'
+                $ref: '#/components/schemas/UserOut'
           description: Successful Response
         '422':
           content:
@@ -1072,7 +1052,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
-      summary: Log in and obtain an access token
+      summary: Log in and set session cookies
       tags:
       - auth
   /api/auth/logout:
@@ -1082,7 +1062,6 @@ paths:
         '204':
           description: Successful Response
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Invalidate all tokens for the current user
       tags:
@@ -1098,7 +1077,6 @@ paths:
                 $ref: '#/components/schemas/UserOut'
           description: Successful Response
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Return the authenticated user
       tags:
@@ -1343,7 +1321,6 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Remove a berth assignment
       tags:
@@ -1377,7 +1354,6 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Assign a berth to a user
       tags:
@@ -1440,7 +1416,6 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Create an availability window for a berth
       tags:
@@ -1471,7 +1446,6 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Delete an availability window
       tags:
@@ -1512,7 +1486,6 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: List events for a berth
       tags:
@@ -1628,7 +1601,6 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: List gateways visible to the harbormaster
       tags:
@@ -1647,7 +1619,6 @@ paths:
                 type: array
           description: Successful Response
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: List all harbors
       tags:
@@ -1727,7 +1698,6 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: List nodes with derived health
       tags:
@@ -1765,7 +1735,6 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Get node detail with recent telemetry
       tags:
@@ -1794,7 +1763,6 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Mark node as decommissioned
       tags:
@@ -1806,7 +1774,6 @@ paths:
         '204':
           description: Successful Response
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Delete the current boat-owner account
       tags:
@@ -1821,7 +1788,6 @@ paths:
                 $ref: '#/components/schemas/UserOut'
           description: Successful Response
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Get current user profile
       tags:
@@ -1848,7 +1814,6 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Update current user profile
       tags:
@@ -1864,7 +1829,6 @@ paths:
                 $ref: '#/components/schemas/NotificationPrefsOut'
           description: Successful Response
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Get notification preferences for the current user
       tags:
@@ -1891,7 +1855,6 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       security:
-      - HTTPBearer: []
       - APIKeyCookie: []
       summary: Update notification preferences for the current user
       tags:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -934,6 +934,10 @@ components:
       title: ValidationError
       type: object
   securitySchemes:
+    APIKeyCookie:
+      in: cookie
+      name: dockpulse_access
+      type: apiKey
     HTTPBearer:
       scheme: bearer
       type: http
@@ -978,6 +982,7 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: Create an adoption request for a scanned node
       tags:
       - adoptions
@@ -1006,6 +1011,7 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: Get an adoption request by id
       tags:
       - adoptions
@@ -1040,6 +1046,7 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: Subscribe to adoption progress via Server-Sent Events
       tags:
       - adoptions
@@ -1076,7 +1083,48 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: Invalidate all tokens for the current user
+      tags:
+      - auth
+  /api/auth/me:
+    get:
+      operationId: getCurrentUser
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserOut'
+          description: Successful Response
+      security:
+      - HTTPBearer: []
+      - APIKeyCookie: []
+      summary: Return the authenticated user
+      tags:
+      - auth
+  /api/auth/refresh:
+    post:
+      operationId: refreshSession
+      parameters:
+      - in: cookie
+        name: dockpulse_refresh
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dockpulse Refresh
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Rotate the refresh cookie and reissue the access cookie
       tags:
       - auth
   /api/auth/register:
@@ -1296,6 +1344,7 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: Remove a berth assignment
       tags:
       - berths
@@ -1329,6 +1378,7 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: Assign a berth to a user
       tags:
       - berths
@@ -1391,6 +1441,7 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: Create an availability window for a berth
       tags:
       - berths
@@ -1421,6 +1472,7 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: Delete an availability window
       tags:
       - berths
@@ -1461,6 +1513,7 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: List events for a berth
       tags:
       - berths
@@ -1576,6 +1629,7 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: List gateways visible to the harbormaster
       tags:
       - gateways
@@ -1594,6 +1648,7 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: List all harbors
       tags:
       - harbors
@@ -1673,6 +1728,7 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: List nodes with derived health
       tags:
       - nodes
@@ -1710,6 +1766,7 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: Get node detail with recent telemetry
       tags:
       - nodes
@@ -1738,6 +1795,7 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: Mark node as decommissioned
       tags:
       - nodes
@@ -1749,6 +1807,7 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: Delete the current boat-owner account
       tags:
       - users
@@ -1763,6 +1822,7 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: Get current user profile
       tags:
       - users
@@ -1789,6 +1849,7 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: Update current user profile
       tags:
       - users
@@ -1804,6 +1865,7 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: Get notification preferences for the current user
       tags:
       - users
@@ -1830,6 +1892,7 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
+      - APIKeyCookie: []
       summary: Update notification preferences for the current user
       tags:
       - users

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from "react";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { MainLayout } from "./components/layout/MainLayout";
+import { AuthProvider } from "./lib/auth-context";
 
 const Dashboard = lazy(() =>
   import("./pages/Dashboard").then((m) => ({ default: m.Dashboard })),
@@ -13,29 +14,31 @@ const Settings = lazy(() =>
 export function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Navigate to="/saltsjobaden" replace />} />
+      <AuthProvider>
+        <Routes>
+          <Route path="/" element={<Navigate to="/saltsjobaden" replace />} />
 
-        <Route path="/:marinaSlug" element={<MainLayout />}>
-          <Route
-            index
-            element={
-              <Suspense fallback={<div className="h-full w-full" />}>
-                <Dashboard />
-              </Suspense>
-            }
-          />
+          <Route path="/:marinaSlug" element={<MainLayout />}>
+            <Route
+              index
+              element={
+                <Suspense fallback={<div className="h-full w-full" />}>
+                  <Dashboard />
+                </Suspense>
+              }
+            />
 
-          <Route
-            path="settings"
-            element={
-              <Suspense fallback={<div className="h-full w-full" />}>
-                <Settings />
-              </Suspense>
-            }
-          />
-        </Route>
-      </Routes>
+            <Route
+              path="settings"
+              element={
+                <Suspense fallback={<div className="h-full w-full" />}>
+                  <Settings />
+                </Suspense>
+              }
+            />
+          </Route>
+        </Routes>
+      </AuthProvider>
     </BrowserRouter>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from "react";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { MainLayout } from "./components/layout/MainLayout";
+import { RequireAuth } from "./components/RequireAuth";
 import { AuthProvider } from "./lib/auth-context";
 
 const Dashboard = lazy(() =>
@@ -31,9 +32,11 @@ export function App() {
             <Route
               path="settings"
               element={
-                <Suspense fallback={<div className="h-full w-full" />}>
-                  <Settings />
-                </Suspense>
+                <RequireAuth>
+                  <Suspense fallback={<div className="h-full w-full" />}>
+                    <Settings />
+                  </Suspense>
+                </RequireAuth>
               }
             />
           </Route>

--- a/frontend/src/components/ActivityLogPanel.tsx
+++ b/frontend/src/components/ActivityLogPanel.tsx
@@ -2,6 +2,7 @@ import { Activity, Clock, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useOutletContext } from "react-router-dom";
 import type { components } from "../api-types";
+import { apiFetch } from "../lib/api";
 import { cn } from "../lib/utils";
 import type { AuthOutletContext } from "./layout/MainLayout";
 
@@ -34,7 +35,7 @@ export function ActivityLogPanel({
   isOpen,
   onCloseCB,
 }: ActivityLogPanelProps) {
-  const { user, token } = useOutletContext<AuthOutletContext>();
+  const { user } = useOutletContext<AuthOutletContext>();
   const isLoaded = !!user && user.role !== undefined;
   const isFirstLoad = useRef(true);
   const historyFetchedRef = useRef(false);
@@ -87,9 +88,8 @@ export function ActivityLogPanel({
       const results = await Promise.all(
         sampleBerths.map(async (berth) => {
           try {
-            const res = await fetch(
+            const res = await apiFetch(
               `/api/berths/${berth.berth_id}/events?limit=5`,
-              { headers: { Authorization: `Bearer ${token}` } },
             );
             if (!res.ok) return [] as ActivityEvent[];
             const data = await res.json();
@@ -132,7 +132,7 @@ export function ActivityLogPanel({
     }
 
     fetchInitialHistory();
-  }, [isLoaded, berths, token]);
+  }, [isLoaded, berths]);
 
   // diff live berth stream into synthetic events
   useEffect(() => {

--- a/frontend/src/components/BerthDetailPanel.tsx
+++ b/frontend/src/components/BerthDetailPanel.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from "react";
 import { Link, useOutletContext, useParams } from "react-router-dom";
 import type { components } from "../api-types";
 import { useBerthDetail } from "../hooks/useBerthDetail";
+import { apiFetch } from "../lib/api";
 import { cn } from "../lib/utils";
 import type { AuthOutletContext } from "./layout/MainLayout";
 
@@ -28,7 +29,7 @@ export function BerthDetailPanel({
   berth: liveBerth,
 }: BerthDetailPanelProps) {
   const { marinaSlug } = useParams<{ marinaSlug: string }>();
-  const { user: currentUser, token } = useOutletContext<AuthOutletContext>();
+  const { user: currentUser } = useOutletContext<AuthOutletContext>();
   const isHarborMaster = currentUser?.role === "harbormaster";
 
   const { berth: fetchedBerth, isLoading, error } = useBerthDetail(berthId);
@@ -47,8 +48,7 @@ export function BerthDetailPanel({
       setIsEventsLoading(true);
 
       try {
-        const res = await fetch(`/api/berths/${berthId}/events`, {
-          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        const res = await apiFetch(`/api/berths/${berthId}/events`, {
           signal: controller.signal,
         });
 
@@ -68,7 +68,7 @@ export function BerthDetailPanel({
     fetchEvents();
 
     return () => controller.abort();
-  }, [berthId, isHarborMaster, token]);
+  }, [berthId, isHarborMaster]);
 
   function handleClose(event?: React.MouseEvent<HTMLButtonElement>) {
     event?.stopPropagation();

--- a/frontend/src/components/NotificationSettings.tsx
+++ b/frontend/src/components/NotificationSettings.tsx
@@ -1,5 +1,6 @@
 import { Bell, Check } from "lucide-react";
 import { useEffect, useState } from "react";
+import { apiFetch } from "../lib/api";
 import { cn } from "../lib/utils";
 
 interface NotificationPrefs {
@@ -7,11 +8,7 @@ interface NotificationPrefs {
   notify_departure: boolean;
 }
 
-interface NotificationSettingsProps {
-  token: string;
-}
-
-export function NotificationSettings({ token }: NotificationSettingsProps) {
+export function NotificationSettings() {
   const [prefs, setPrefs] = useState<NotificationPrefs | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -23,9 +20,7 @@ export function NotificationSettings({ token }: NotificationSettingsProps) {
   useEffect(() => {
     async function fetchPrefs() {
       try {
-        const res = await fetch("/api/users/me/notification-prefs", {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const res = await apiFetch("/api/users/me/notification-prefs");
         if (res.ok) {
           const data = await res.json();
           setPrefs(data);
@@ -39,7 +34,7 @@ export function NotificationSettings({ token }: NotificationSettingsProps) {
       }
     }
     fetchPrefs();
-  }, [token]);
+  }, []);
 
   async function togglePref(key: keyof NotificationPrefs) {
     if (!prefs || isSaving) return;
@@ -49,12 +44,9 @@ export function NotificationSettings({ token }: NotificationSettingsProps) {
     setMessage(null);
 
     try {
-      const res = await fetch("/api/users/me/notification-prefs", {
+      const res = await apiFetch("/api/users/me/notification-prefs", {
         method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(nextPrefs),
       });
 

--- a/frontend/src/components/RequireAuth.tsx
+++ b/frontend/src/components/RequireAuth.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+import { Navigate, useParams } from "react-router-dom";
+import { useAuth } from "../lib/auth-context";
+
+export function RequireAuth({ children }: { children: ReactNode }) {
+  const { user, loading } = useAuth();
+  const { marinaSlug } = useParams<{ marinaSlug: string }>();
+
+  // first paint waits for /me to resolve so we don't flash a redirect before state lands
+  if (loading) {
+    return <div className="h-full w-full" />;
+  }
+  if (!user) {
+    const target = marinaSlug ? `/${marinaSlug}?login=1` : "/?login=1";
+    return <Navigate to={target} replace />;
+  }
+  return <>{children}</>;
+}

--- a/frontend/src/components/layout/AuthDialog.tsx
+++ b/frontend/src/components/layout/AuthDialog.tsx
@@ -2,13 +2,14 @@ import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { Loader2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { apiFetch } from "../../lib/api";
+import { useAuth } from "../../lib/auth-context";
 import { cn } from "../../lib/utils";
 import { Button } from "../shared/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "../shared/ui/dialog";
 import { Input } from "../shared/ui/input";
 import { Label } from "../shared/ui/label";
 import { PasswordInput } from "../shared/ui/password-input";
-import type { AuthUser } from "./MainLayout";
 
 type AuthTab = "login" | "signup";
 
@@ -66,14 +67,10 @@ async function getErrorMessage(
 interface AuthDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onAuthSuccess: (accessToken: string, optimisticUser: AuthUser) => void;
 }
 
-export function AuthDialog({
-  open,
-  onOpenChange,
-  onAuthSuccess,
-}: AuthDialogProps) {
+export function AuthDialog({ open, onOpenChange }: AuthDialogProps) {
+  const { refresh } = useAuth();
   const [authTab, setAuthTab] = useState<AuthTab>("login");
   const [loginEmail, setLoginEmail] = useState("");
   const [loginPassword, setLoginPassword] = useState("");
@@ -116,23 +113,16 @@ export function AuthDialog({
   }
 
   async function authenticate(email: string, password: string) {
-    const tokenRes = await fetch("/api/auth/login", {
+    const res = await apiFetch("/api/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email, password }),
+      skipAuthRefresh: true,
     });
 
-    if (!tokenRes.ok) {
-      throw new Error(
-        await getErrorMessage(tokenRes, "Wrong email or password."),
-      );
+    if (!res.ok) {
+      throw new Error(await getErrorMessage(res, "Wrong email or password."));
     }
-
-    const { access_token: accessToken } = await tokenRes.json();
-    if (!accessToken) {
-      throw new Error("Login succeeded, but no access token was returned.");
-    }
-    return accessToken as string;
   }
 
   async function handleLogin(e?: React.FormEvent) {
@@ -144,8 +134,9 @@ export function AuthDialog({
     const email = loginEmail.trim();
 
     try {
-      const accessToken = await authenticate(email, loginPassword);
-      onAuthSuccess(accessToken, { email });
+      await authenticate(email, loginPassword);
+      await refresh();
+      onOpenChange(false);
       resetForms();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not log in.");
@@ -169,10 +160,11 @@ export function AuthDialog({
     };
 
     try {
-      const res = await fetch("/api/auth/register", {
+      const res = await apiFetch("/api/auth/register", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
+        skipAuthRefresh: true,
       });
 
       if (!res.ok) {
@@ -181,16 +173,10 @@ export function AuthDialog({
         );
       }
 
-      // server accepted creds → reuse them to drop user into a logged-in state
-      const accessToken = await authenticate(
-        payload.email,
-        signupForm.password,
-      );
-      onAuthSuccess(accessToken, {
-        email: payload.email,
-        firstname: payload.firstname,
-        lastname: payload.lastname,
-      });
+      // server accepted creds, reuse them to drop user into a logged-in state
+      await authenticate(payload.email, signupForm.password);
+      await refresh();
+      onOpenChange(false);
       resetForms();
       toast.success(`Welcome, ${payload.firstname}!`);
     } catch (err) {

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { Outlet, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Outlet, useNavigate, useSearchParams } from "react-router-dom";
 import { Toaster } from "sonner";
 import { type AuthUser, useAuth } from "../../lib/auth-context";
 import { cn } from "../../lib/utils";
@@ -113,6 +113,17 @@ function MainLayoutContent({
 function MainLayout() {
   const [isLoginOpen, setIsLoginOpen] = useState(false);
   const { user } = useAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // route guard redirect lands here with ?login=1, open the dialog and consume the flag
+  useEffect(() => {
+    if (searchParams.get("login") === "1") {
+      setIsLoginOpen(true);
+      const next = new URLSearchParams(searchParams);
+      next.delete("login");
+      setSearchParams(next, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
 
   return (
     <DashboardLayoutProvider userRole={user?.role}>

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Outlet, useNavigate } from "react-router-dom";
-import { Toaster, toast } from "sonner";
+import { Toaster } from "sonner";
+import { type AuthUser, useAuth } from "../../lib/auth-context";
 import { cn } from "../../lib/utils";
 import { AuthDialog } from "./AuthDialog";
 import {
@@ -11,44 +12,25 @@ import { Footer } from "./Footer";
 import { Header } from "./Header";
 import { SideMenu } from "./SideMenu";
 
-export type AuthUser = {
-  user_id?: string;
-  email: string;
-  firstname?: string;
-  lastname?: string;
-  phone?: string;
-  boat_club?: string;
-  role?: string;
-  assigned_berth_id?: string | null;
-};
+export type { AuthUser } from "../../lib/auth-context";
 
 export type AuthOutletContext = {
   user: AuthUser | null;
-  setUser: React.Dispatch<React.SetStateAction<AuthUser | null>>;
-  token: string | null;
-  setToken: React.Dispatch<React.SetStateAction<string | null>>;
   isLoginOpen: boolean;
   setIsLoginOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 interface MainLayoutContentProps {
-  user: AuthUser | null;
-  setUser: React.Dispatch<React.SetStateAction<AuthUser | null>>;
-  token: string | null;
-  setToken: React.Dispatch<React.SetStateAction<string | null>>;
   isLoginOpen: boolean;
   setIsLoginOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 function MainLayoutContent({
-  user,
-  setUser,
-  token,
-  setToken,
   isLoginOpen,
   setIsLoginOpen,
 }: MainLayoutContentProps) {
   const navigate = useNavigate();
+  const { user, logout } = useAuth();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
 
   const {
@@ -63,46 +45,13 @@ function MainLayoutContent({
 
   const isHarborMaster = user?.role === "harbormaster";
 
-  function handleAuthSuccess(accessToken: string, optimisticUser: AuthUser) {
-    localStorage.setItem("token", accessToken);
-    setToken(accessToken);
-    // optimistic fill so avatar isn't blank during /me round-trip
-    setUser((prev) => prev ?? optimisticUser);
-    setIsLoginOpen(false);
-  }
-
   async function handleLogout() {
     if (isLoggingOut) return;
-
-    const logoutToken = token;
-
     setIsLoggingOut(true);
-    localStorage.removeItem("token");
-    setToken(null);
-    setUser(null);
-    setIsLoginOpen(false);
-    navigate("/", { replace: true });
-
-    if (!logoutToken) {
-      setIsLoggingOut(false);
-      return;
-    }
-
     try {
-      const res = await fetch("/api/auth/logout", {
-        method: "POST",
-        headers: { Authorization: `Bearer ${logoutToken}` },
-      });
-      // local session already gone, but warn user the server still holds the token
-      if (!res.ok) {
-        toast.warning(
-          "Logged out locally, but the server didn't confirm. Token will expire on its own.",
-        );
-      }
-    } catch {
-      toast.warning(
-        "Logged out locally, but couldn't reach the server. Token will expire on its own.",
-      );
+      await logout();
+      setIsLoginOpen(false);
+      navigate("/", { replace: true });
     } finally {
       setIsLoggingOut(false);
     }
@@ -116,7 +65,7 @@ function MainLayoutContent({
   return (
     <div className="bg-transparent duration-1000 font-body min-h-screen overflow-x-hidden relative transition-colors w-screen">
       <Header
-        isLoggedIn={Boolean(token)}
+        isLoggedIn={Boolean(user)}
         isLoggingOut={isLoggingOut}
         userInitials={userInitials}
         onLoginClickCB={() => setIsLoginOpen(true)}
@@ -144,9 +93,6 @@ function MainLayoutContent({
           context={
             {
               user,
-              setUser,
-              token,
-              setToken,
               isLoginOpen,
               setIsLoginOpen,
             } satisfies AuthOutletContext
@@ -154,11 +100,7 @@ function MainLayoutContent({
         />
       </main>
 
-      <AuthDialog
-        open={isLoginOpen}
-        onOpenChange={setIsLoginOpen}
-        onAuthSuccess={handleAuthSuccess}
-      />
+      <AuthDialog open={isLoginOpen} onOpenChange={setIsLoginOpen} />
 
       {/* mobile harbormaster has bottom dock, footer would clash */}
       {!isDesktop && isHarborMaster ? null : <Footer />}
@@ -170,59 +112,11 @@ function MainLayoutContent({
 
 function MainLayout() {
   const [isLoginOpen, setIsLoginOpen] = useState(false);
-  const [user, setUser] = useState<AuthUser | null>(null);
-
-  // localStorage simpler than httpOnly cookies but XSS-readable; revisit
-  const [token, setToken] = useState<string | null>(
-    localStorage.getItem("token"),
-  );
-
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (!token) {
-      setUser(null);
-      return;
-    }
-
-    // abort stale /me requests if token changes again before this resolves
-    const ac = new AbortController();
-
-    fetch("/api/users/me", {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: ac.signal,
-    })
-      .then((res) => {
-        // only 401 clears session, transient errors leave token alone
-        if (res.status === 401) {
-          localStorage.removeItem("token");
-          setToken(null);
-          setUser(null);
-          setIsLoginOpen(true);
-          navigate("/", { replace: true });
-          return null;
-        }
-        if (!res.ok) throw new Error(`/me ${res.status}`);
-        return res.json();
-      })
-      .then((data) => {
-        if (data) setUser(data);
-      })
-      .catch((err) => {
-        if (err.name === "AbortError") return;
-        console.error("failed to load user", err);
-      });
-
-    return () => ac.abort();
-  }, [token, navigate]);
+  const { user } = useAuth();
 
   return (
     <DashboardLayoutProvider userRole={user?.role}>
       <MainLayoutContent
-        user={user}
-        setUser={setUser}
-        token={token}
-        setToken={setToken}
         isLoginOpen={isLoginOpen}
         setIsLoginOpen={setIsLoginOpen}
       />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,126 @@
+// double-submit csrf, server compares cookie to header on every non-safe method
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+const CSRF_COOKIE = "dockpulse_csrf";
+const CSRF_HEADER = "X-CSRF-Token";
+
+const LOGOUT_EVENT = "dockpulse:logged-out";
+
+function readCsrfCookie(): string | null {
+  for (const chunk of document.cookie.split(";")) {
+    const [name, ...rest] = chunk.trim().split("=");
+    if (name === CSRF_COOKIE) return rest.join("=") || null;
+  }
+  return null;
+}
+
+function withCsrfHeader(init: RequestInit | undefined): RequestInit {
+  const method = (init?.method ?? "GET").toUpperCase();
+  if (SAFE_METHODS.has(method)) return init ?? {};
+  const csrf = readCsrfCookie();
+  if (!csrf) return init ?? {};
+  const headers = new Headers(init?.headers);
+  if (!headers.has(CSRF_HEADER)) headers.set(CSRF_HEADER, csrf);
+  return { ...init, headers };
+}
+
+let refreshInFlight: Promise<boolean> | null = null;
+
+async function performRefresh(): Promise<boolean> {
+  // shared promise so concurrent 401s only fire one /refresh
+  if (refreshInFlight) return refreshInFlight;
+  refreshInFlight = (async () => {
+    try {
+      const res = await fetch("/api/auth/refresh", {
+        method: "POST",
+        credentials: "include",
+        headers: (() => {
+          const csrf = readCsrfCookie();
+          return csrf ? { [CSRF_HEADER]: csrf } : {};
+        })(),
+      });
+      return res.ok;
+    } catch {
+      return false;
+    } finally {
+      refreshInFlight = null;
+    }
+  })();
+  return refreshInFlight;
+}
+
+function dispatchLogout() {
+  window.dispatchEvent(new CustomEvent(LOGOUT_EVENT));
+}
+
+export function onLoggedOut(handler: () => void): () => void {
+  const wrapped = () => handler();
+  window.addEventListener(LOGOUT_EVENT, wrapped);
+  return () => window.removeEventListener(LOGOUT_EVENT, wrapped);
+}
+
+export interface ApiFetchOptions extends RequestInit {
+  // skip the auto-refresh-on-401 dance, used by /refresh and /login themselves
+  skipAuthRefresh?: boolean;
+}
+
+export async function apiFetch(
+  input: RequestInfo | URL,
+  init?: ApiFetchOptions,
+): Promise<Response> {
+  const { skipAuthRefresh, ...rest } = init ?? {};
+  const send = () =>
+    fetch(input, {
+      credentials: "include",
+      ...withCsrfHeader(rest),
+    });
+  let res = await send();
+  if (res.status !== 401 || skipAuthRefresh) return res;
+
+  const refreshed = await performRefresh();
+  if (!refreshed) {
+    dispatchLogout();
+    return res;
+  }
+  res = await send();
+  if (res.status === 401) dispatchLogout();
+  return res;
+}
+
+export async function apiJson<T>(
+  input: RequestInfo | URL,
+  init?: ApiFetchOptions,
+): Promise<T> {
+  const res = await apiFetch(input, init);
+  if (!res.ok) {
+    throw new ApiError(res.status, await readErrorMessage(res));
+  }
+  return (await res.json()) as T;
+}
+
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+async function readErrorMessage(res: Response): Promise<string> {
+  try {
+    const data = await res.json();
+    if (typeof data?.detail === "string") return data.detail;
+    if (Array.isArray(data?.detail)) {
+      return data.detail
+        .map((err: { loc?: unknown[]; msg?: string }) => {
+          const field = Array.isArray(err.loc) ? err.loc.at(-1) : null;
+          return field ? `${field}: ${err.msg}` : err.msg;
+        })
+        .join(", ");
+    }
+    return res.statusText || `HTTP ${res.status}`;
+  } catch {
+    return res.statusText || `HTTP ${res.status}`;
+  }
+}

--- a/frontend/src/lib/auth-context.tsx
+++ b/frontend/src/lib/auth-context.tsx
@@ -1,0 +1,86 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import { apiFetch, onLoggedOut } from "./api";
+
+export type AuthUser = {
+  user_id?: string;
+  email: string;
+  firstname?: string;
+  lastname?: string;
+  phone?: string;
+  boat_club?: string;
+  role?: string;
+  assigned_berth_id?: string | null;
+};
+
+export type AuthState = {
+  user: AuthUser | null;
+  loading: boolean;
+  refresh: () => Promise<void>;
+  logout: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthState | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  // start true so first render doesn't flash logged-out before /me resolves
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await apiFetch("/api/auth/me", { skipAuthRefresh: true });
+      if (res.status === 401) {
+        setUser(null);
+        return;
+      }
+      if (!res.ok) throw new Error(`/me ${res.status}`);
+      const data = (await res.json()) as AuthUser;
+      setUser(data);
+    } catch (err) {
+      // transient network error keeps last-known state, don't drop session
+      console.error("auth refresh failed", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const logout = useCallback(async () => {
+    try {
+      await apiFetch("/api/auth/logout", {
+        method: "POST",
+        skipAuthRefresh: true,
+      });
+    } catch (err) {
+      console.warn("logout request failed", err);
+    } finally {
+      setUser(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => onLoggedOut(() => setUser(null)), []);
+
+  return (
+    <AuthContext.Provider value={{ user, loading, refresh, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthContext);
+  if (ctx === null) {
+    throw new Error("useAuth must be used inside AuthProvider");
+  }
+  return ctx;
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -18,6 +18,8 @@ import {
 import { Input } from "../components/shared/ui/input";
 import { Label } from "../components/shared/ui/label";
 import { PasswordInput } from "../components/shared/ui/password-input";
+import { apiFetch } from "../lib/api";
+import { useAuth } from "../lib/auth-context";
 
 type SettingsForm = {
   firstname: string;
@@ -174,9 +176,8 @@ const errorClass = "text-sm text-red-500";
 const labelGroupClass = "space-y-1.5";
 
 function Settings() {
-  const { user, setUser, token, setToken, setIsLoginOpen } =
-    useOutletContext<AuthOutletContext>();
-
+  const { user, setIsLoginOpen } = useOutletContext<AuthOutletContext>();
+  const { refresh, logout } = useAuth();
   const navigate = useNavigate();
 
   const initialForm = useMemo(() => getInitialForm(user), [user]);
@@ -226,7 +227,7 @@ function Settings() {
     const ac = new AbortController();
     setIsLoadingAvailability(true);
 
-    fetch(`/api/berths/${berthId}/availability`, { signal: ac.signal })
+    apiFetch(`/api/berths/${berthId}/availability`, { signal: ac.signal })
       .then((res) =>
         res.ok ? (res.json() as Promise<AvailabilityWindow[]>) : [],
       )
@@ -256,17 +257,10 @@ function Settings() {
     setAvailabilitySuccess(null);
   }
 
-  function clearLocalAuthState() {
-    // mirrors MainLayout.handleLogout local cleanup, minus the server logout
-    localStorage.removeItem("token");
-    setToken(null);
-    setUser(null);
-  }
-
   async function handleSaveAvailability(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
 
-    if (!token) {
+    if (!user) {
       setAvailabilityError("You need to log in before updating availability.");
       setIsLoginOpen(true);
       return;
@@ -290,12 +284,9 @@ function Settings() {
     setAvailabilitySuccess(null);
 
     try {
-      const res = await fetch(`/api/berths/${berthId}/availability`, {
+      const res = await apiFetch(`/api/berths/${berthId}/availability`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           from_date: dateInputToIso(availabilityForm.from_date),
           return_date: dateInputToIso(availabilityForm.return_date),
@@ -333,7 +324,7 @@ function Settings() {
   }
 
   async function handleClearAvailability(window: AvailabilityWindow) {
-    if (!token) {
+    if (!user) {
       setAvailabilityError("You need to log in before clearing availability.");
       setIsLoginOpen(true);
       return;
@@ -349,12 +340,9 @@ function Settings() {
     setAvailabilitySuccess(null);
 
     try {
-      const res = await fetch(
+      const res = await apiFetch(
         `/api/berths/${berthId}/availability/${window.window_id}`,
-        {
-          method: "DELETE",
-          headers: { Authorization: `Bearer ${token}` },
-        },
+        { method: "DELETE" },
       );
 
       if (!res.ok) {
@@ -385,7 +373,7 @@ function Settings() {
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
 
-    if (!token) {
+    if (!user) {
       setErrors({ general: "You need to log in before editing settings." });
       setIsLoginOpen(true);
       return;
@@ -418,12 +406,9 @@ function Settings() {
     setSuccessMessage(null);
 
     try {
-      const res = await fetch("/api/users/me", {
+      const res = await apiFetch("/api/users/me", {
         method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
       });
 
@@ -434,7 +419,7 @@ function Settings() {
 
       const updatedUser = (await res.json()) as AuthUser;
 
-      setUser(updatedUser);
+      await refresh();
       setForm({
         ...getInitialForm(updatedUser),
         current_password: "",
@@ -449,7 +434,7 @@ function Settings() {
   }
 
   async function handleDeleteAccount() {
-    if (!token) {
+    if (!user) {
       setDeleteError("You need to log in before deleting your account.");
       setIsLoginOpen(true);
       return;
@@ -477,12 +462,7 @@ function Settings() {
     setDeleteError(null);
 
     try {
-      const res = await fetch("/api/users/me", {
-        method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
+      const res = await apiFetch("/api/users/me", { method: "DELETE" });
 
       if (!res.ok) {
         const responseErrors = await getErrorsFromResponse(
@@ -496,7 +476,8 @@ function Settings() {
         return;
       }
 
-      clearLocalAuthState();
+      // logout to clear cookies + provider state, account is already gone server-side
+      await logout();
       setIsDeleteOpen(false);
       navigate("/");
       setIsLoginOpen(true);
@@ -682,7 +663,7 @@ function Settings() {
         </Button>
       </form>
 
-      {token && <NotificationSettings token={token} />}
+      {user && <NotificationSettings />}
 
       <section className="mt-6 rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-lg backdrop-blur">
         <div>


### PR DESCRIPTION
## Summary

Replaces `localStorage`-Bearer auth with httpOnly cookie sessions + rotating refresh tokens, double-submit CSRF on mutating routes, and a route guard on `/settings`. XSS no longer leaks the access token. Breaking change to the OpenAPI surface: `HTTPBearer` removed, `POST /api/auth/login` returns `UserOut` instead of `TokenOut`.

## Changes

- New `refresh_tokens(jti, user_id, issued_at, expires_at, revoked_at, replaced_by_jti)` table + alembic migration.
- `dockpulse_access` (15m JWT) + `dockpulse_refresh` (14d rotating JWT) httpOnly cookies. `Secure` derives from `app_env`. CSRF token in non-httpOnly `dockpulse_csrf` cookie.
- `POST /api/auth/refresh` rotates the family. Reuse of a revoked refresh token revokes the whole family + bumps `token_version` → forced re-login everywhere.
- `GET /api/auth/me` for session probing. Login response shape now `UserOut`.
- App-level `require_csrf` dep on every non-safe method, double-submit against the cookie. No-ops for anonymous flows like `/login`.
- OpenAPI security scheme swapped to `APIKeyCookie(dockpulse_access)`. `HTTPBearer` dropped.
- Frontend `AuthProvider` (real React context) + `lib/api.ts` wrapper: `credentials: include`, CSRF echo from cookie on non-GET, shared single-flight `/refresh` on 401, logout event on terminal failure. `localStorage` token gone.
- `<RequireAuth>` on `/settings`. Redirects to `/?login=1`; `MainLayout` opens `AuthDialog` on the flag and consumes it.
- Test fixtures migrated to cookie auth via new `auth_cookies()` helper, conftest event-hook auto-attaches `X-CSRF-Token`. `make_auth_token` retained for tests asserting on token shape.

## Checklist

- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [x] All existing tests pass
- [x] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
