### PR TITLE
fix(fe): stop pointer propagation on panel close buttons for mobile

### DIFF
--- a/frontend/src/components/ActivityLogPanel.tsx
+++ b/frontend/src/components/ActivityLogPanel.tsx
@@ -36,6 +36,15 @@ export function ActivityLogPanel({
   onCloseCB,
 }: ActivityLogPanelProps) {
   const { user } = useOutletContext<AuthOutletContext>();
+
+  function handleClose(event: React.MouseEvent<HTMLButtonElement>) {
+    event.stopPropagation();
+    onCloseCB?.();
+  }
+
+  function handlePointerDown(event: React.PointerEvent<HTMLButtonElement>) {
+    event.stopPropagation();
+  }
   const isLoaded = !!user && user.role !== undefined;
   const isFirstLoad = useRef(true);
   const historyFetchedRef = useRef(false);
@@ -207,8 +216,9 @@ export function ActivityLogPanel({
         <button
           type="button"
           aria-label="Close activity log"
-          onClick={onCloseCB}
-          className="grid place-items-center w-10 h-10 rounded-full bg-[#0A2540]/5 text-[#0A2540]/60 active:bg-[#0A2540]/15 transition-colors cursor-pointer"
+          onPointerDown={handlePointerDown}
+          onClick={handleClose}
+          className="pointer-events-auto relative z-[130] grid place-items-center w-10 h-10 rounded-full bg-[#0A2540]/5 text-[#0A2540]/60 active:bg-[#0A2540]/15 transition-colors cursor-pointer"
         >
           <X size={16} strokeWidth={3} />
         </button>

--- a/frontend/src/components/HarborMasterOverview.tsx
+++ b/frontend/src/components/HarborMasterOverview.tsx
@@ -21,6 +21,15 @@ export function HarborMasterOverview({
   const now = useNow();
   const isFirstLoad = useRef(true);
 
+  function handleClose(event: React.MouseEvent<HTMLButtonElement>) {
+    event.stopPropagation();
+    onCloseCB?.();
+  }
+
+  function handlePointerDown(event: React.PointerEvent<HTMLButtonElement>) {
+    event.stopPropagation();
+  }
+
   useEffect(() => {
     const timer = setTimeout(() => {
       isFirstLoad.current = false;
@@ -65,8 +74,9 @@ export function HarborMasterOverview({
         <button
           type="button"
           aria-label="Close harbor overview"
-          onClick={onCloseCB}
-          className="grid place-items-center w-10 h-10 rounded-full bg-[#0A2540]/5 text-[#0A2540]/60 active:bg-[#0A2540]/15 transition-colors cursor-pointer"
+          onPointerDown={handlePointerDown}
+          onClick={handleClose}
+          className="pointer-events-auto relative z-[130] grid place-items-center w-10 h-10 rounded-full bg-[#0A2540]/5 text-[#0A2540]/60 active:bg-[#0A2540]/15 transition-colors cursor-pointer"
         >
           <X size={16} strokeWidth={3} />
         </button>


### PR DESCRIPTION
## Summary

Potential fix for mobile close button not working.

On mobile, tapping the X button generates a `pointerdown` event first, then a click.                                
                                                                                                                    
Without the fix, pointerdown bubbles up through the DOM and eventually hits the panzoom map listener, which calls 
 preventDefault(), cancelling the click before it fires. The onClick handler never runs, so the panel stays open.                                                                                                 
                  
With onPointerDown={handlePointerDown}` calling event.stopPropagation()`, the event is killed at the button itself  and never reaches panzoom. The click fires normally, `onClick` runs, panel closes.

I have not tested if it fixes the bug. Please do before merging.

See: 
https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events

Otherwise check:
https://developer.mozilla.org/en-US/docs/Web/API/Touch_events

## Related Issue

Closes #160 

## Changes

- Added `handleClose`: calls stopPropagation() then onCloseCB?.()                                                 
- Added handlePointerDown`: calls `stopPropagation()?
- Button: `onClick={onCloseCB}? -> `onClick={handleClose}, added `onPointerDown={handlePointerDown, added            
  pointer-events-auto relative z-[130] to className 

## Checklist

- [ ] Code compiles/builds without errors or warnings
- [ ] Code follows the project style guide and has been formatted
- [ ] All existing tests pass
- [ ] New functionality includes appropriate tests
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
