### PR TITLE
chore(db): hardening sweep across schema, ops and authz

### DIFF
--- a/backend/alembic/versions/7a4e1c2f9b30_add_events_alerts_time_indexes.py
+++ b/backend/alembic/versions/7a4e1c2f9b30_add_events_alerts_time_indexes.py
@@ -1,0 +1,39 @@
+"""add events/alerts time indexes
+
+Revision ID: 7a4e1c2f9b30
+Revises: 6c273ed76aa2
+Create Date: 2026-05-08
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "7a4e1c2f9b30"
+down_revision: str | Sequence[str] | None = "6c273ed76aa2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # composite covers berth-only queries via leftmost prefix, drop redundant
+    op.drop_index("ix_events_berth_id", table_name="events")
+    op.create_index(
+        "ix_events_berth_id_timestamp",
+        "events",
+        ["berth_id", sa.text("timestamp DESC")],
+    )
+    # serves recent-unacked dashboard query
+    op.create_index(
+        "ix_alerts_acknowledged_timestamp",
+        "alerts",
+        ["acknowledged", sa.text("timestamp DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_alerts_acknowledged_timestamp", table_name="alerts")
+    op.drop_index("ix_events_berth_id_timestamp", table_name="events")
+    op.create_index("ix_events_berth_id", "events", ["berth_id"])

--- a/backend/alembic/versions/8d51e7a3c4f2_add_adoption_requests_pending_unique.py
+++ b/backend/alembic/versions/8d51e7a3c4f2_add_adoption_requests_pending_unique.py
@@ -1,0 +1,35 @@
+"""add adoption_requests pending unique
+
+Revision ID: 8d51e7a3c4f2
+Revises: 7a4e1c2f9b30
+Create Date: 2026-05-08
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "8d51e7a3c4f2"
+down_revision: str | Sequence[str] | None = "7a4e1c2f9b30"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # one in-flight claim per (mesh_uuid, gateway_id), retries after expiry stay valid
+    op.create_index(
+        "uq_adoption_requests_pending_mesh_gateway",
+        "adoption_requests",
+        ["mesh_uuid", "gateway_id"],
+        unique=True,
+        postgresql_where=sa.text("status = 'pending'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_adoption_requests_pending_mesh_gateway",
+        table_name="adoption_requests",
+    )

--- a/backend/alembic/versions/c2f5a91d4b88_add_schema_constraints.py
+++ b/backend/alembic/versions/c2f5a91d4b88_add_schema_constraints.py
@@ -1,0 +1,54 @@
+"""add schema constraints
+
+Revision ID: c2f5a91d4b88
+Revises: 8d51e7a3c4f2
+Create Date: 2026-05-08
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c2f5a91d4b88"
+down_revision: str | Sequence[str] | None = "8d51e7a3c4f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # one label per dock, null labels skip the check
+    op.create_index(
+        "uq_berths_dock_id_label",
+        "berths",
+        ["dock_id", "label"],
+        unique=True,
+        postgresql_where=sa.text("label IS NOT NULL"),
+    )
+    # forbid zero/negative duration windows
+    op.create_check_constraint(
+        "ck_berth_availability_windows_dates",
+        "berth_availability_windows",
+        "return_date > from_date",
+    )
+    # revoke-all-for-user is a hot path on token rotation
+    op.create_index(
+        "ix_refresh_tokens_user_active",
+        "refresh_tokens",
+        ["user_id"],
+        postgresql_where=sa.text("revoked_at IS NULL"),
+    )
+    # harbor-wide free/occupied filters
+    op.create_index("ix_berths_status", "berths", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_berths_status", table_name="berths")
+    op.drop_index("ix_refresh_tokens_user_active", table_name="refresh_tokens")
+    op.drop_constraint(
+        "ck_berth_availability_windows_dates",
+        "berth_availability_windows",
+        type_="check",
+    )
+    op.drop_index("uq_berths_dock_id_label", table_name="berths")

--- a/backend/alembic/versions/d4f8b62e7c19_drop_users_role.py
+++ b/backend/alembic/versions/d4f8b62e7c19_drop_users_role.py
@@ -1,0 +1,43 @@
+"""drop users.role and user_role enum
+
+Revision ID: d4f8b62e7c19
+Revises: c2f5a91d4b88
+Create Date: 2026-05-08
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d4f8b62e7c19"
+down_revision: str | Sequence[str] | None = "c2f5a91d4b88"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # user_harbor_roles is the single source for harbormaster scoping
+    op.drop_column("users", "role")
+    sa.Enum(name="user_role").drop(op.get_bind(), checkfirst=False)
+
+
+def downgrade() -> None:
+    user_role = sa.Enum("harbormaster", "boat_owner", name="user_role")
+    user_role.create(op.get_bind(), checkfirst=False)
+    op.add_column(
+        "users",
+        sa.Column(
+            "role",
+            user_role,
+            nullable=False,
+            server_default="boat_owner",
+        ),
+    )
+    # backfill harbormaster from grants
+    op.execute(
+        "UPDATE users SET role = 'harbormaster' "
+        "WHERE user_id IN (SELECT user_id FROM user_harbor_roles)"
+    )
+    op.alter_column("users", "role", server_default=None)

--- a/backend/alembic/versions/e7c93a1f8420_add_audit_timestamps.py
+++ b/backend/alembic/versions/e7c93a1f8420_add_audit_timestamps.py
@@ -1,0 +1,83 @@
+"""add audit timestamps
+
+Revision ID: e7c93a1f8420
+Revises: d4f8b62e7c19
+Create Date: 2026-05-08
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e7c93a1f8420"
+down_revision: str | Sequence[str] | None = "d4f8b62e7c19"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+AUDITED_TABLES = ("harbors", "docks", "berths", "nodes", "alerts")
+
+
+def upgrade() -> None:
+    # trigger covers raw SQL paths the orm onupdate hook misses
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION set_updated_at() RETURNS trigger AS $$
+        BEGIN
+          NEW.updated_at = now();
+          RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    for table in AUDITED_TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+        )
+        op.add_column(
+            table,
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+        )
+        op.execute(
+            f"""
+            CREATE TRIGGER trg_{table}_updated_at
+            BEFORE UPDATE ON {table}
+            FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+            """
+        )
+
+    # cheap insurance, app still sets adopted_at explicitly
+    op.alter_column(
+        "nodes",
+        "adopted_at",
+        server_default=sa.func.now(),
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "nodes",
+        "adopted_at",
+        server_default=None,
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=False,
+    )
+    for table in AUDITED_TABLES:
+        op.execute(f"DROP TRIGGER IF EXISTS trg_{table}_updated_at ON {table};")
+        op.drop_column(table, "updated_at")
+        op.drop_column(table, "created_at")
+    op.execute("DROP FUNCTION IF EXISTS set_updated_at();")

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -23,8 +23,6 @@ CurrentUserDep = Annotated[User, Depends(get_current_user)]
 async def require_harbor_authority(
     user: CurrentUserDep, harbor_id: str, session: SessionDep
 ) -> User:
-    if user.role != "harbormaster":
-        raise HTTPException(status_code=403, detail="Harbormaster role required")
     row = await session.execute(
         select(UserHarborRole.user_id).where(
             UserHarborRole.user_id == user.user_id,
@@ -37,6 +35,23 @@ async def require_harbor_authority(
     return user
 
 
+async def require_any_harbormaster(
+    user: CurrentUserDep, session: SessionDep
+) -> User:
+    # 403 unless user has at least one harbormaster grant anywhere
+    row = await session.execute(
+        select(UserHarborRole.user_id)
+        .where(
+            UserHarborRole.user_id == user.user_id,
+            UserHarborRole.role == "harbormaster",
+        )
+        .limit(1)
+    )
+    if row.scalar_one_or_none() is None:
+        raise HTTPException(status_code=403, detail="Harbormaster role required")
+    return user
+
+
 async def user_managed_harbor_ids(user: User, session: AsyncSession) -> set[str]:
     result = await session.execute(
         select(UserHarborRole.harbor_id).where(
@@ -45,6 +60,15 @@ async def user_managed_harbor_ids(user: User, session: AsyncSession) -> set[str]
         )
     )
     return set(result.scalars().all())
+
+
+async def user_is_harbormaster(user: User, session: AsyncSession) -> bool:
+    row = await session.execute(
+        select(UserHarborRole.user_id)
+        .where(UserHarborRole.user_id == user.user_id)
+        .limit(1)
+    )
+    return row.scalar_one_or_none() is not None
 
 
 async def harbor_id_from_berth(berth_id: str, session: SessionDep) -> str:
@@ -152,3 +176,4 @@ HarbormasterForNodeDep = Annotated[User, Depends(require_harbormaster_for_node)]
 HarbormasterForAdoptionRequestDep = Annotated[
     User, Depends(require_harbormaster_for_adoption_request)
 ]
+AnyHarbormasterDep = Annotated[User, Depends(require_any_harbormaster)]

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -35,9 +35,7 @@ async def require_harbor_authority(
     return user
 
 
-async def require_any_harbormaster(
-    user: CurrentUserDep, session: SessionDep
-) -> User:
+async def require_any_harbormaster(user: CurrentUserDep, session: SessionDep) -> User:
     # 403 unless user has at least one harbormaster grant anywhere
     row = await session.execute(
         select(UserHarborRole.user_id)

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -8,13 +8,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
 from app import broadcaster
-from app.models import Berth, Event, Node, User
+from app.models import Berth, Dock, Event, Node, User, UserHarborRole
 from app.notifications import send_email
 from app.schemas import BerthUpdateEvent
 
 logger = logging.getLogger(__name__)
-
-# todo harbor-scope once User has harbor_id pages every hm right now
 
 
 def publish_berth_update(berth: Berth) -> None:
@@ -40,9 +38,15 @@ async def _notify_harbormasters(
     new_status: str,
     event_id: str,
 ) -> None:
+    # only harbormasters of the harbor that owns this berth
     result = await session.execute(
         select(User)
-        .where(User.role == "harbormaster")
+        .join(UserHarborRole, UserHarborRole.user_id == User.user_id)
+        .join(Dock, Dock.harbor_id == UserHarborRole.harbor_id)
+        .where(
+            Dock.dock_id == berth.dock_id,
+            UserHarborRole.role == "harbormaster",
+        )
         .options(joinedload(User.notification_prefs))
     )
     harbormasters = result.unique().scalars().all()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -31,6 +31,7 @@ class AuditTimestampsMixin:
         onupdate=func.now(),
     )
 
+
 berth_status_enum = Enum("free", "occupied", name="berth_status")
 event_type_enum = Enum(
     "occupied", "freed", "alert_unauthorized", "heartbeat", name="event_type"

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -158,9 +158,11 @@ class Event(Base):
 
     event_id: Mapped[str] = mapped_column(String, primary_key=True)
     berth_id: Mapped[str] = mapped_column(ForeignKey("berths.berth_id"), nullable=False)
+    # loose by design: events can predate the Node row during adoption
     node_id: Mapped[str] = mapped_column(String, nullable=False)
     event_type: Mapped[str] = mapped_column(event_type_enum, nullable=False)
     sensor_raw: Mapped[int] = mapped_column(Integer, nullable=False)
+    # mesh layer reassigns this on rejoin, kept as a per-event snapshot
     mesh_unicast_addr: Mapped[str] = mapped_column(String, nullable=False)
     timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -7,9 +7,11 @@ from sqlalchemy import (
     Double,
     Enum,
     ForeignKey,
+    Index,
     Integer,
     String,
     func,
+    text,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -52,6 +54,12 @@ class User(Base):
 
 class BerthAvailabilityWindow(Base):
     __tablename__ = "berth_availability_windows"
+    __table_args__ = (
+        CheckConstraint(
+            "return_date > from_date",
+            name="ck_berth_availability_windows_dates",
+        ),
+    )
 
     window_id: Mapped[str] = mapped_column(String, primary_key=True)
     berth_id: Mapped[str] = mapped_column(
@@ -99,6 +107,16 @@ class Dock(Base):
 
 class Berth(Base):
     __tablename__ = "berths"
+    __table_args__ = (
+        Index(
+            "uq_berths_dock_id_label",
+            "dock_id",
+            "label",
+            unique=True,
+            postgresql_where=text("label IS NOT NULL"),
+        ),
+        Index("ix_berths_status", "status"),
+    )
 
     berth_id: Mapped[str] = mapped_column(String, primary_key=True)
     dock_id: Mapped[str] = mapped_column(ForeignKey("docks.dock_id"), nullable=False)
@@ -122,6 +140,9 @@ class Berth(Base):
 
 class Event(Base):
     __tablename__ = "events"
+    __table_args__ = (
+        Index("ix_events_berth_id_timestamp", "berth_id", text("timestamp DESC")),
+    )
 
     event_id: Mapped[str] = mapped_column(String, primary_key=True)
     berth_id: Mapped[str] = mapped_column(ForeignKey("berths.berth_id"), nullable=False)
@@ -136,6 +157,13 @@ class Event(Base):
 
 class Alert(Base):
     __tablename__ = "alerts"
+    __table_args__ = (
+        Index(
+            "ix_alerts_acknowledged_timestamp",
+            "acknowledged",
+            text("timestamp DESC"),
+        ),
+    )
 
     alert_id: Mapped[str] = mapped_column(String, primary_key=True)
     berth_id: Mapped[str] = mapped_column(ForeignKey("berths.berth_id"), nullable=False)
@@ -202,6 +230,15 @@ class Node(Base):
 
 class AdoptionRequest(Base):
     __tablename__ = "adoption_requests"
+    __table_args__ = (
+        Index(
+            "uq_adoption_requests_pending_mesh_gateway",
+            "mesh_uuid",
+            "gateway_id",
+            unique=True,
+            postgresql_where=text("status = 'pending'"),
+        ),
+    )
 
     request_id: Mapped[str] = mapped_column(String, primary_key=True)
     mesh_uuid: Mapped[str] = mapped_column(String, nullable=False)
@@ -282,6 +319,13 @@ class UserHarborRole(Base):
 
 class RefreshToken(Base):
     __tablename__ = "refresh_tokens"
+    __table_args__ = (
+        Index(
+            "ix_refresh_tokens_user_active",
+            "user_id",
+            postgresql_where=text("revoked_at IS NULL"),
+        ),
+    )
 
     jti: Mapped[str] = mapped_column(String, primary_key=True)
     user_id: Mapped[str] = mapped_column(

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -97,7 +97,7 @@ class Dock(Base):
 
     dock_id: Mapped[str] = mapped_column(String, primary_key=True)
     harbor_id: Mapped[str] = mapped_column(
-        ForeignKey("harbors.harbor_id"), nullable=False
+        ForeignKey("harbors.harbor_id"), nullable=False, index=True
     )
     name: Mapped[str] = mapped_column(String, nullable=False)
 
@@ -119,7 +119,9 @@ class Berth(Base):
     )
 
     berth_id: Mapped[str] = mapped_column(String, primary_key=True)
-    dock_id: Mapped[str] = mapped_column(ForeignKey("docks.dock_id"), nullable=False)
+    dock_id: Mapped[str] = mapped_column(
+        ForeignKey("docks.dock_id"), nullable=False, index=True
+    )
     label: Mapped[str | None] = mapped_column(String)
     length_m: Mapped[float | None] = mapped_column(Double)
     width_m: Mapped[float | None] = mapped_column(Double)
@@ -166,7 +168,9 @@ class Alert(Base):
     )
 
     alert_id: Mapped[str] = mapped_column(String, primary_key=True)
-    berth_id: Mapped[str] = mapped_column(ForeignKey("berths.berth_id"), nullable=False)
+    berth_id: Mapped[str] = mapped_column(
+        ForeignKey("berths.berth_id"), nullable=False, index=True
+    )
     type: Mapped[str] = mapped_column(alert_type_enum, nullable=False)
     message: Mapped[str] = mapped_column(String, nullable=False)
     acknowledged: Mapped[bool] = mapped_column(Boolean, default=False)
@@ -209,13 +213,22 @@ class PendingGateway(Base):
 
 class Node(Base):
     __tablename__ = "nodes"
+    __table_args__ = (
+        # at most one live node per berth, decommissioned rows kept for history
+        Index(
+            "ix_nodes_berth_active",
+            "berth_id",
+            unique=True,
+            postgresql_where=text("status <> 'decommissioned'"),
+        ),
+    )
 
     node_id: Mapped[str] = mapped_column(String, primary_key=True)
     mesh_uuid: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     serial_number: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     berth_id: Mapped[str] = mapped_column(ForeignKey("berths.berth_id"), nullable=False)
     gateway_id: Mapped[str] = mapped_column(
-        ForeignKey("gateways.gateway_id"), nullable=False
+        ForeignKey("gateways.gateway_id"), nullable=False, index=True
     )
     mesh_unicast_addr: Mapped[str] = mapped_column(String, nullable=False)
     dev_key_fp: Mapped[str] = mapped_column(String, nullable=False)
@@ -224,7 +237,7 @@ class Node(Base):
         DateTime(timezone=True), nullable=False
     )
     adopted_by_user_id: Mapped[str | None] = mapped_column(
-        ForeignKey("users.user_id", ondelete="SET NULL"), nullable=True
+        ForeignKey("users.user_id", ondelete="SET NULL"), nullable=True, index=True
     )
 
 
@@ -238,6 +251,12 @@ class AdoptionRequest(Base):
             unique=True,
             postgresql_where=text("status = 'pending'"),
         ),
+        # sweeper hot path filters on pending only
+        Index(
+            "ix_adoption_requests_pending_expires_at",
+            "expires_at",
+            postgresql_where=text("status = 'pending'"),
+        ),
     )
 
     request_id: Mapped[str] = mapped_column(String, primary_key=True)
@@ -245,9 +264,11 @@ class AdoptionRequest(Base):
     serial_number: Mapped[str] = mapped_column(String, nullable=False)
     claim_jti: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     gateway_id: Mapped[str] = mapped_column(
-        ForeignKey("gateways.gateway_id"), nullable=False
+        ForeignKey("gateways.gateway_id"), nullable=False, index=True
     )
-    berth_id: Mapped[str] = mapped_column(ForeignKey("berths.berth_id"), nullable=False)
+    berth_id: Mapped[str] = mapped_column(
+        ForeignKey("berths.berth_id"), nullable=False, index=True
+    )
     expires_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
     )
@@ -259,7 +280,7 @@ class AdoptionRequest(Base):
     mesh_unicast_addr: Mapped[str | None] = mapped_column(String)
     dev_key_fp: Mapped[str | None] = mapped_column(String)
     created_by_user_id: Mapped[str | None] = mapped_column(
-        ForeignKey("users.user_id", ondelete="SET NULL"), nullable=True
+        ForeignKey("users.user_id", ondelete="SET NULL"), nullable=True, index=True
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -24,7 +24,6 @@ event_type_enum = Enum(
 alert_type_enum = Enum(
     "unauthorized_mooring", "sensor_offline", "low_battery", name="alert_type"
 )
-user_role_enum = Enum("harbormaster", "boat_owner", name="user_role")
 gateway_status_enum = Enum("online", "offline", name="gateway_status")
 node_status_enum = Enum("provisioned", "offline", "decommissioned", name="node_status")
 adoption_status_enum = Enum("pending", "ok", "err", name="adoption_status")
@@ -41,9 +40,6 @@ class User(Base):
     password_hash: Mapped[str] = mapped_column(String, nullable=False)
     boat_club: Mapped[str | None] = mapped_column(String)
     token_version: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    role: Mapped[str] = mapped_column(
-        user_role_enum, nullable=False, default="boat_owner"
-    )
     assignments: Mapped[list["Assignment"]] = relationship(
         back_populates="user", cascade="all, delete-orphan"
     )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -13,9 +13,23 @@ from sqlalchemy import (
     func,
     text,
 )
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, declarative_mixin, mapped_column, relationship
 
 from app.db import Base
+
+
+@declarative_mixin
+class AuditTimestampsMixin:
+    # trigger set_updated_at() is the source of truth, onupdate keeps orm consistent
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
 
 berth_status_enum = Enum("free", "occupied", name="berth_status")
 event_type_enum = Enum(
@@ -77,7 +91,7 @@ class BerthAvailabilityWindow(Base):
     )
 
 
-class Harbor(Base):
+class Harbor(AuditTimestampsMixin, Base):
     __tablename__ = "harbors"
 
     harbor_id: Mapped[str] = mapped_column(String, primary_key=True)
@@ -88,7 +102,7 @@ class Harbor(Base):
     docks: Mapped[list["Dock"]] = relationship(back_populates="harbor")
 
 
-class Dock(Base):
+class Dock(AuditTimestampsMixin, Base):
     __tablename__ = "docks"
 
     dock_id: Mapped[str] = mapped_column(String, primary_key=True)
@@ -101,7 +115,7 @@ class Dock(Base):
     berths: Mapped[list["Berth"]] = relationship(back_populates="dock")
 
 
-class Berth(Base):
+class Berth(AuditTimestampsMixin, Base):
     __tablename__ = "berths"
     __table_args__ = (
         Index(
@@ -153,7 +167,7 @@ class Event(Base):
     berth: Mapped["Berth"] = relationship(back_populates="events")
 
 
-class Alert(Base):
+class Alert(AuditTimestampsMixin, Base):
     __tablename__ = "alerts"
     __table_args__ = (
         Index(
@@ -207,7 +221,7 @@ class PendingGateway(Base):
     attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
 
 
-class Node(Base):
+class Node(AuditTimestampsMixin, Base):
     __tablename__ = "nodes"
     __table_args__ = (
         # at most one live node per berth, decommissioned rows kept for history
@@ -230,7 +244,7 @@ class Node(Base):
     dev_key_fp: Mapped[str] = mapped_column(String, nullable=False)
     status: Mapped[str] = mapped_column(node_status_enum, nullable=False)
     adopted_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False
+        DateTime(timezone=True), nullable=False, server_default=func.now()
     )
     adopted_by_user_id: Mapped[str | None] = mapped_column(
         ForeignKey("users.user_id", ondelete="SET NULL"), nullable=True, index=True

--- a/backend/app/routers/admin/users.py
+++ b/backend/app/routers/admin/users.py
@@ -81,12 +81,16 @@ async def list_users(session: SessionDep) -> list[dict]:
     rows = (await session.execute(select(User).order_by(User.email))).scalars().all()
     # one query for all harbormasters, avoids n+1 across user list
     hm_rows = (
-        await session.execute(
-            select(UserHarborRole.user_id).where(
-                UserHarborRole.role == "harbormaster"
+        (
+            await session.execute(
+                select(UserHarborRole.user_id).where(
+                    UserHarborRole.role == "harbormaster"
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     harbormaster_ids = set(hm_rows)
     return [
         {

--- a/backend/app/routers/admin/users.py
+++ b/backend/app/routers/admin/users.py
@@ -1,7 +1,7 @@
 """user crud + harbormaster harbor-grants"""
 
 import uuid
-from typing import Annotated, Literal
+from typing import Annotated
 
 from argon2 import PasswordHasher
 from fastapi import APIRouter, Depends, HTTPException
@@ -19,17 +19,16 @@ router = APIRouter()
 
 
 class UserCreate(BaseModel):
+    # role derived from user_harbor_roles, grant via grant_harbor after creation
     email: EmailStr
     password: SecretStr = Field(min_length=8, max_length=128)
     firstname: str = Field(min_length=1, max_length=64)
     lastname: str = Field(min_length=1, max_length=64)
-    role: Literal["harbormaster", "boat_owner"] = "boat_owner"
     phone: str | None = Field(default=None, max_length=32)
     boat_club: str | None = Field(default=None, max_length=128)
 
 
 class UserPatch(BaseModel):
-    role: Literal["harbormaster", "boat_owner"] | None = None
     firstname: str | None = Field(default=None, min_length=1, max_length=64)
     lastname: str | None = Field(default=None, min_length=1, max_length=64)
     phone: str | None = Field(default=None, max_length=32)
@@ -80,13 +79,22 @@ class GrantResultOut(BaseModel):
 )
 async def list_users(session: SessionDep) -> list[dict]:
     rows = (await session.execute(select(User).order_by(User.email))).scalars().all()
+    # one query for all harbormasters, avoids n+1 across user list
+    hm_rows = (
+        await session.execute(
+            select(UserHarborRole.user_id).where(
+                UserHarborRole.role == "harbormaster"
+            )
+        )
+    ).scalars().all()
+    harbormaster_ids = set(hm_rows)
     return [
         {
             "user_id": u.user_id,
             "email": u.email,
             "firstname": u.firstname,
             "lastname": u.lastname,
-            "role": u.role,
+            "role": "harbormaster" if u.user_id in harbormaster_ids else "boat_owner",
             "phone": u.phone,
             "boat_club": u.boat_club,
         }
@@ -118,13 +126,13 @@ async def create_user(
         firstname=body.firstname,
         lastname=body.lastname,
         password_hash=ph.hash(body.password.get_secret_value()),
-        role=body.role,
         phone=body.phone,
         boat_club=body.boat_club,
     )
     session.add(u)
     await session.commit()
-    return {"user_id": u.user_id, "email": u.email, "role": u.role}
+    # newly created user has no grants, always boat_owner until grant_harbor
+    return {"user_id": u.user_id, "email": u.email, "role": "boat_owner"}
 
 
 @router.patch(
@@ -136,12 +144,20 @@ async def patch_user(user_id: str, body: UserPatch, session: SessionDep) -> dict
     u = await session.get(User, user_id)
     if u is None:
         raise HTTPException(status_code=404, detail="User not found")
-    for field in ("role", "firstname", "lastname", "phone", "boat_club"):
+    for field in ("firstname", "lastname", "phone", "boat_club"):
         v = getattr(body, field)
         if v is not None:
             setattr(u, field, v)
     await session.commit()
-    return {"user_id": u.user_id, "email": u.email, "role": u.role}
+    has_grant = (
+        await session.execute(
+            select(UserHarborRole.user_id)
+            .where(UserHarborRole.user_id == user_id)
+            .limit(1)
+        )
+    ).scalar_one_or_none() is not None
+    role = "harbormaster" if has_grant else "boat_owner"
+    return {"user_id": u.user_id, "email": u.email, "role": role}
 
 
 @router.delete("/users/{user_id}", operation_id="adminDeleteUser", status_code=204)
@@ -190,14 +206,8 @@ async def list_user_grants(user_id: str, session: SessionDep) -> list[dict]:
     status_code=201,
 )
 async def grant_harbor(user_id: str, body: HarborGrant, session: SessionDep) -> dict:
-    user = await session.get(User, user_id)
-    if user is None:
+    if await session.get(User, user_id) is None:
         raise HTTPException(status_code=404, detail="User not found")
-    if user.role != "harbormaster":
-        raise HTTPException(
-            status_code=409,
-            detail=f"User has role {user.role!r}; promote to harbormaster first",
-        )
     if await session.get(Harbor, body.harbor_id) is None:
         raise HTTPException(
             status_code=404, detail=f"Harbor {body.harbor_id} not found"

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -22,6 +22,7 @@ from app.dependencies import CurrentUserDep, SessionDep
 from app.models import RefreshToken, User
 from app.rate_limit import limiter
 from app.schemas import LoginIn, UserCreate, UserOut
+from app.serializers import to_user_out
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
@@ -78,7 +79,7 @@ async def register(request: Request, body: UserCreate, session: SessionDep):
     session.add(user)
     await session.commit()
     await session.refresh(user)
-    return user
+    return await to_user_out(session, user)
 
 
 @router.post(
@@ -104,7 +105,7 @@ async def login(
 
     await _issue_session(user, response, session)
     await session.commit()
-    return user
+    return await to_user_out(session, user)
 
 
 @router.get(
@@ -113,8 +114,8 @@ async def login(
     operation_id="getCurrentUser",
     summary="Return the authenticated user",
 )
-async def me(current_user: CurrentUserDep) -> User:
-    return current_user
+async def me(current_user: CurrentUserDep, session: SessionDep) -> UserOut:
+    return await to_user_out(session, current_user)
 
 
 @router.post(

--- a/backend/app/routers/gateways.py
+++ b/backend/app/routers/gateways.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, Query
 from sqlalchemy import select
 
-from app.dependencies import CurrentUserDep, SessionDep, user_managed_harbor_ids
+from app.dependencies import AnyHarbormasterDep, SessionDep, user_managed_harbor_ids
 from app.models import Dock, Gateway, PendingGateway
 from app.schemas import GatewayOut, PendingGatewayOut
 
@@ -15,7 +15,7 @@ router = APIRouter(prefix="/api/gateways", tags=["gateways"])
     summary="List gateways visible to the harbormaster",
 )
 async def list_gateways(
-    user: CurrentUserDep,
+    user: AnyHarbormasterDep,
     session: SessionDep,
     harbor_id: str | None = Query(None, description="Filter by harbor"),
     dock_id: str | None = Query(None, description="Filter by dock"),
@@ -25,8 +25,6 @@ async def list_gateways(
         pattern="^(online|offline)$",
     ),
 ) -> list[GatewayOut]:
-    if user.role != "harbormaster":
-        raise HTTPException(status_code=403, detail="Harbormaster role required")
     managed = await user_managed_harbor_ids(user, session)
     if not managed:
         return []
@@ -53,12 +51,9 @@ async def list_gateways(
     summary="List unknown gateway ids seen on MQTT",
 )
 async def list_pending_gateways(
-    user: CurrentUserDep, session: SessionDep
+    user: AnyHarbormasterDep, session: SessionDep
 ) -> list[PendingGatewayOut]:
-    # any harbormaster sees the global list — there's no harbor mapping yet
-    # because pending rows precede dock association
-    if user.role != "harbormaster":
-        raise HTTPException(status_code=403, detail="Harbormaster role required")
+    # global list, pending rows precede dock association
     result = await session.execute(
         select(PendingGateway).order_by(PendingGateway.last_seen_at.desc())
     )
@@ -72,10 +67,8 @@ async def list_pending_gateways(
     summary="Dismiss a pending gateway entry",
 )
 async def dismiss_pending_gateway(
-    gateway_id: str, user: CurrentUserDep, session: SessionDep
+    gateway_id: str, user: AnyHarbormasterDep, session: SessionDep
 ) -> None:
-    if user.role != "harbormaster":
-        raise HTTPException(status_code=403, detail="Harbormaster role required")
     row = await session.get(PendingGateway, gateway_id)
     if row is None:
         raise HTTPException(status_code=404, detail="Pending gateway not found")

--- a/backend/app/routers/nodes.py
+++ b/backend/app/routers/nodes.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, Query
 from sqlalchemy import select
 
 from app.dependencies import (
-    CurrentUserDep,
+    AnyHarbormasterDep,
     HarbormasterForNodeDep,
     SessionDep,
     user_managed_harbor_ids,
@@ -65,7 +65,7 @@ def _to_health_out(node: Node, berth: Berth | None, now: datetime) -> dict:
     summary="List nodes with derived health",
 )
 async def list_nodes(
-    user: CurrentUserDep,
+    user: AnyHarbormasterDep,
     session: SessionDep,
     gateway_id: Annotated[str | None, Query(description="Filter by gateway")] = None,
     berth_id: Annotated[str | None, Query(description="Filter by berth")] = None,
@@ -73,8 +73,6 @@ async def list_nodes(
         HealthLiteral | None, Query(description="Filter by health")
     ] = None,
 ) -> list[dict]:
-    if user.role != "harbormaster":
-        raise HTTPException(status_code=403, detail="Harbormaster role required")
     managed = await user_managed_harbor_ids(user, session)
     if not managed:
         return []

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -5,7 +5,12 @@ from argon2.exceptions import VerifyMismatchError
 from fastapi import APIRouter, HTTPException, Query
 from sqlalchemy import select
 
-from app.dependencies import CurrentUserDep, HarbormasterForBerthDep, SessionDep
+from app.dependencies import (
+    CurrentUserDep,
+    HarbormasterForBerthDep,
+    SessionDep,
+    user_is_harbormaster,
+)
 from app.models import Assignment, User, UserNotificationPrefs
 from app.schemas import (
     NotificationPrefsOut,
@@ -13,6 +18,8 @@ from app.schemas import (
     UserOut,
     UserPatch,
 )
+from app.serializers import assigned_berth_id as _assigned_berth_id
+from app.serializers import to_user_out
 
 router = APIRouter(prefix="/api/users", tags=["users"])
 
@@ -21,32 +28,6 @@ _ph = PasswordHasher()
 
 def _hash_password(password: str) -> str:
     return _ph.hash(password)
-
-
-async def _assigned_berth_id(session, user_id: str) -> str | None:
-    # boat owner has at most one assignment in v1; pick first deterministically
-    result = await session.execute(
-        select(Assignment.berth_id)
-        .where(Assignment.user_id == user_id)
-        .order_by(Assignment.berth_id)
-        .limit(1)
-    )
-    return result.scalar_one_or_none()
-
-
-def _to_user_out(user: User, assigned_berth_id: str | None) -> UserOut:
-    return UserOut.model_validate(
-        {
-            "user_id": user.user_id,
-            "firstname": user.firstname,
-            "lastname": user.lastname,
-            "email": user.email,
-            "phone": user.phone,
-            "boat_club": user.boat_club,
-            "role": user.role,
-            "assigned_berth_id": assigned_berth_id,
-        }
-    )
 
 
 @router.get(
@@ -70,7 +51,7 @@ async def get_user_by_berth(
     user = await session.get(User, user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
-    return _to_user_out(user, berth_id)
+    return await to_user_out(session, user, berth_id)
 
 
 @router.get(
@@ -81,7 +62,7 @@ async def get_user_by_berth(
 )
 async def get_me(current_user: CurrentUserDep, session: SessionDep):
     berth_id = await _assigned_berth_id(session, current_user.user_id)
-    return _to_user_out(current_user, berth_id)
+    return await to_user_out(session, current_user, berth_id)
 
 
 @router.patch(
@@ -122,7 +103,7 @@ async def update_me(body: UserPatch, current_user: CurrentUserDep, session: Sess
     await session.commit()
     await session.refresh(current_user)
     berth_id = await _assigned_berth_id(session, current_user.user_id)
-    return _to_user_out(current_user, berth_id)
+    return await to_user_out(session, current_user, berth_id)
 
 
 @router.delete(
@@ -132,9 +113,8 @@ async def update_me(body: UserPatch, current_user: CurrentUserDep, session: Sess
     summary="Delete the current boat-owner account",
 )
 async def delete_me(current_user: CurrentUserDep, session: SessionDep):
-    # harbormasters own hardware adoption records; offboarding them is a
-    # separate admin flow, not self-service
-    if current_user.role != "boat_owner":
+    # harbormasters own hardware adoption records, offboarding is admin-only
+    if await user_is_harbormaster(current_user, session):
         raise HTTPException(
             status_code=403,
             detail="Harbormaster accounts cannot be self-deleted",

--- a/backend/app/serializers.py
+++ b/backend/app/serializers.py
@@ -1,0 +1,41 @@
+"""shared response serializers"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies import user_is_harbormaster
+from app.models import Assignment, User
+from app.schemas import UserOut
+
+
+async def assigned_berth_id(session: AsyncSession, user_id: str) -> str | None:
+    # boat owner has at most one assignment in v1, pick first deterministically
+    result = await session.execute(
+        select(Assignment.berth_id)
+        .where(Assignment.user_id == user_id)
+        .order_by(Assignment.berth_id)
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def to_user_out(
+    session: AsyncSession,
+    user: User,
+    berth_id: str | None = None,
+) -> UserOut:
+    if berth_id is None:
+        berth_id = await assigned_berth_id(session, user.user_id)
+    role = "harbormaster" if await user_is_harbormaster(user, session) else "boat_owner"
+    return UserOut.model_validate(
+        {
+            "user_id": user.user_id,
+            "firstname": user.firstname,
+            "lastname": user.lastname,
+            "email": user.email,
+            "phone": user.phone,
+            "boat_club": user.boat_club,
+            "role": role,
+            "assigned_berth_id": berth_id,
+        }
+    )

--- a/backend/scripts/dpcli/CONTRIBUTING.md
+++ b/backend/scripts/dpcli/CONTRIBUTING.md
@@ -91,6 +91,6 @@ firstname: Annotated[str, typer.Option(prompt=True)]
 password: Annotated[str, typer.Option(prompt=True, hide_input=True, confirmation_prompt=True)]
 
 # Enum — only accepts declared values, renders as [value1|value2] in --help
-# Usage: dpcli my-cmd --role harbormaster
-role: Annotated[Role, typer.Option(help="User role")] = Role.boat_owner
+# Usage: dpcli my-cmd --event-type occupied
+event_type: Annotated[EventType, typer.Option(help="Event type")] = EventType.occupied
 ```

--- a/backend/scripts/dpcli/README.md
+++ b/backend/scripts/dpcli/README.md
@@ -20,16 +20,14 @@ Override via env var if needed.
 ### Users
 
 ```bash
-dpcli create-user --email admin@harbor.se --role harbormaster
-# prompts for password; firstname/lastname default to "Harbor"/"Master" for
-# harbormasters (press enter to accept). boat_owner role still requires names.
-dpcli grant-harbor admin@harbor.se h1      # scope harbormaster authority to a harbor
-dpcli revoke-harbor admin@harbor.se h1
-dpcli promote-user admin@harbor.se
-dpcli demote-user admin@harbor.se
-dpcli list-users
-dpcli delete-user admin@harbor.se          # asks for confirmation; skip with --yes
+dpcli create-user --email admin@harbor.se   # prompts for password, firstname, lastname
+dpcli grant-harbor admin@harbor.se h1       # promotes to harbormaster scoped to harbor h1
+dpcli revoke-harbor admin@harbor.se h1      # remove harbormaster authority
+dpcli list-users                             # role column derived from harbor grants
+dpcli delete-user admin@harbor.se           # asks for confirmation; skip with --yes
 ```
+
+A user is a harbormaster iff they have at least one row in `user_harbor_roles`. There are no global promote/demote commands — grant or revoke a harbor instead.
 
 ### Harbor / Dock / Berths
 
@@ -80,6 +78,6 @@ dpcli ack-alert <alert-id>
 
 ```bash
 dpcli seed-db
-dpcli create-user --email admin@harbor.se --role harbormaster
+dpcli create-user --email admin@harbor.se
 dpcli grant-harbor admin@harbor.se h1
 ```

--- a/backend/scripts/dpcli/cli.py
+++ b/backend/scripts/dpcli/cli.py
@@ -37,11 +37,6 @@ _ph = PasswordHasher()
 _console = Console()
 
 
-class Role(StrEnum):
-    boat_owner = "boat_owner"
-    harbormaster = "harbormaster"
-
-
 # mirror DB enums in app/models.py so bad input fails before hitting Postgres
 class EventType(StrEnum):
     occupied = "occupied"
@@ -62,38 +57,17 @@ def create_user(
     password: Annotated[
         str, typer.Option(prompt=True, hide_input=True, confirmation_prompt=True)
     ],
-    role: Annotated[Role, typer.Option(help="User role")] = Role.boat_owner,
     firstname: Annotated[str | None, typer.Option()] = None,
     lastname: Annotated[str | None, typer.Option()] = None,
     phone: Annotated[str | None, typer.Option()] = None,
     boat_club: Annotated[str | None, typer.Option()] = None,
 ):
-    """Register a new user directly in the database."""
-    # harbormasters represent the harbor not a person, so accept generic defaults
-    is_hm = role == Role.harbormaster
+    """Register a new user. Use grant-harbor to make them a harbormaster."""
     if firstname is None:
-        firstname = typer.prompt("Firstname", default="Harbor" if is_hm else None)
+        firstname = typer.prompt("Firstname")
     if lastname is None:
-        lastname = typer.prompt("Lastname", default="Master" if is_hm else None)
-    asyncio.run(
-        _create_user(firstname, lastname, email, password, role, phone, boat_club)
-    )
-
-
-@app.command()
-def promote_user(
-    email: Annotated[str, typer.Argument(help="Email of the user to promote")],
-):
-    """Set a user's role to harbormaster."""
-    asyncio.run(_set_role(email, Role.harbormaster))
-
-
-@app.command()
-def demote_user(
-    email: Annotated[str, typer.Argument(help="Email of the user to demote")],
-):
-    """Set a user's role to boat_owner."""
-    asyncio.run(_set_role(email, Role.boat_owner))
+        lastname = typer.prompt("Lastname")
+    asyncio.run(_create_user(firstname, lastname, email, password, phone, boat_club))
 
 
 @app.command()
@@ -296,7 +270,6 @@ async def _create_user(
     lastname: str,
     email: str,
     password: str,
-    role: Role,
     phone: str | None,
     boat_club: str | None,
 ) -> None:
@@ -314,27 +287,11 @@ async def _create_user(
             phone=phone,
             boat_club=boat_club,
             password_hash=_ph.hash(password),
-            role=role.value,
         )
         session.add(user)
         await session.commit()
 
-    typer.echo(f"Created {role.value} {email}  (id: {user.user_id})")
-
-
-async def _set_role(email: str, role: Role) -> None:
-    async with get_sessionmaker()() as session:
-        result = await session.execute(select(User).where(User.email == email))
-        user = result.scalar_one_or_none()
-        if user is None:
-            typer.echo(f"Error: no user with email {email}", err=True)
-            raise typer.Exit(1)
-        if user.role == role.value:
-            typer.echo(f"{email} is already {role.value}")
-            return
-        user.role = role.value
-        await session.commit()
-    typer.echo(f"Set {email} to {role.value}")
+    typer.echo(f"Created user {email}  (id: {user.user_id})")
 
 
 async def _create_harbor(
@@ -468,13 +425,6 @@ async def _grant_harbor(email: str, harbor_id: str) -> None:
         if user is None:
             typer.echo(f"Error: no user with email {email}", err=True)
             raise typer.Exit(1)
-        if user.role != "harbormaster":
-            typer.echo(
-                f"Error: {email} has role {user.role!r}, must be harbormaster "
-                f"(use `dpcli promote-user {email}` first)",
-                err=True,
-            )
-            raise typer.Exit(1)
         if await session.get(Harbor, harbor_id) is None:
             typer.echo(f"Error: no harbor with id {harbor_id}", err=True)
             raise typer.Exit(1)
@@ -528,14 +478,22 @@ async def _list_users() -> None:
     async with get_sessionmaker()() as session:
         result = await session.execute(select(User).order_by(User.email))
         users = result.scalars().all()
+        # one query for all harbormaster ids, no n+1 across the user list
+        hm_rows = await session.execute(
+            select(UserHarborRole.user_id).where(
+                UserHarborRole.role == "harbormaster"
+            )
+        )
+        harbormaster_ids = set(hm_rows.scalars().all())
 
     table = Table("ID", "Email", "Name", "Role", "Phone", "Boat Club")
     for u in users:
+        role = "harbormaster" if u.user_id in harbormaster_ids else "boat_owner"
         table.add_row(
             u.user_id,
             u.email,
             f"{u.firstname} {u.lastname}",
-            u.role,
+            role,
             u.phone or "",
             u.boat_club or "",
         )

--- a/backend/scripts/dpcli/cli.py
+++ b/backend/scripts/dpcli/cli.py
@@ -480,9 +480,7 @@ async def _list_users() -> None:
         users = result.scalars().all()
         # one query for all harbormaster ids, no n+1 across the user list
         hm_rows = await session.execute(
-            select(UserHarborRole.user_id).where(
-                UserHarborRole.role == "harbormaster"
-            )
+            select(UserHarborRole.user_id).where(UserHarborRole.role == "harbormaster")
         )
         harbormaster_ids = set(hm_rows.scalars().all())
 

--- a/backend/tests/admin/test_users.py
+++ b/backend/tests/admin/test_users.py
@@ -3,7 +3,8 @@
 from httpx import AsyncClient
 
 
-async def test_create_harbormaster(client: AsyncClient, auth_headers):
+async def test_create_user_starts_as_boat_owner(client: AsyncClient, auth_headers):
+    # role derived from user_harbor_roles, no grant yet
     r = await client.post(
         "/api/admin/users",
         headers=auth_headers,
@@ -12,11 +13,10 @@ async def test_create_harbormaster(client: AsyncClient, auth_headers):
             "password": "supersecret123",
             "firstname": "Harbor",
             "lastname": "Master",
-            "role": "harbormaster",
         },
     )
     assert r.status_code == 201
-    assert r.json()["role"] == "harbormaster"
+    assert r.json()["role"] == "boat_owner"
 
 
 async def test_create_user_rejects_duplicate_email(
@@ -55,15 +55,16 @@ async def test_grant_harbor_to_harbormaster(
     assert r2.json()["noop"] is True
 
 
-async def test_grant_harbor_rejects_non_harbormaster(
+async def test_grant_harbor_promotes_boat_owner(
     client: AsyncClient, auth_headers, boat_owner, harbor_h1
 ):
+    # granting any user a harbor role makes them a harbormaster
     r = await client.post(
         f"/api/admin/users/{boat_owner.user_id}/harbor-grants",
         headers=auth_headers,
         json={"harbor_id": "h1"},
     )
-    assert r.status_code == 409
+    assert r.status_code == 201
 
 
 async def test_revoke_harbor(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -160,7 +160,6 @@ async def harbor_master(session: AsyncSession, harbor_h1) -> User:
         lastname="Master",
         email="hilda@example.com",
         password_hash=hash_password("secret"),
-        role="harbormaster",
     )
     session.add(user)
     await session.flush()
@@ -177,7 +176,6 @@ async def boat_owner(session: AsyncSession) -> User:
         lastname="Owner",
         email="olle@example.com",
         password_hash=hash_password("secret"),
-        role="boat_owner",
     )
     session.add(user)
     await session.commit()

--- a/backend/tests/test_assignment_api.py
+++ b/backend/tests/test_assignment_api.py
@@ -14,7 +14,6 @@ async def second_owner(session: AsyncSession) -> User:
         lastname="Owner",
         email="olga@example.com",
         password_hash=hash_password("secret"),
-        role="boat_owner",
     )
     session.add(user)
     await session.commit()

--- a/backend/tests/test_cookie_auth.py
+++ b/backend/tests/test_cookie_auth.py
@@ -23,7 +23,6 @@ async def _register_user(session: AsyncSession) -> User:
         lastname="Cookie",
         email="cora@example.com",
         password_hash=hash_password("supersecret"),
-        role="boat_owner",
     )
     session.add(user)
     await session.commit()

--- a/backend/tests/test_dependencies.py
+++ b/backend/tests/test_dependencies.py
@@ -35,10 +35,11 @@ async def test_require_harbor_authority_403_for_non_member(
 async def test_require_harbor_authority_403_for_boat_owner(
     session: AsyncSession, boat_owner: User, harbor_h1
 ):
+    # boat_owner has no UserHarborRole grant, same 403 as a non-member harbormaster
     with pytest.raises(HTTPException) as exc:
         await require_harbor_authority(boat_owner, "h1", session)
     assert exc.value.status_code == 403
-    assert exc.value.detail == "Harbormaster role required"
+    assert exc.value.detail == "Not authorized for this harbor"
 
 
 async def test_user_managed_harbor_ids_returns_membership_set(

--- a/backend/tests/test_dpcli.py
+++ b/backend/tests/test_dpcli.py
@@ -11,7 +11,6 @@ def test_help_lists_commands():
     # spot-check a few commands so import + registration regressions surface
     for cmd in (
         "create-user",
-        "promote-user",
         "grant-harbor",
         "revoke-harbor",
         "seed-db",

--- a/backend/tests/test_sweeper.py
+++ b/backend/tests/test_sweeper.py
@@ -14,14 +14,16 @@ def _make_request(
     expires_in: timedelta,
     status: str = "pending",
     completed_at: datetime | None = None,
+    mesh_uuid: str = "aaaa" * 8,
+    gateway_id: str = "gw1",
 ):
     now = datetime.now(UTC)
     return AdoptionRequest(
         request_id=request_id,
-        mesh_uuid="aaaa" * 8,
+        mesh_uuid=mesh_uuid,
         serial_number=f"sn-{request_id}",
         claim_jti=f"jti-{request_id}",
-        gateway_id="gw1",
+        gateway_id=gateway_id,
         berth_id="b1",
         expires_at=now + expires_in,
         status=status,
@@ -75,11 +77,18 @@ async def test_sweep_skips_already_completed_requests(
 async def test_sweep_handles_multiple_expired_requests(
     session: AsyncSession, harbor_world, harbor_master
 ):
+    # partial unique forbids dup pending per (mesh_uuid, gateway_id)
     session.add_all(
         [
-            _make_request("e1", expires_in=timedelta(seconds=-60)),
-            _make_request("e2", expires_in=timedelta(seconds=-30)),
-            _make_request("fresh", expires_in=timedelta(seconds=120)),
+            _make_request(
+                "e1", expires_in=timedelta(seconds=-60), mesh_uuid="aaaa" * 8
+            ),
+            _make_request(
+                "e2", expires_in=timedelta(seconds=-30), mesh_uuid="bbbb" * 8
+            ),
+            _make_request(
+                "fresh", expires_in=timedelta(seconds=120), mesh_uuid="cccc" * 8
+            ),
         ]
     )
     await session.commit()

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -14,8 +14,13 @@ services:
       - ./mosquitto-acl.conf:/mosquitto/config/acl.conf:ro
       - mqtt-pki:/mosquitto/certs:ro
 
+  db-migrate:
+    # picks up new revisions without rebuild
+    volumes:
+      - ./backend/alembic:/app/alembic
+
   backend:
-    command: sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
     environment:
       LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
       LOG_FORMAT: ${LOG_FORMAT:-text}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,26 @@ services:
     container_name: dockpulse-prod-db-migrate
     logging: *loki-logging
 
+  db-backup:
+    container_name: dockpulse-prod-db-backup
+    image: postgres:16-alpine
+    restart: unless-stopped
+    entrypoint: ["sh", "/scripts/pg-backup.sh"]
+    environment:
+      PGHOST: db
+      PGUSER: ${POSTGRES_USER:?POSTGRES_USER must be set}
+      PGPASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
+      PGDATABASE: ${POSTGRES_DB:?POSTGRES_DB must be set}
+      RETENTION_DAYS: ${PG_BACKUP_RETENTION_DAYS:-14}
+    volumes:
+      - ./tools/pg-backup.sh:/scripts/pg-backup.sh:ro
+      - pg-backups:/backups
+    depends_on:
+      db:
+        condition: service_healthy
+    networks: [internal]
+    logging: *loki-logging
+
   mosquitto:
     container_name: dockpulse-prod-mosquitto
     volumes: !override
@@ -132,3 +152,4 @@ networks:
 
 volumes:
   mqtt-certs:
+  pg-backups:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,10 @@ services:
     container_name: dockpulse-prod-db
     logging: *loki-logging
 
+  db-migrate:
+    container_name: dockpulse-prod-db-migrate
+    logging: *loki-logging
+
   mosquitto:
     container_name: dockpulse-prod-mosquitto
     volumes: !override

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -21,6 +21,10 @@ services:
       - /var/lib/postgresql/data
     logging: *loki-logging
 
+  db-migrate:
+    container_name: dockpulse-staging-db-migrate
+    logging: *loki-logging
+
   mosquitto:
     container_name: dockpulse-staging-mosquitto
     logging: *loki-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,11 +29,12 @@ services:
   db:
     container_name: dockpulse-db
     image: postgres:16-alpine
+    # tune shared_buffers via PGTune when host RAM > 2 GB
     restart: unless-stopped
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER must be set}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB must be set}
     volumes:
       - pgdata:/var/lib/postgresql/data
     networks: [internal]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,23 @@ services:
       start_period: 10s
     logging: *default-logging
 
+  db-migrate:
+    container_name: dockpulse-db-migrate
+    image: ghcr.io/ii1302-8/dockpulse-backend:${TAG:-staging}
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    # gates backend via service_completed_successfully, prevents replica DDL race
+    restart: "no"
+    command: ["alembic", "upgrade", "head"]
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+    depends_on:
+      db:
+        condition: service_healthy
+    networks: [internal]
+    logging: *default-logging
+
   backend:
     container_name: dockpulse-backend
     image: ghcr.io/ii1302-8/dockpulse-backend:${TAG:-staging}
@@ -71,7 +88,7 @@ services:
       context: .
       dockerfile: backend/Dockerfile
     restart: unless-stopped
-    command: sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       SECRET_KEY: ${SECRET_KEY:?SECRET_KEY must be set (32+ random bytes, e.g. openssl rand -hex 32)}
@@ -96,6 +113,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      db-migrate:
+        condition: service_completed_successfully
       mosquitto:
         condition: service_healthy
       cert-tools:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -1699,13 +1699,6 @@ components:
             type: string
           - type: 'null'
           title: Phone
-        role:
-          default: boat_owner
-          enum:
-          - harbormaster
-          - boat_owner
-          title: Role
-          type: string
       required:
       - email
       - password
@@ -1741,14 +1734,6 @@ components:
             type: string
           - type: 'null'
           title: Phone
-        role:
-          anyOf:
-          - enum:
-            - harbormaster
-            - boat_owner
-            type: string
-          - type: 'null'
-          title: Role
       title: UserPatch
       type: object
     app__schemas__UserCreate:

--- a/tools/pg-backup.sh
+++ b/tools/pg-backup.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# nightly pg_dump loop, retains last RETENTION_DAYS gz dumps in /backups
+set -eu
+
+: "${PGHOST:?PGHOST must be set}"
+: "${PGUSER:?PGUSER must be set}"
+: "${PGPASSWORD:?PGPASSWORD must be set}"
+: "${PGDATABASE:?PGDATABASE must be set}"
+
+BACKUP_DIR="${BACKUP_DIR:-/backups}"
+RETENTION_DAYS="${RETENTION_DAYS:-14}"
+SLEEP_SECONDS="${SLEEP_SECONDS:-86400}"
+
+mkdir -p "$BACKUP_DIR"
+
+while true; do
+    ts=$(date -u +%Y%m%d-%H%M%SZ)
+    out="$BACKUP_DIR/dockpulse-${ts}.sql.gz"
+    tmp="${out}.partial"
+    echo "[pg-backup] dumping ${PGDATABASE}@${PGHOST} -> ${out}"
+    if pg_dump --format=plain --no-owner --no-privileges "$PGDATABASE" | gzip -9 > "$tmp"; then
+        mv "$tmp" "$out"
+        echo "[pg-backup] wrote $(stat -c%s "$out") bytes"
+    else
+        echo "[pg-backup] dump failed, removing partial" >&2
+        rm -f "$tmp"
+    fi
+    find "$BACKUP_DIR" -maxdepth 1 -name 'dockpulse-*.sql.gz' -mtime +"$RETENTION_DAYS" -print -delete
+    sleep "$SLEEP_SECONDS"
+done


### PR DESCRIPTION
## Summary

Adds missing indexes/constraints, splits alembic into a one-shot service, drops the duplicate `User.role` in favour of `user_harbor_roles` as the single source of truth and adds audit timestamps.

## Changes

- a lot

## Checklist

- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [x] All existing tests pass
- [x] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
