### PR TITLE
feat(users): add GET /api/users?berth_id lookup

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,9 +1,11 @@
+from typing import Annotated
+
 from argon2 import PasswordHasher
 from argon2.exceptions import VerifyMismatchError
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from sqlalchemy import select
 
-from app.dependencies import CurrentUserDep, SessionDep
+from app.dependencies import CurrentUserDep, HarbormasterForBerthDep, SessionDep
 from app.models import Assignment, User, UserNotificationPrefs
 from app.schemas import (
     NotificationPrefsOut,
@@ -45,6 +47,30 @@ def _to_user_out(user: User, assigned_berth_id: str | None) -> UserOut:
             "assigned_berth_id": assigned_berth_id,
         }
     )
+
+
+@router.get(
+    "",
+    response_model=UserOut,
+    operation_id="getUserByBerth",
+    summary="Get the user assigned to a berth",
+)
+async def get_user_by_berth(
+    session: SessionDep,
+    _: HarbormasterForBerthDep,
+    berth_id: Annotated[str, Query(description="berth to look up assigned user for")],
+):
+    user_id = (
+        await session.execute(
+            select(Assignment.user_id).where(Assignment.berth_id == berth_id)
+        )
+    ).scalar_one_or_none()
+    if user_id is None:
+        raise HTTPException(status_code=404, detail="No user assigned to this berth")
+    user = await session.get(User, user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return _to_user_out(user, berth_id)
 
 
 @router.get(

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -297,3 +297,62 @@ async def test_patch_notification_prefs_updates_fields(
 async def test_notification_prefs_requires_auth(client: AsyncClient):
     r = await client.get("/api/users/me/notification-prefs")
     assert r.status_code == 401
+
+
+async def test_get_user_by_berth_returns_assigned_user(
+    client: AsyncClient, seeded_berth, harbor_master, boat_owner
+):
+    creds = _creds(make_token(harbor_master.user_id))
+    await client.put(
+        "/api/berths/b1/assignment",
+        json={"user_id": boat_owner.user_id},
+        cookies=creds,
+    )
+
+    r = await client.get("/api/users", params={"berth_id": "b1"}, cookies=creds)
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["user_id"] == boat_owner.user_id
+    assert data["firstname"] == boat_owner.firstname
+    assert data["lastname"] == boat_owner.lastname
+    assert data["email"] == boat_owner.email
+    assert data["assigned_berth_id"] == "b1"
+    assert "password_hash" not in data
+
+
+async def test_get_user_by_berth_unassigned_returns_404(
+    client: AsyncClient, seeded_berth, harbor_master
+):
+    r = await client.get(
+        "/api/users",
+        params={"berth_id": "b1"},
+        cookies=_creds(make_token(harbor_master.user_id)),
+    )
+    assert r.status_code == 404
+
+
+async def test_get_user_by_berth_unknown_berth_returns_404(
+    client: AsyncClient, harbor_master
+):
+    r = await client.get(
+        "/api/users",
+        params={"berth_id": "nope"},
+        cookies=_creds(make_token(harbor_master.user_id)),
+    )
+    assert r.status_code == 404
+
+
+async def test_get_user_by_berth_requires_harbormaster(
+    client: AsyncClient, seeded_berth, boat_owner
+):
+    r = await client.get(
+        "/api/users",
+        params={"berth_id": "b1"},
+        cookies=_creds(make_token(boat_owner.user_id)),
+    )
+    assert r.status_code == 403
+
+
+async def test_get_user_by_berth_requires_auth(client: AsyncClient):
+    r = await client.get("/api/users", params={"berth_id": "b1"})
+    assert r.status_code == 401

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -3866,6 +3866,34 @@ paths:
       summary: Mark node as decommissioned
       tags:
       - nodes
+  /api/users:
+    get:
+      operationId: getUserByBerth
+      parameters:
+      - in: query
+        name: berth_id
+        required: true
+        schema:
+          title: Berth Id
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserOut'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - APIKeyCookie: []
+      summary: Get the user assigned to a berth
+      tags:
+      - users
   /api/users/me:
     delete:
       operationId: deleteMe

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -831,6 +831,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the user assigned to a berth */
+        get: operations["getUserByBerth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/users/me": {
         parameters: {
             query?: never;
@@ -3923,6 +3940,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["NodeHealthOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    getUserByBerth: {
+        parameters: {
+            query: {
+                berth_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserOut"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

New endpoint so harbormaster UI can fetch full user details (name, email, phone, boat club) for the boat owner assigned to a berth.

## Checklist

- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [x] All existing tests pass
- [x] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
