### PR TITLE
feat: email verification on user registration

### DIFF
--- a/backend/alembic/versions/da492cf8c15a_add_email_verification.py
+++ b/backend/alembic/versions/da492cf8c15a_add_email_verification.py
@@ -4,18 +4,21 @@ Revision ID: da492cf8c15a
 Revises: 6c273ed76aa2
 Create Date: 2026-05-07 15:33:12.486610
 
+Creates user_verifications table for single-use email verification tokens and
+adds email_verified to users. Backfills existing rows to True — pre-existing
+accounts are trusted and must not be locked out.
 """
-from typing import Sequence, Union
 
-from alembic import op
+from collections.abc import Sequence
+
 import sqlalchemy as sa
 
+from alembic import op
 
-# revision identifiers, used by Alembic.
-revision: str = 'da492cf8c15a'
-down_revision: Union[str, Sequence[str], None] = '6c273ed76aa2'
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+revision: str = "da492cf8c15a"
+down_revision: str | Sequence[str] | None = "6c273ed76aa2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
@@ -43,7 +46,9 @@ def upgrade() -> None:
             server_default=sa.text("false"),
         ),
     )
-    op.create_index("ix_user_verifications_token", "user_verifications", ["token"])
+    op.create_index(
+        "ix_user_verifications_token", "user_verifications", ["token"], unique=True
+    )
     op.create_index(
         "ix_user_verifications_user_id", "user_verifications", ["user_id"]
     )

--- a/backend/alembic/versions/da492cf8c15a_add_email_verification.py
+++ b/backend/alembic/versions/da492cf8c15a_add_email_verification.py
@@ -1,0 +1,72 @@
+"""add_email_verification
+
+Revision ID: da492cf8c15a
+Revises: 6c273ed76aa2
+Create Date: 2026-05-07 15:33:12.486610
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'da492cf8c15a'
+down_revision: Union[str, Sequence[str], None] = '6c273ed76aa2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_verifications",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.String(),
+            sa.ForeignKey("users.user_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("token", sa.String(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "used",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.create_index("ix_user_verifications_token", "user_verifications", ["token"])
+    op.create_index(
+        "ix_user_verifications_user_id", "user_verifications", ["user_id"]
+    )
+    op.create_index(
+        "ix_user_verifications_expires_at", "user_verifications", ["expires_at"]
+    )
+
+    op.add_column(
+        "users",
+        sa.Column(
+            "email_verified",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    # backfill: existing accounts are trusted, don't lock them out
+    op.execute("UPDATE users SET email_verified = true")
+
+
+def downgrade() -> None:
+    op.drop_column("users", "email_verified")
+    op.drop_index("ix_user_verifications_expires_at", "user_verifications")
+    op.drop_index("ix_user_verifications_user_id", "user_verifications")
+    op.drop_index("ix_user_verifications_token", "user_verifications")
+    op.drop_table("user_verifications")

--- a/backend/alembic/versions/da492cf8c15a_add_email_verification.py
+++ b/backend/alembic/versions/da492cf8c15a_add_email_verification.py
@@ -1,7 +1,7 @@
 """add_email_verification
 
 Revision ID: da492cf8c15a
-Revises: 6c273ed76aa2
+Revises: e7c93a1f8420
 Create Date: 2026-05-07 15:33:12.486610
 
 Creates user_verifications table for single-use email verification tokens and
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "da492cf8c15a"
-down_revision: str | Sequence[str] | None = "6c273ed76aa2"
+down_revision: str | Sequence[str] | None = "e7c93a1f8420"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -38,6 +38,8 @@ class Settings(BaseSettings):
     app_env: Literal["dev", "staging", "prod"] = "dev"
     resend_api_key: str | None = None
     email_from: str = "DockPulse <noreply@dockpulse.xyz>"
+    app_base_url: str = "http://localhost:5173"
+    verification_token_ttl_hours: int = 24
     # csv origins, empty disables CORS middleware (vite proxy makes dev same-origin)
     cors_allowed_origins: Annotated[list[str], NoDecode] = []
     # per-ip throttle for credential brute-force

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -379,6 +379,7 @@ class RefreshToken(Base):
         ForeignKey("refresh_tokens.jti", ondelete="SET NULL")
     )
 
+
 class UserVerification(Base):
     __tablename__ = "user_verifications"
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -55,6 +55,7 @@ class User(Base):
     password_hash: Mapped[str] = mapped_column(String, nullable=False)
     boat_club: Mapped[str | None] = mapped_column(String)
     token_version: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    email_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     assignments: Mapped[list["Assignment"]] = relationship(
         back_populates="user", cascade="all, delete-orphan"
     )
@@ -377,3 +378,19 @@ class RefreshToken(Base):
     replaced_by_jti: Mapped[str | None] = mapped_column(
         ForeignKey("refresh_tokens.jti", ondelete="SET NULL")
     )
+
+class UserVerification(Base):
+    __tablename__ = "user_verifications"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("users.user_id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    token: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+    used: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)

--- a/backend/app/notifications.py
+++ b/backend/app/notifications.py
@@ -16,7 +16,6 @@ async def send_email(
 ) -> None:
     settings = get_settings()
     if settings.app_env != "prod":
-        # only prod sends, avoids spamming real users from staging/dev data
         logger.info(
             "email suppressed (app_env=%s) | to=%s | subject=%s",
             settings.app_env,
@@ -29,26 +28,39 @@ async def send_email(
             "RESEND_API_KEY unset, email suppressed | to=%s | subject=%s", to, subject
         )
         return
-    # resend sdk sync, offload so handler doesnt block loop
     await asyncio.to_thread(_send_sync, settings, to, subject, html, idempotency_key)
 
 
-def send_verification_email(email: str, token: str, firstname: str):
-    verify_url = f"https://yourdomain.com/verify?token={token}"
+async def send_verification_email(email: str, token: str, firstname: str) -> None:
+    settings = get_settings()
+    verify_url = f"{settings.app_base_url}/verify-email?token={token}"
+    await send_email(
+        to=email,
+        subject="Verify your DockPulse account",
+        html=(
+            f"<h1>Welcome, {firstname}!</h1>"
+            f"<p>Please verify your email by clicking the link below:</p>"
+            f'<a href="{verify_url}">Verify Email</a>'
+            f"<p>This link expires in {settings.verification_token_ttl_hours} hours.</p>"
+            f"<p>If you didn't create this account, you can safely ignore this email.</p>"
+        ),
+    )
 
-    params = {
-        "from": "DockPulse <noreply@dockpulse.com>",
-        "to": [email],
-        "subject": "Verify your DockPulse Account",
-        "html": f"""
-            <h1>Welcome to the club, {firstname}!</h1>
-            <p>Please click the link below to verify your email address:</p>
-            <a href="{verify_url}">Verify Email</a>
-            <p>If you didn't create this account, you can safely ignore this email.</p>
-        """,
-    }
 
-    resend.Emails.send(params)
+async def send_account_exists_email(email: str, firstname: str) -> None:
+    await send_email(
+        to=email,
+        subject="Someone tried to register with your DockPulse account",
+        html=(
+            f"<h1>Hi {firstname},</h1>"
+            f"<p>Someone tried to register a DockPulse account using your email address, "
+            f"but an account already exists.</p>"
+            f"<p>If this was you, you can log in directly. "
+            f"If you've forgotten your password, use the password reset flow.</p>"
+            f"<p>If this wasn't you, you can safely ignore this email.</p>"
+        ),
+    )
+
 
 def _send_sync(
     settings,
@@ -74,7 +86,6 @@ def _send_sync(
 
 
 async def send_push(user_id: str, title: str, body: str) -> None:
-    # stub, resend has no push channel, needs fcm/apn
     logger.warning(
         "push not implemented | user_id=%s | title=%s | body=%s", user_id, title, body
     )

--- a/backend/app/notifications.py
+++ b/backend/app/notifications.py
@@ -39,10 +39,11 @@ async def send_verification_email(email: str, token: str, firstname: str) -> Non
         subject="Verify your DockPulse account",
         html=(
             f"<h1>Welcome, {firstname}!</h1>"
-            f"<p>Please verify your email by clicking the link below:</p>"
+            "<p>Please verify your email by clicking the link below:</p>"
             f'<a href="{verify_url}">Verify Email</a>'
-            f"<p>This link expires in {settings.verification_token_ttl_hours} hours.</p>"
-            f"<p>If you didn't create this account, you can safely ignore this email.</p>"
+            f"<p>This link expires in"
+            f" {settings.verification_token_ttl_hours} hours.</p>"
+            "<p>If you didn't create this account, you can safely ignore this email.</p>"
         ),
     )
 
@@ -53,8 +54,8 @@ async def send_account_exists_email(email: str, firstname: str) -> None:
         subject="Someone tried to register with your DockPulse account",
         html=(
             f"<h1>Hi {firstname},</h1>"
-            f"<p>Someone tried to register a DockPulse account using your email address, "
-            f"but an account already exists.</p>"
+            "<p>Someone tried to register a DockPulse account using your email"
+            " address, but an account already exists.</p>"
             f"<p>If this was you, you can log in directly. "
             f"If you've forgotten your password, use the password reset flow.</p>"
             f"<p>If this wasn't you, you can safely ignore this email.</p>"

--- a/backend/app/notifications.py
+++ b/backend/app/notifications.py
@@ -43,7 +43,8 @@ async def send_verification_email(email: str, token: str, firstname: str) -> Non
             f'<a href="{verify_url}">Verify Email</a>'
             f"<p>This link expires in"
             f" {settings.verification_token_ttl_hours} hours.</p>"
-            "<p>If you didn't create this account, you can safely ignore this email.</p>"
+            "<p>If you didn't create this account, you can safely"
+            " ignore this email.</p>"
         ),
     )
 

--- a/backend/app/notifications.py
+++ b/backend/app/notifications.py
@@ -33,6 +33,23 @@ async def send_email(
     await asyncio.to_thread(_send_sync, settings, to, subject, html, idempotency_key)
 
 
+def send_verification_email(email: str, token: str, firstname: str):
+    verify_url = f"https://yourdomain.com/verify?token={token}"
+
+    params = {
+        "from": "DockPulse <noreply@dockpulse.com>",
+        "to": [email],
+        "subject": "Verify your DockPulse Account",
+        "html": f"""
+            <h1>Welcome to the club, {firstname}!</h1>
+            <p>Please click the link below to verify your email address:</p>
+            <a href="{verify_url}">Verify Email</a>
+            <p>If you didn't create this account, you can safely ignore this email.</p>
+        """,
+    }
+
+    resend.Emails.send(params)
+
 def _send_sync(
     settings,
     to: str | list[str],

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -64,7 +64,9 @@ async def _invalidate_verification_tokens(user_id: str, session: SessionDep) -> 
     )
 
 
-def _create_verification_token(user_id: str, session: SessionDep, settings) -> str:
+async def _create_verification_token(
+    user_id: str, session: SessionDep, settings
+) -> str:
     token = secrets.token_urlsafe(32)
     session.add(
         UserVerification(
@@ -97,7 +99,9 @@ async def register(
     if existing is not None:
         if not existing.email_verified:
             await _invalidate_verification_tokens(existing.user_id, session)
-            token = _create_verification_token(existing.user_id, session, settings)
+            token = await _create_verification_token(
+                existing.user_id, session, settings
+            )
             await session.commit()
             background_tasks.add_task(
                 send_verification_email,
@@ -130,7 +134,7 @@ async def register(
         await session.rollback()
         return {"message": "Check your email to verify your account"}
 
-    token = _create_verification_token(user.user_id, session, settings)
+    token = await _create_verification_token(user.user_id, session, settings)
     await session.commit()
     background_tasks.add_task(
         send_verification_email,

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -145,6 +145,36 @@ async def register(
     return {"message": "Check your email to verify your account"}
 
 
+@router.get(
+    "/verify-email",
+    status_code=200,
+    operation_id="verifyEmail",
+    summary="Verify email address using token from email link",
+)
+@limiter.limit("10/hour")
+async def verify_email(
+    request: Request,
+    token: str,
+    session: SessionDep,
+):
+    result = await session.execute(
+        select(UserVerification).where(UserVerification.token == token)
+    )
+    record = result.scalar_one_or_none()
+
+    if record is None or record.used or record.expires_at <= datetime.now(UTC):
+        raise HTTPException(status_code=400, detail="Invalid or expired token")
+
+    user = await session.get(User, record.user_id)
+    if user is None:
+        raise HTTPException(status_code=400, detail="Invalid or expired token")
+
+    record.used = True
+    user.email_verified = True
+    await session.commit()
+    return {"message": "Email verified. You can now log in."}
+
+
 @router.post(
     "/login",
     response_model=UserOut,

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -233,6 +233,11 @@ async def login(
     if user is None:
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
+    if not user.email_verified:
+        raise HTTPException(
+            status_code=403, detail="Email not verified. Check your inbox."
+        )
+
     await _issue_session(user, response, session)
     await session.commit()
     return await to_user_out(session, user)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -64,9 +64,7 @@ async def _invalidate_verification_tokens(user_id: str, session: SessionDep) -> 
     )
 
 
-async def _create_verification_token(
-    user_id: str, session: SessionDep, settings
-) -> str:
+def _create_verification_token(user_id: str, session: SessionDep, settings) -> str:
     token = secrets.token_urlsafe(32)
     session.add(
         UserVerification(
@@ -93,15 +91,15 @@ async def register(
     background_tasks: BackgroundTasks,
 ):
     settings = get_settings()
+    # pay argon2 cost up front so duplicate-email paths don't leak timing
+    password_hash = _hash_password(body.password.get_secret_value())
     result = await session.execute(select(User).where(User.email == body.email))
     existing = result.scalar_one_or_none()
 
     if existing is not None:
         if not existing.email_verified:
             await _invalidate_verification_tokens(existing.user_id, session)
-            token = await _create_verification_token(
-                existing.user_id, session, settings
-            )
+            token = _create_verification_token(existing.user_id, session, settings)
             await session.commit()
             background_tasks.add_task(
                 send_verification_email,
@@ -124,7 +122,7 @@ async def register(
         email=body.email,
         phone=body.phone,
         boat_club=body.boat_club,
-        password_hash=_hash_password(body.password.get_secret_value()),
+        password_hash=password_hash,
         email_verified=False,
     )
     session.add(user)
@@ -134,7 +132,7 @@ async def register(
         await session.rollback()
         return {"message": "Check your email to verify your account"}
 
-    token = await _create_verification_token(user.user_id, session, settings)
+    token = _create_verification_token(user.user_id, session, settings)
     await session.commit()
     background_tasks.add_task(
         send_verification_email,
@@ -150,6 +148,7 @@ async def register(
     status_code=200,
     operation_id="verifyEmail",
     summary="Verify email address using token from email link",
+    responses={400: {"description": "Invalid or expired token"}},
 )
 @limiter.limit("10/hour")
 async def verify_email(
@@ -188,7 +187,7 @@ async def resend_verification(
     session: SessionDep,
     background_tasks: BackgroundTasks,
 ):
-    _msg = {
+    msg = {
         "message": (
             "If that email is registered and unverified, a new link has been sent."
         )
@@ -197,11 +196,11 @@ async def resend_verification(
     user = result.scalar_one_or_none()
 
     if user is None or user.email_verified:
-        return _msg
+        return msg
 
     settings = get_settings()
     await _invalidate_verification_tokens(user.user_id, session)
-    token = await _create_verification_token(user.user_id, session, settings)
+    token = _create_verification_token(user.user_id, session, settings)
     await session.commit()
     background_tasks.add_task(
         send_verification_email,
@@ -209,7 +208,7 @@ async def resend_verification(
         token=token,
         firstname=user.firstname,
     )
-    return _msg
+    return msg
 
 
 @router.post(
@@ -217,6 +216,10 @@ async def resend_verification(
     response_model=UserOut,
     operation_id="login",
     summary="Log in and set session cookies",
+    responses={
+        401: {"description": "Invalid credentials"},
+        403: {"description": "Email not verified"},
+    },
 )
 @limiter.limit(lambda: get_settings().rate_limit_login)
 async def login(

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -24,7 +24,7 @@ from app.dependencies import CurrentUserDep, SessionDep
 from app.models import RefreshToken, User, UserVerification
 from app.notifications import send_account_exists_email, send_verification_email
 from app.rate_limit import limiter
-from app.schemas import LoginIn, UserCreate, UserOut
+from app.schemas import LoginIn, ResendVerificationIn, UserCreate, UserOut
 from app.serializers import to_user_out
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
@@ -173,6 +173,43 @@ async def verify_email(
     user.email_verified = True
     await session.commit()
     return {"message": "Email verified. You can now log in."}
+
+
+@router.post(
+    "/resend-verification",
+    status_code=200,
+    operation_id="resendVerification",
+    summary="Resend verification email",
+)
+@limiter.limit("5/hour")
+async def resend_verification(
+    request: Request,
+    body: ResendVerificationIn,
+    session: SessionDep,
+    background_tasks: BackgroundTasks,
+):
+    _msg = {
+        "message": (
+            "If that email is registered and unverified, a new link has been sent."
+        )
+    }
+    result = await session.execute(select(User).where(User.email == body.email))
+    user = result.scalar_one_or_none()
+
+    if user is None or user.email_verified:
+        return _msg
+
+    settings = get_settings()
+    await _invalidate_verification_tokens(user.user_id, session)
+    token = await _create_verification_token(user.user_id, session, settings)
+    await session.commit()
+    background_tasks.add_task(
+        send_verification_email,
+        email=user.email,
+        token=token,
+        firstname=user.firstname,
+    )
+    return _msg
 
 
 @router.post(

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -91,13 +91,15 @@ async def register(
     background_tasks: BackgroundTasks,
 ):
     settings = get_settings()
+    # email verification only enforced in prod, dev/staging skip the loop
+    require_verification = settings.app_env == "prod"
     # pay argon2 cost up front so duplicate-email paths don't leak timing
     password_hash = _hash_password(body.password.get_secret_value())
     result = await session.execute(select(User).where(User.email == body.email))
     existing = result.scalar_one_or_none()
 
     if existing is not None:
-        if not existing.email_verified:
+        if require_verification and not existing.email_verified:
             await _invalidate_verification_tokens(existing.user_id, session)
             token = _create_verification_token(existing.user_id, session, settings)
             await session.commit()
@@ -108,6 +110,10 @@ async def register(
                 firstname=existing.firstname,
             )
         else:
+            if not existing.email_verified:
+                # auto-promote stale unverified row in non-prod
+                existing.email_verified = True
+                await session.commit()
             background_tasks.add_task(
                 send_account_exists_email,
                 email=existing.email,
@@ -123,13 +129,17 @@ async def register(
         phone=body.phone,
         boat_club=body.boat_club,
         password_hash=password_hash,
-        email_verified=False,
+        email_verified=not require_verification,
     )
     session.add(user)
     try:
         await session.flush()
     except IntegrityError:
         await session.rollback()
+        return {"message": "Check your email to verify your account"}
+
+    if not require_verification:
+        await session.commit()
         return {"message": "Check your email to verify your account"}
 
     token = _create_verification_token(user.user_id, session, settings)
@@ -236,7 +246,7 @@ async def login(
     if user is None:
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
-    if not user.email_verified:
+    if get_settings().app_env == "prod" and not user.email_verified:
         raise HTTPException(
             status_code=403, detail="Email not verified. Check your inbox."
         )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,12 +1,14 @@
+import secrets
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
 import jwt
 from argon2 import PasswordHasher
 from argon2.exceptions import VerifyMismatchError
-from fastapi import APIRouter, Cookie, HTTPException, Request, Response
+from fastapi import APIRouter, BackgroundTasks, Cookie, HTTPException, Request, Response
 from sqlalchemy import select, update
+from sqlalchemy.exc import IntegrityError
 
 from app.auth import (
     ALGORITHM,
@@ -19,7 +21,8 @@ from app.auth import (
 )
 from app.config import get_settings
 from app.dependencies import CurrentUserDep, SessionDep
-from app.models import RefreshToken, User
+from app.models import RefreshToken, User, UserVerification
+from app.notifications import send_account_exists_email, send_verification_email
 from app.rate_limit import limiter
 from app.schemas import LoginIn, UserCreate, UserOut
 from app.serializers import to_user_out
@@ -27,8 +30,7 @@ from app.serializers import to_user_out
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 _ph = PasswordHasher()
-# dummy hash so unknown email still pays verify cost
-# blocks user enum via response timing
+# dummy hash so unknown email still pays verify cost — blocks user enum via timing
 _DUMMY_HASH = _ph.hash("dummy-password-for-timing-equalization")
 
 
@@ -54,18 +56,62 @@ async def _issue_session(
     )
 
 
+async def _invalidate_verification_tokens(user_id: str, session: SessionDep) -> None:
+    await session.execute(
+        update(UserVerification)
+        .where(UserVerification.user_id == user_id, UserVerification.used.is_(False))
+        .values(used=True)
+    )
+
+
+def _create_verification_token(user_id: str, session: SessionDep, settings) -> str:
+    token = secrets.token_urlsafe(32)
+    session.add(
+        UserVerification(
+            user_id=user_id,
+            token=token,
+            expires_at=datetime.now(UTC)
+            + timedelta(hours=settings.verification_token_ttl_hours),
+        )
+    )
+    return token
+
+
 @router.post(
     "/register",
-    response_model=UserOut,
     status_code=201,
     operation_id="registerUser",
     summary="Register a new user",
 )
 @limiter.limit(lambda: get_settings().rate_limit_register)
-async def register(request: Request, body: UserCreate, session: SessionDep):
-    existing = await session.execute(select(User).where(User.email == body.email))
-    if existing.scalar_one_or_none() is not None:
-        raise HTTPException(status_code=409, detail="Email already in use")
+async def register(
+    request: Request,
+    body: UserCreate,
+    session: SessionDep,
+    background_tasks: BackgroundTasks,
+):
+    settings = get_settings()
+    result = await session.execute(select(User).where(User.email == body.email))
+    existing = result.scalar_one_or_none()
+
+    if existing is not None:
+        if not existing.email_verified:
+            await _invalidate_verification_tokens(existing.user_id, session)
+            token = _create_verification_token(existing.user_id, session, settings)
+            await session.commit()
+            background_tasks.add_task(
+                send_verification_email,
+                email=existing.email,
+                token=token,
+                firstname=existing.firstname,
+            )
+        else:
+            background_tasks.add_task(
+                send_account_exists_email,
+                email=existing.email,
+                firstname=existing.firstname,
+            )
+        return {"message": "Check your email to verify your account"}
 
     user = User(
         user_id=str(uuid.uuid4()),
@@ -75,11 +121,24 @@ async def register(request: Request, body: UserCreate, session: SessionDep):
         phone=body.phone,
         boat_club=body.boat_club,
         password_hash=_hash_password(body.password.get_secret_value()),
+        email_verified=False,
     )
     session.add(user)
+    try:
+        await session.flush()
+    except IntegrityError:
+        await session.rollback()
+        return {"message": "Check your email to verify your account"}
+
+    token = _create_verification_token(user.user_id, session, settings)
     await session.commit()
-    await session.refresh(user)
-    return await to_user_out(session, user)
+    background_tasks.add_task(
+        send_verification_email,
+        email=user.email,
+        token=token,
+        firstname=user.firstname,
+    )
+    return {"message": "Check your email to verify your account"}
 
 
 @router.post(
@@ -149,7 +208,6 @@ async def refresh_session(
         raise HTTPException(status_code=401, detail="Invalid refresh token")
 
     if row.revoked_at is not None:
-        # reuse of a rotated token, treat as theft and burn the family
         await _revoke_all_refresh_tokens_for(user_id, session)
         await session.execute(
             update(User)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -272,6 +272,12 @@ class LoginIn(BaseModel):
     password: SecretStr
 
 
+class ResendVerificationIn(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    email: EmailField
+
+
 # --- system ---
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -160,6 +160,7 @@ async def harbor_master(session: AsyncSession, harbor_h1) -> User:
         lastname="Master",
         email="hilda@example.com",
         password_hash=hash_password("secret"),
+        email_verified=True,
     )
     session.add(user)
     await session.flush()
@@ -176,6 +177,7 @@ async def boat_owner(session: AsyncSession) -> User:
         lastname="Owner",
         email="olle@example.com",
         password_hash=hash_password("secret"),
+        email_verified=True,
     )
     session.add(user)
     await session.commit()

--- a/backend/tests/test_cookie_auth.py
+++ b/backend/tests/test_cookie_auth.py
@@ -23,6 +23,7 @@ async def _register_user(session: AsyncSession) -> User:
         lastname="Cookie",
         email="cora@example.com",
         password_hash=hash_password("supersecret"),
+        email_verified=True,
     )
     session.add(user)
     await session.commit()

--- a/backend/tests/test_email_verification.py
+++ b/backend/tests/test_email_verification.py
@@ -129,6 +129,20 @@ async def test_register_duplicate_unverified_resends_token(
     # second send should have a different token (old one invalidated)
     assert sent[0]["token"] != sent[1]["token"]
 
+    # verify old token is invalidated and new one is active
+    user = (
+        await session.execute(select(User).where(User.email == "alice@example.com"))
+    ).scalar_one()
+    all_tokens = (
+        await session.execute(
+            select(UserVerification).where(UserVerification.user_id == user.user_id)
+        )
+    ).scalars().all()
+    used_tokens = [t for t in all_tokens if t.used]
+    active_tokens = [t for t in all_tokens if not t.used]
+    assert len(used_tokens) == 1
+    assert len(active_tokens) == 1
+
 
 async def test_register_duplicate_verified_sends_account_exists(
     client: AsyncClient, session: AsyncSession, monkeypatch

--- a/backend/tests/test_email_verification.py
+++ b/backend/tests/test_email_verification.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime, timedelta
+
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -176,3 +178,126 @@ async def test_register_duplicate_verified_sends_account_exists(
     assert r.status_code == 201
     assert len(account_exists_sent) == 1
     assert account_exists_sent[0]["email"] == "alice@example.com"
+
+
+async def test_register_duplicate_unverified_does_not_update_password(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    async def _noop(**kw):
+        pass
+
+    monkeypatch.setattr("app.routers.auth.send_verification_email", _noop)
+
+    from argon2.exceptions import VerifyMismatchError
+
+    from app.routers.auth import _ph
+
+    await client.post("/api/auth/register", json=_REG)
+    new_pw = "differentpassword1"
+    await client.post("/api/auth/register", json={**_REG, "password": new_pw})
+
+    user = (
+        await session.execute(select(User).where(User.email == "alice@example.com"))
+    ).scalar_one()
+    try:
+        _ph.verify(user.password_hash, new_pw)
+        raise AssertionError("password should not have been updated")
+    except VerifyMismatchError:
+        pass
+
+
+# ── verify-email ─────────────────────────────────────────────────────────────
+
+
+async def _create_unverified_user_with_token(
+    session: AsyncSession,
+    user_id: str = "u-verify",
+    email: str = "verify@example.com",
+) -> tuple[User, str]:
+    from tests._helpers import hash_password
+
+    user = User(
+        user_id=user_id,
+        firstname="Vera",
+        lastname="Verify",
+        email=email,
+        password_hash=hash_password("password1234"),
+        email_verified=False,
+    )
+    session.add(user)
+    await session.flush()
+    token_value = "test-token-abc123"
+    session.add(
+        UserVerification(
+            user_id=user_id,
+            token=token_value,
+            expires_at=datetime.now(UTC) + timedelta(hours=24),
+        )
+    )
+    await session.commit()
+    return user, token_value
+
+
+async def test_verify_email_marks_user_verified(
+    client: AsyncClient, session: AsyncSession
+):
+    user, token = await _create_unverified_user_with_token(session)
+    r = await client.get(f"/api/auth/verify-email?token={token}")
+    assert r.status_code == 200
+    assert "verified" in r.json()["message"].lower()
+    await session.refresh(user)
+    assert user.email_verified is True
+
+
+async def test_verify_email_marks_token_used(
+    client: AsyncClient, session: AsyncSession
+):
+    user, token = await _create_unverified_user_with_token(session)
+    await client.get(f"/api/auth/verify-email?token={token}")
+    record = (
+        await session.execute(
+            select(UserVerification).where(UserVerification.token == token)
+        )
+    ).scalar_one()
+    assert record.used is True
+
+
+async def test_verify_email_unknown_token_returns_400(client: AsyncClient):
+    r = await client.get("/api/auth/verify-email?token=nonexistent")
+    assert r.status_code == 400
+
+
+async def test_verify_email_used_token_returns_400(
+    client: AsyncClient, session: AsyncSession
+):
+    user, token = await _create_unverified_user_with_token(session)
+    await client.get(f"/api/auth/verify-email?token={token}")
+    r = await client.get(f"/api/auth/verify-email?token={token}")
+    assert r.status_code == 400
+
+
+async def test_verify_email_expired_token_returns_400(
+    client: AsyncClient, session: AsyncSession
+):
+    from tests._helpers import hash_password
+
+    user = User(
+        user_id="u-expired",
+        firstname="Expo",
+        lastname="Red",
+        email="expired@example.com",
+        password_hash=hash_password("password1234"),
+        email_verified=False,
+    )
+    session.add(user)
+    await session.flush()
+    session.add(
+        UserVerification(
+            user_id="u-expired",
+            token="expired-token",
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+    )
+    await session.commit()
+    r = await client.get("/api/auth/verify-email?token=expired-token")
+    assert r.status_code == 400

--- a/backend/tests/test_email_verification.py
+++ b/backend/tests/test_email_verification.py
@@ -1,0 +1,164 @@
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import ACCESS_COOKIE, REFRESH_COOKIE
+from app.models import User, UserVerification
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+_REG = {
+    "firstname": "Alice",
+    "lastname": "Smith",
+    "email": "alice@example.com",
+    "password": "correcthorsebatterystaple",
+}
+
+
+async def _register(
+    client: AsyncClient,
+    monkeypatch,
+    email: str = "alice@example.com",
+) -> list:
+    sent: list = []
+
+    async def _capture(**kw):
+        sent.append(kw)
+
+    monkeypatch.setattr("app.routers.auth.send_verification_email", _capture)
+    monkeypatch.setattr("app.routers.auth.send_account_exists_email", _capture)
+    await client.post("/api/auth/register", json={**_REG, "email": email})
+    return sent
+
+
+# ── register ─────────────────────────────────────────────────────────────────
+
+
+async def test_register_returns_201_with_message(client: AsyncClient, monkeypatch):
+    async def _noop(**kw):
+        pass
+
+    monkeypatch.setattr("app.routers.auth.send_verification_email", _noop)
+
+    r = await client.post("/api/auth/register", json=_REG)
+    assert r.status_code == 201
+    assert "email" in r.json()["message"].lower()
+
+
+async def test_register_does_not_issue_session_cookies(
+    client: AsyncClient, monkeypatch
+):
+    async def _noop(**kw):
+        pass
+
+    monkeypatch.setattr("app.routers.auth.send_verification_email", _noop)
+
+    r = await client.post("/api/auth/register", json=_REG)
+    assert ACCESS_COOKIE not in r.cookies
+    assert REFRESH_COOKIE not in r.cookies
+
+
+async def test_register_user_is_unverified(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    async def _noop(**kw):
+        pass
+
+    monkeypatch.setattr("app.routers.auth.send_verification_email", _noop)
+
+    await client.post("/api/auth/register", json=_REG)
+    user = (
+        await session.execute(select(User).where(User.email == "alice@example.com"))
+    ).scalar_one()
+    assert user.email_verified is False
+
+
+async def test_register_creates_verification_token(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    async def _noop(**kw):
+        pass
+
+    monkeypatch.setattr("app.routers.auth.send_verification_email", _noop)
+
+    await client.post("/api/auth/register", json=_REG)
+    user = (
+        await session.execute(select(User).where(User.email == "alice@example.com"))
+    ).scalar_one()
+    tokens = (
+        await session.execute(
+            select(UserVerification).where(UserVerification.user_id == user.user_id)
+        )
+    ).scalars().all()
+    assert len(tokens) == 1
+    assert tokens[0].used is False
+
+
+async def test_register_fires_verification_email(
+    client: AsyncClient, monkeypatch
+):
+    sent: list[dict] = []
+
+    async def _capture(**kw):
+        sent.append(kw)
+
+    monkeypatch.setattr("app.routers.auth.send_verification_email", _capture)
+    await client.post("/api/auth/register", json=_REG)
+    assert len(sent) == 1
+    assert sent[0]["email"] == "alice@example.com"
+    assert sent[0]["firstname"] == "Alice"
+    assert len(sent[0]["token"]) > 10
+
+
+async def test_register_duplicate_unverified_resends_token(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    sent: list[dict] = []
+
+    async def _capture(**kw):
+        sent.append(kw)
+
+    monkeypatch.setattr("app.routers.auth.send_verification_email", _capture)
+    monkeypatch.setattr("app.routers.auth.send_account_exists_email", _capture)
+
+    await client.post("/api/auth/register", json=_REG)
+    r2 = await client.post("/api/auth/register", json=_REG)
+
+    assert r2.status_code == 201
+    assert len(sent) == 2
+    # second send should have a different token (old one invalidated)
+    assert sent[0]["token"] != sent[1]["token"]
+
+
+async def test_register_duplicate_verified_sends_account_exists(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    account_exists_sent: list[dict] = []
+
+    async def _noop(**kw):
+        pass
+
+    async def _capture_exists(**kw):
+        account_exists_sent.append(kw)
+
+    monkeypatch.setattr("app.routers.auth.send_verification_email", _noop)
+    monkeypatch.setattr("app.routers.auth.send_account_exists_email", _capture_exists)
+
+    # create verified user directly
+    from tests._helpers import hash_password
+
+    user = User(
+        user_id="verified-1",
+        firstname="Alice",
+        lastname="Smith",
+        email="alice@example.com",
+        password_hash=hash_password("correcthorsebatterystaple"),
+        email_verified=True,
+    )
+    session.add(user)
+    await session.commit()
+
+    r = await client.post("/api/auth/register", json=_REG)
+    assert r.status_code == 201
+    assert len(account_exists_sent) == 1
+    assert account_exists_sent[0]["email"] == "alice@example.com"

--- a/backend/tests/test_email_verification.py
+++ b/backend/tests/test_email_verification.py
@@ -370,3 +370,73 @@ async def test_resend_returns_200_for_already_verified(
         "/api/auth/resend-verification", json={"email": "done@example.com"}
     )
     assert r.status_code == 200
+
+
+# ── login gate ────────────────────────────────────────────────────────────────
+
+
+async def test_login_blocked_for_unverified_user(
+    client: AsyncClient, session: AsyncSession
+):
+    from tests._helpers import hash_password
+
+    user = User(
+        user_id="u-unverified-login",
+        firstname="Unver",
+        lastname="Ified",
+        email="unverified@example.com",
+        password_hash=hash_password("password1234"),
+        email_verified=False,
+    )
+    session.add(user)
+    await session.commit()
+    r = await client.post(
+        "/api/auth/login",
+        json={"email": "unverified@example.com", "password": "password1234"},
+    )
+    assert r.status_code == 403
+    assert "verified" in r.json()["detail"].lower()
+
+
+async def test_login_succeeds_for_verified_user(
+    client: AsyncClient, session: AsyncSession
+):
+    from tests._helpers import hash_password
+
+    user = User(
+        user_id="u-verified-login",
+        firstname="Ver",
+        lastname="Ified",
+        email="verified-login@example.com",
+        password_hash=hash_password("password1234"),
+        email_verified=True,
+    )
+    session.add(user)
+    await session.commit()
+    r = await client.post(
+        "/api/auth/login",
+        json={"email": "verified-login@example.com", "password": "password1234"},
+    )
+    assert r.status_code == 200
+
+
+async def test_login_wrong_password_still_401_not_403(
+    client: AsyncClient, session: AsyncSession
+):
+    from tests._helpers import hash_password
+
+    user = User(
+        user_id="u-wrong-pw",
+        firstname="Wrong",
+        lastname="Pass",
+        email="wrongpass@example.com",
+        password_hash=hash_password("correctpassword1234"),
+        email_verified=False,
+    )
+    session.add(user)
+    await session.commit()
+    r = await client.post(
+        "/api/auth/login",
+        json={"email": "wrongpass@example.com", "password": "wrongpassword"},
+    )
+    assert r.status_code == 401

--- a/backend/tests/test_email_verification.py
+++ b/backend/tests/test_email_verification.py
@@ -301,3 +301,72 @@ async def test_verify_email_expired_token_returns_400(
     await session.commit()
     r = await client.get("/api/auth/verify-email?token=expired-token")
     assert r.status_code == 400
+
+
+# ── resend-verification ───────────────────────────────────────────────────────
+
+
+async def test_resend_returns_200_for_unverified(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    sent: list[dict] = []
+
+    async def _capture(**kw):
+        sent.append(kw)
+
+    monkeypatch.setattr("app.routers.auth.send_verification_email", _capture)
+    await _create_unverified_user_with_token(session)
+    r = await client.post(
+        "/api/auth/resend-verification", json={"email": "verify@example.com"}
+    )
+    assert r.status_code == 200
+    assert "link" in r.json()["message"].lower()
+    assert len(sent) == 1
+
+
+async def test_resend_invalidates_old_token(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    async def _noop(**kw):
+        pass
+
+    monkeypatch.setattr("app.routers.auth.send_verification_email", _noop)
+
+    user, old_token = await _create_unverified_user_with_token(session)
+    await client.post(
+        "/api/auth/resend-verification", json={"email": "verify@example.com"}
+    )
+    old = (
+        await session.execute(
+            select(UserVerification).where(UserVerification.token == old_token)
+        )
+    ).scalar_one()
+    assert old.used is True
+
+
+async def test_resend_returns_200_for_unknown_email(client: AsyncClient):
+    r = await client.post(
+        "/api/auth/resend-verification", json={"email": "nobody@example.com"}
+    )
+    assert r.status_code == 200
+
+
+async def test_resend_returns_200_for_already_verified(
+    client: AsyncClient, session: AsyncSession
+):
+    from tests._helpers import hash_password
+
+    user = User(
+        user_id="u-already-verified",
+        firstname="Vera",
+        lastname="Done",
+        email="done@example.com",
+        password_hash=hash_password("password1234"),
+        email_verified=True,
+    )
+    session.add(user)
+    await session.commit()
+    r = await client.post(
+        "/api/auth/resend-verification", json={"email": "done@example.com"}
+    )
+    assert r.status_code == 200

--- a/backend/tests/test_email_verification.py
+++ b/backend/tests/test_email_verification.py
@@ -88,17 +88,19 @@ async def test_register_creates_verification_token(
         await session.execute(select(User).where(User.email == "alice@example.com"))
     ).scalar_one()
     tokens = (
-        await session.execute(
-            select(UserVerification).where(UserVerification.user_id == user.user_id)
+        (
+            await session.execute(
+                select(UserVerification).where(UserVerification.user_id == user.user_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(tokens) == 1
     assert tokens[0].used is False
 
 
-async def test_register_fires_verification_email(
-    client: AsyncClient, monkeypatch
-):
+async def test_register_fires_verification_email(client: AsyncClient, monkeypatch):
     sent: list[dict] = []
 
     async def _capture(**kw):
@@ -136,10 +138,14 @@ async def test_register_duplicate_unverified_resends_token(
         await session.execute(select(User).where(User.email == "alice@example.com"))
     ).scalar_one()
     all_tokens = (
-        await session.execute(
-            select(UserVerification).where(UserVerification.user_id == user.user_id)
+        (
+            await session.execute(
+                select(UserVerification).where(UserVerification.user_id == user.user_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     used_tokens = [t for t in all_tokens if t.used]
     active_tokens = [t for t in all_tokens if not t.used]
     assert len(used_tokens) == 1

--- a/backend/tests/test_email_verification.py
+++ b/backend/tests/test_email_verification.py
@@ -446,3 +446,68 @@ async def test_login_wrong_password_still_401_not_403(
         json={"email": "wrongpass@example.com", "password": "wrongpassword"},
     )
     assert r.status_code == 401
+
+
+# ── non-prod bypass ──────────────────────────────────────────────────────────
+
+
+async def test_register_in_dev_marks_user_verified_immediately(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    monkeypatch.setenv("APP_ENV", "dev")
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+
+    sent: list = []
+
+    async def _capture(**kw):
+        sent.append(kw)
+
+    monkeypatch.setattr("app.routers.auth.send_verification_email", _capture)
+
+    r = await client.post("/api/auth/register", json=_REG)
+    assert r.status_code == 201
+    user = (
+        await session.execute(select(User).where(User.email == "alice@example.com"))
+    ).scalar_one()
+    assert user.email_verified is True
+    # no token created, no email queued
+    tokens = (
+        (
+            await session.execute(
+                select(UserVerification).where(UserVerification.user_id == user.user_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert tokens == []
+    assert sent == []
+
+
+async def test_login_in_dev_allows_unverified_user(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    monkeypatch.setenv("APP_ENV", "dev")
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+
+    from tests._helpers import hash_password
+
+    user = User(
+        user_id="u-dev-unverified",
+        firstname="Dev",
+        lastname="Unver",
+        email="dev-unver@example.com",
+        password_hash=hash_password("password1234"),
+        email_verified=False,
+    )
+    session.add(user)
+    await session.commit()
+    r = await client.post(
+        "/api/auth/login",
+        json={"email": "dev-unver@example.com", "password": "password1234"},
+    )
+    assert r.status_code == 200

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -100,3 +100,31 @@ async def test_recipient_normalization(monkeypatch, to, expected):
     )
     await notifications.send_email(to, "s", "<p>h</p>")
     assert captured["to"] == expected
+
+
+async def test_send_verification_email_builds_correct_url(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "prod")
+    monkeypatch.setenv("RESEND_API_KEY", "re_test")
+    monkeypatch.setenv("APP_BASE_URL", "https://app.example.com")
+    payloads: list[dict] = []
+    monkeypatch.setattr(
+        notifications.resend.Emails, "send", lambda p: payloads.append(p)
+    )
+    await notifications.send_verification_email("bob@example.com", "tok123", "Bob")
+    assert len(payloads) == 1
+    assert payloads[0]["to"] == ["bob@example.com"]
+    assert "https://app.example.com/verify-email?token=tok123" in payloads[0]["html"]
+    assert "Bob" in payloads[0]["html"]
+
+
+async def test_send_account_exists_email_sends_warning(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "prod")
+    monkeypatch.setenv("RESEND_API_KEY", "re_test")
+    payloads: list[dict] = []
+    monkeypatch.setattr(
+        notifications.resend.Emails, "send", lambda p: payloads.append(p)
+    )
+    await notifications.send_account_exists_email("bob@example.com", "Bob")
+    assert len(payloads) == 1
+    assert payloads[0]["to"] == ["bob@example.com"]
+    assert "already exists" in payloads[0]["html"].lower()

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -1,5 +1,6 @@
 import pytest_asyncio
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import User
@@ -158,7 +159,6 @@ async def test_register_creates_user(client: AsyncClient, session: AsyncSession,
     data = r.json()
     assert "email" in data["message"].lower()
 
-    from sqlalchemy import select
     stored = (
         await session.execute(
             select(User).where(User.email == "cecilia@example.com")
@@ -190,12 +190,15 @@ async def test_register_rejects_invalid_email(client: AsyncClient):
     assert r.status_code == 422
 
 
-async def test_register_accepts_unicode_names(client: AsyncClient):
+async def test_register_accepts_unicode_names(client: AsyncClient, monkeypatch):
+    async def _noop(**kw): pass
+    monkeypatch.setattr("app.routers.auth.send_verification_email", _noop)
+
     payload = {
         **_REGISTER_PAYLOAD,
-        "email": "lukasz@example.com",
-        "firstname": "Łukasz",
-        "lastname": "O’Brien",
+        "email": "dog@example.com",
+        "firstname": "Dögg",
+        "lastname": "Not Ä'Dog",
     }
     r = await client.post("/api/auth/register", json=payload)
     assert r.status_code == 201

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -150,7 +150,9 @@ _REGISTER_PAYLOAD = {
 }
 
 
-async def test_register_creates_user(client: AsyncClient, session: AsyncSession, monkeypatch):
+async def test_register_creates_user(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
     async def _noop(**kw): pass
     monkeypatch.setattr("app.routers.auth.send_verification_email", _noop)
 
@@ -169,7 +171,9 @@ async def test_register_creates_user(client: AsyncClient, session: AsyncSession,
     assert verify_password(stored.password_hash, "hunter2hunter2")
 
 
-async def test_register_duplicate_email_no_enumeration(client: AsyncClient, test_user: User, monkeypatch):
+async def test_register_duplicate_email_no_enumeration(
+    client: AsyncClient, test_user: User, monkeypatch
+):
     async def _noop(**kw): pass
     monkeypatch.setattr("app.routers.auth.send_account_exists_email", _noop)
 

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -29,6 +29,7 @@ async def test_user(session: AsyncSession) -> User:
         password_hash=_hash("secretpassword"),
         boat_club="Göteborgs Segelsällskap",
         token_version=0,
+        email_verified=True,
     )
     session.add(user)
     await session.commit()
@@ -148,25 +149,33 @@ _REGISTER_PAYLOAD = {
 }
 
 
-async def test_register_creates_user(client: AsyncClient, session: AsyncSession):
+async def test_register_creates_user(client: AsyncClient, session: AsyncSession, monkeypatch):
+    async def _noop(**kw): pass
+    monkeypatch.setattr("app.routers.auth.send_verification_email", _noop)
+
     r = await client.post("/api/auth/register", json=_REGISTER_PAYLOAD)
     assert r.status_code == 201
     data = r.json()
-    assert data["email"] == "cecilia@example.com"
-    assert data["firstname"] == "Cecilia"
-    assert "password" not in data
-    assert "password_hash" not in data
-    assert data["user_id"]
+    assert "email" in data["message"].lower()
 
-    stored = await session.get(User, data["user_id"])
+    from sqlalchemy import select
+    stored = (
+        await session.execute(
+            select(User).where(User.email == "cecilia@example.com")
+        )
+    ).scalar_one()
     assert stored is not None
+    assert stored.email_verified is False
     assert verify_password(stored.password_hash, "hunter2hunter2")
 
 
-async def test_register_duplicate_email_conflict(client: AsyncClient, test_user: User):
+async def test_register_duplicate_email_no_enumeration(client: AsyncClient, test_user: User, monkeypatch):
+    async def _noop(**kw): pass
+    monkeypatch.setattr("app.routers.auth.send_account_exists_email", _noop)
+
     payload = {**_REGISTER_PAYLOAD, "email": test_user.email}
     r = await client.post("/api/auth/register", json=payload)
-    assert r.status_code == 409
+    assert r.status_code == 201
 
 
 async def test_register_rejects_short_password(client: AsyncClient):

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -153,7 +153,9 @@ _REGISTER_PAYLOAD = {
 async def test_register_creates_user(
     client: AsyncClient, session: AsyncSession, monkeypatch
 ):
-    async def _noop(**kw): pass
+    async def _noop(**kw):
+        pass
+
     monkeypatch.setattr("app.routers.auth.send_verification_email", _noop)
 
     r = await client.post("/api/auth/register", json=_REGISTER_PAYLOAD)
@@ -162,9 +164,7 @@ async def test_register_creates_user(
     assert "email" in data["message"].lower()
 
     stored = (
-        await session.execute(
-            select(User).where(User.email == "cecilia@example.com")
-        )
+        await session.execute(select(User).where(User.email == "cecilia@example.com"))
     ).scalar_one()
     assert stored is not None
     assert stored.email_verified is False
@@ -174,7 +174,9 @@ async def test_register_creates_user(
 async def test_register_duplicate_email_no_enumeration(
     client: AsyncClient, test_user: User, monkeypatch
 ):
-    async def _noop(**kw): pass
+    async def _noop(**kw):
+        pass
+
     monkeypatch.setattr("app.routers.auth.send_account_exists_email", _noop)
 
     payload = {**_REGISTER_PAYLOAD, "email": test_user.email}
@@ -195,7 +197,9 @@ async def test_register_rejects_invalid_email(client: AsyncClient):
 
 
 async def test_register_accepts_unicode_names(client: AsyncClient, monkeypatch):
-    async def _noop(**kw): pass
+    async def _noop(**kw):
+        pass
+
     monkeypatch.setattr("app.routers.auth.send_verification_email", _noop)
 
     payload = {

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -1368,6 +1368,18 @@ components:
       - request_id
       title: ResendDecommissionOut
       type: object
+    ResendVerificationIn:
+      properties:
+        email:
+          examples:
+          - alex@example.com
+          format: email
+          title: Email
+          type: string
+      required:
+      - email
+      title: ResendVerificationIn
+      type: object
     SnapshotAdoption:
       properties:
         err_last_15min:
@@ -3157,8 +3169,7 @@ paths:
         '201':
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/UserOut'
+              schema: {}
           description: Successful Response
         '422':
           content:
@@ -3167,6 +3178,55 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Register a new user
+      tags:
+      - auth
+  /api/auth/resend-verification:
+    post:
+      operationId: resendVerification
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResendVerificationIn'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {}
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Resend verification email
+      tags:
+      - auth
+  /api/auth/verify-email:
+    get:
+      operationId: verifyEmail
+      parameters:
+      - in: query
+        name: token
+        required: true
+        schema:
+          title: Token
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {}
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Verify email address using token from email link
       tags:
       - auth
   /api/berths:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -3097,6 +3097,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserOut'
           description: Successful Response
+        '401':
+          description: Invalid credentials
+        '403':
+          description: Email not verified
         '422':
           content:
             application/json:
@@ -3220,6 +3224,8 @@ paths:
             application/json:
               schema: {}
           description: Successful Response
+        '400':
+          description: Invalid or expired token
         '422':
           content:
             application/json:


### PR DESCRIPTION
## Summary


- New users must verify their email before logging in, register returns 201 with a message, no session cookies

- `GET /api/auth/verify-email?token=` marks the user verified and the token used (400 on invalid/expired/used)

- `POST /api/auth/resend-verification` resends the verification email. always returns 200 to prevent enumeration

- Login returns 403 with a clear message for unverified users (only after correct password, no enumeration
   risk)

- Alembic migration adds `user_verifications` table and `email_verified` column; backfills existing users to `true`

## Related Issue

Closes #82 

## Checklist

- [ ] Code compiles/builds without errors or warnings
- [ ] Code follows the project style guide and has been formatted
- [ ] All existing tests pass
- [ ] New functionality includes appropriate tests
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
