### PR TITLE
fix(sse): publish berth.update on adopt and ship snapshot first frame

### DIFF
--- a/backend/app/adoption/finalize.py
+++ b/backend/app/adoption/finalize.py
@@ -13,6 +13,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import broadcaster
+from app.events import load_berth_with_assignment, publish_berth_update
 from app.models import AdoptionRequest, Node
 from app.schemas import AdoptionRequestOut
 
@@ -119,6 +120,10 @@ async def complete_adoption_ok(
         return
     await session.refresh(request)
     publish_adoption_update(request)
+    # map waits on berth.update so adoption refreshes without first reading
+    berth = await load_berth_with_assignment(session, request.berth_id)
+    if berth is not None:
+        publish_berth_update(berth)
     logger.info(
         "adoption ok: request=%s node=%s berth=%s",
         request_id,

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -17,12 +17,14 @@ logger = logging.getLogger(__name__)
 # todo harbor-scope once User has harbor_id pages every hm right now
 
 
-def _publish_berth_update(berth: Berth) -> None:
+def publish_berth_update(berth: Berth) -> None:
     event = BerthUpdateEvent(berth=berth)
     broadcaster.publish(event.model_dump(mode="json"))
 
 
-async def _load_berth(session: AsyncSession, berth_id: str) -> Berth | None:
+async def load_berth_with_assignment(
+    session: AsyncSession, berth_id: str
+) -> Berth | None:
     # eager-load assignment so BerthOut serialization never lazy-loads in async
     stmt = (
         select(Berth)
@@ -82,7 +84,7 @@ async def process_sensor_reading(
     battery_pct: int | None = None,
 ) -> Event | None:
     """Persist a berth status reading. Return a new Event on state change."""
-    berth = await _load_berth(session, berth_id)
+    berth = await load_berth_with_assignment(session, berth_id)
     if berth is None:
         raise ValueError(f"Unknown berth: {berth_id}")
 
@@ -111,7 +113,7 @@ async def process_sensor_reading(
     if new_status == prev_status or berth.is_reserved:
         await session.commit()
         if berth.battery_pct != prev_battery:
-            _publish_berth_update(berth)
+            publish_berth_update(berth)
         return None
 
     event = Event(
@@ -126,7 +128,7 @@ async def process_sensor_reading(
     berth.status = new_status
     session.add(event)
     await session.commit()
-    _publish_berth_update(berth)
+    publish_berth_update(berth)
     await _notify_harbormasters(session, berth, new_status, event.event_id)
     return event
 
@@ -138,11 +140,11 @@ async def process_heartbeat(
     battery_pct: int | None = None,
 ) -> None:
     """Touch berth liveness from a heartbeat; no Event row written."""
-    berth = await _load_berth(session, berth_id)
+    berth = await load_berth_with_assignment(session, berth_id)
     if berth is None:
         raise ValueError(f"Unknown berth: {berth_id}")
     berth.last_updated = datetime.now(UTC)
     if battery_pct is not None:
         berth.battery_pct = battery_pct
     await session.commit()
-    _publish_berth_update(berth)
+    publish_berth_update(berth)

--- a/backend/app/routers/berths.py
+++ b/backend/app/routers/berths.py
@@ -20,6 +20,7 @@ from app.schemas import (
     BerthAvailabilityWindowIn,
     BerthAvailabilityWindowOut,
     BerthOut,
+    BerthSnapshotEvent,
     BerthUpdateEvent,
     EventOut,
 )
@@ -56,29 +57,40 @@ async def list_berths(
     operation_id="streamBerths",
     summary="Subscribe to live berth updates via Server-Sent Events",
     description=(
-        "Opens a long-lived `text/event-stream` connection. Each message is a "
-        "JSON-encoded `BerthUpdateEvent`. Clients should first fetch a snapshot "
-        "via `GET /api/berths` and then merge streamed updates by `berth_id`. "
-        "Reconnects re-subscribe but do not replay missed events — re-fetch the "
-        "snapshot after an `open` that follows a disconnection."
+        "Opens a long-lived `text/event-stream` connection. The first frame "
+        "is a `BerthSnapshotEvent` carrying every berth; subsequent frames "
+        "are `BerthUpdateEvent` deltas merged by `berth_id`. Reconnects "
+        "yield a fresh snapshot, so clients do not need a separate "
+        "`GET /api/berths` call to bootstrap or recover."
     ),
     response_class=EventSourceResponse,
     responses={
         200: {
-            "model": BerthUpdateEvent,
-            "description": "Each frame is a JSON-encoded BerthUpdateEvent.",
+            "model": BerthSnapshotEvent | BerthUpdateEvent,
+            "description": (
+                "First frame is a `BerthSnapshotEvent`; subsequent frames "
+                "are `BerthUpdateEvent`."
+            ),
         }
     },
 )
-async def stream_berths(request: Request):
+async def stream_berths(request: Request, session: SessionDep):
     async def event_gen():
+        # subscribe before snapshot so updates between them aren't lost
         async with broadcaster.subscribe() as queue:
+            stmt = select(Berth).options(selectinload(Berth.assignment))
+            berths = list((await session.execute(stmt)).scalars().all())
+            snapshot = BerthSnapshotEvent(berths=berths).model_dump(mode="json")
+            yield {"event": snapshot["type"], "data": json.dumps(snapshot)}
             while True:
                 if await request.is_disconnected():
                     return
                 try:
                     event = await asyncio.wait_for(queue.get(), timeout=1.0)
                 except TimeoutError:
+                    continue
+                # broadcaster fans every event to every queue, drop non-berth
+                if event.get("type") != "berth.update":
                     continue
                 yield {"event": event["type"], "data": json.dumps(event)}
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -300,6 +300,11 @@ class BerthUpdateEvent(BaseModel):
     berth: BerthOut
 
 
+class BerthSnapshotEvent(BaseModel):
+    type: Literal["berth.snapshot"] = "berth.snapshot"
+    berths: list[BerthOut]
+
+
 class AdoptionUpdateEvent(BaseModel):
     type: Literal["adoption.update"] = "adoption.update"
     request: AdoptionRequestOut

--- a/backend/tests/test_adoption_stream.py
+++ b/backend/tests/test_adoption_stream.py
@@ -117,6 +117,29 @@ async def test_finalize_ok_publishes_event_matching_stream_filter(
     assert event["request"]["mesh_unicast_addr"] == "0x0042"
 
 
+async def test_finalize_ok_also_publishes_berth_update(
+    session: AsyncSession,
+    pending_request: AdoptionRequest,
+):
+    # map waits on berth.update so adoption refreshes without first reading
+    async with broadcaster.subscribe() as queue:
+        await complete_adoption_ok(
+            session,
+            request_id="req-pending",
+            mesh_unicast_addr="0x0042",
+            dev_key_fp="9f3a8b2c4d1e7f60",
+        )
+        events = [
+            await asyncio.wait_for(queue.get(), timeout=1.0),
+            await asyncio.wait_for(queue.get(), timeout=1.0),
+        ]
+
+    types = {e["type"] for e in events}
+    assert types == {"adoption.update", "berth.update"}
+    berth_evt = next(e for e in events if e["type"] == "berth.update")
+    assert berth_evt["berth"]["berth_id"] == "b1"
+
+
 async def test_finalize_err_publishes_event_matching_stream_filter(
     session: AsyncSession,
     pending_request: AdoptionRequest,

--- a/backend/tests/test_stream.py
+++ b/backend/tests/test_stream.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 
 import pytest
 
@@ -106,3 +107,57 @@ async def test_unsubscribe_after_context_exit(session, seeded_berth):
     async with broadcaster.subscribe():
         assert broadcaster.subscriber_count() == 1
     assert broadcaster.subscriber_count() == 0
+
+
+async def test_berth_stream_first_frame_is_snapshot(session, seeded_berth):
+    from app.routers.berths import stream_berths
+
+    class _Req:
+        async def is_disconnected(self):
+            return False
+
+    response = await stream_berths(_Req(), session)  # type: ignore[arg-type]
+    gen = response.body_iterator
+    try:
+        frame = await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+        assert frame["event"] == "berth.snapshot"
+        payload = json.loads(frame["data"])
+        assert payload["type"] == "berth.snapshot"
+        assert "b1" in [b["berth_id"] for b in payload["berths"]]
+    finally:
+        await gen.aclose()
+
+
+async def test_berth_stream_loop_drops_non_berth_events(session, seeded_berth):
+    # broadcaster fans every event to every queue, route must drop non-berth
+    from app.routers.berths import stream_berths
+
+    class _Req:
+        async def is_disconnected(self):
+            return False
+
+    response = await stream_berths(_Req(), session)  # type: ignore[arg-type]
+    gen = response.body_iterator
+
+    snapshot = await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+    assert snapshot["event"] == "berth.snapshot"
+
+    broadcaster.publish({"type": "adoption.update", "request": {"r": 1}})
+    broadcaster.publish(
+        {
+            "type": "berth.update",
+            "berth": {
+                "berth_id": "b1",
+                "dock_id": "d1",
+                "status": "free",
+                "is_reserved": False,
+            },
+        }
+    )
+
+    next_frame = await asyncio.wait_for(gen.__anext__(), timeout=2.0)
+    payload = json.loads(next_frame["data"])
+    assert payload["type"] == "berth.update"
+    assert payload["berth"]["berth_id"] == "b1"
+
+    await gen.aclose()

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -604,6 +604,22 @@ components:
       - status
       title: BerthResetOut
       type: object
+    BerthSnapshotEvent:
+      properties:
+        berths:
+          items:
+            $ref: '#/components/schemas/BerthOut'
+          title: Berths
+          type: array
+        type:
+          const: berth.snapshot
+          default: berth.snapshot
+          title: Type
+          type: string
+      required:
+      - berths
+      title: BerthSnapshotEvent
+      type: object
     BerthUpdateEvent:
       properties:
         berth:
@@ -3294,18 +3310,21 @@ paths:
       - berths
   /api/berths/stream:
     get:
-      description: Opens a long-lived `text/event-stream` connection. Each message is a JSON-encoded `BerthUpdateEvent`.
-        Clients should first fetch a snapshot via `GET /api/berths` and then merge streamed updates by
-        `berth_id`. Reconnects re-subscribe but do not replay missed events — re-fetch the snapshot after
-        an `open` that follows a disconnection.
+      description: Opens a long-lived `text/event-stream` connection. The first frame is a `BerthSnapshotEvent`
+        carrying every berth; subsequent frames are `BerthUpdateEvent` deltas merged by `berth_id`. Reconnects
+        yield a fresh snapshot, so clients do not need a separate `GET /api/berths` call to bootstrap
+        or recover.
       operationId: streamBerths
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BerthUpdateEvent'
-          description: Each frame is a JSON-encoded BerthUpdateEvent.
+                anyOf:
+                - $ref: '#/components/schemas/BerthSnapshotEvent'
+                - $ref: '#/components/schemas/BerthUpdateEvent'
+                title: Response 200 Streamberths
+          description: First frame is a `BerthSnapshotEvent`; subsequent frames are `BerthUpdateEvent`.
       summary: Subscribe to live berth updates via Server-Sent Events
       tags:
       - berths

--- a/frontend/mock/sse-server.ts
+++ b/frontend/mock/sse-server.ts
@@ -363,6 +363,13 @@ Bun.serve({
 
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {
+        // mirrors backend first frame, dev hook bootstraps off this
+        controller.enqueue(
+          encodeFrame("berth.snapshot", {
+            type: "berth.snapshot",
+            berths: BERTHS,
+          }),
+        );
         let i = 0;
         const tick = () => {
           const berth = BERTHS[i % BERTHS.length];

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -563,7 +563,7 @@ export interface paths {
         };
         /**
          * Subscribe to live berth updates via Server-Sent Events
-         * @description Opens a long-lived `text/event-stream` connection. Each message is a JSON-encoded `BerthUpdateEvent`. Clients should first fetch a snapshot via `GET /api/berths` and then merge streamed updates by `berth_id`. Reconnects re-subscribe but do not replay missed events — re-fetch the snapshot after an `open` that follows a disconnection.
+         * @description Opens a long-lived `text/event-stream` connection. The first frame is a `BerthSnapshotEvent` carrying every berth; subsequent frames are `BerthUpdateEvent` deltas merged by `berth_id`. Reconnects yield a fresh snapshot, so clients do not need a separate `GET /api/berths` call to bootstrap or recover.
          */
         get: operations["streamBerths"];
         put?: never;
@@ -1251,6 +1251,17 @@ export interface components {
             berth_id: string;
             /** Status */
             status: string;
+        };
+        /** BerthSnapshotEvent */
+        BerthSnapshotEvent: {
+            /** Berths */
+            berths: components["schemas"]["BerthOut"][];
+            /**
+             * Type
+             * @default berth.snapshot
+             * @constant
+             */
+            type: "berth.snapshot";
         };
         /** BerthUpdateEvent */
         BerthUpdateEvent: {
@@ -3391,13 +3402,13 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Each frame is a JSON-encoded BerthUpdateEvent. */
+            /** @description First frame is a `BerthSnapshotEvent`; subsequent frames are `BerthUpdateEvent`. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["BerthUpdateEvent"];
+                    "application/json": components["schemas"]["BerthSnapshotEvent"] | components["schemas"]["BerthUpdateEvent"];
                 };
             };
         };

--- a/frontend/src/hooks/useBerthsStream.ts
+++ b/frontend/src/hooks/useBerthsStream.ts
@@ -3,46 +3,32 @@ import type { components } from "../api-types";
 
 type Berth = components["schemas"]["BerthOut"];
 type BerthEvent = components["schemas"]["BerthUpdateEvent"];
-
-// Suppress snapshot storms on flaky reconnects.
-const SNAPSHOT_THROTTLE_MS = 3000;
+type BerthSnapshot = components["schemas"]["BerthSnapshotEvent"];
 
 export function useBerthsStream() {
   const [berthsById, setBerthsById] = useState<Map<string, Berth>>(new Map());
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const snapshotAbortRef = useRef<AbortController | null>(null);
-  const lastSnapshotAtRef = useRef<number>(0);
-
-  const loadSnapshotACB = useCallback(async () => {
-    snapshotAbortRef.current?.abort();
-    const ac = new AbortController();
-    snapshotAbortRef.current = ac;
-    try {
-      const response = await fetch("/api/berths", { signal: ac.signal });
-      if (!response.ok) {
-        throw new Error(`Failed to fetch berths: ${response.statusText}`);
-      }
-      const list = (await response.json()) as Berth[];
-      if (ac.signal.aborted) return;
-      setBerthsById(new Map(list.map((b) => [b.berth_id, b])));
-      setError(null);
-      lastSnapshotAtRef.current = Date.now();
-    } catch (err) {
-      if ((err as { name?: string })?.name === "AbortError") return;
-      setError(
-        err instanceof Error ? err.message : "An unknown error occurred",
-      );
-    } finally {
-      if (!ac.signal.aborted) setIsLoading(false);
-    }
-  }, []);
+  // bump to force the EventSource effect to tear down + reopen
+  const [generation, setGeneration] = useState(0);
+  const sourceRef = useRef<EventSource | null>(null);
 
   useEffect(() => {
-    let hasOpenedOnce = false;
-    loadSnapshotACB();
-
+    // generation read so the dep array re-runs the effect on retry
+    void generation;
     const source = new EventSource("/api/berths/stream");
+    sourceRef.current = source;
+
+    source.addEventListener("berth.snapshot", (e) => {
+      try {
+        const msg = JSON.parse((e as MessageEvent).data) as BerthSnapshot;
+        setBerthsById(new Map(msg.berths.map((b) => [b.berth_id, b])));
+        setError(null);
+        setIsLoading(false);
+      } catch {
+        // ignore malformed frames
+      }
+    });
 
     source.addEventListener("berth.update", (e) => {
       try {
@@ -57,19 +43,25 @@ export function useBerthsStream() {
       }
     });
 
-    source.onopen = () => {
-      if (hasOpenedOnce) {
-        const sinceLast = Date.now() - lastSnapshotAtRef.current;
-        if (sinceLast >= SNAPSHOT_THROTTLE_MS) loadSnapshotACB();
+    source.onerror = () => {
+      // soft error for retry UI, snapshot on reconnect clears it
+      if (source.readyState === EventSource.CLOSED) {
+        setError("Stream connection closed");
+      } else if (source.readyState === EventSource.CONNECTING) {
+        setError("Stream reconnecting");
       }
-      hasOpenedOnce = true;
     };
 
     return () => {
       source.close();
-      snapshotAbortRef.current?.abort();
+      sourceRef.current = null;
     };
-  }, [loadSnapshotACB]);
+  }, [generation]);
+
+  const refetchACB = useCallback(() => {
+    setIsLoading(true);
+    setGeneration((g) => g + 1);
+  }, []);
 
   const berths = useMemo(() => Array.from(berthsById.values()), [berthsById]);
 
@@ -77,6 +69,6 @@ export function useBerthsStream() {
     berths,
     isLoading,
     error,
-    refetchACB: loadSnapshotACB,
+    refetchACB,
   };
 }


### PR DESCRIPTION
## Summary

Three SSE fixes uncovered while investigating "adopting a node doesn't update the map". Map listened for `berth.update` only, but adoption finalization published `adoption.update` exclusively, so the map stayed stale until the first sensor reading. Stream also forwarded every broadcaster event indiscriminately and the snapshot bootstrap raced the SSE.

## Related Issue

Closes #161

## Changes

- `complete_adoption_ok` publishes a `berth.update` after the adoption row is finalized, map refreshes on adopt without waiting for first reading
- `/api/berths/stream` emits a `BerthSnapshotEvent` first frame, subscribe-then-snapshot order mirrors the adoption stream pattern, eliminates the bootstrap race

## Checklist

- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [x] All existing tests pass
- [x] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
