### PR TITLE
feat(frontend): implement standalone Harbor Activity command center with audit tools

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from app.rate_limit import limiter
 from app.routers import (
     admin,
     adoptions,
+    alerts,
     auth,
     berths,
     docks,
@@ -189,6 +190,7 @@ if _cors_origins:
 
 app.include_router(admin.router)
 app.include_router(adoptions.router)
+app.include_router(alerts.router)
 app.include_router(auth.router)
 app.include_router(berths.router)
 app.include_router(docks.router)

--- a/backend/app/routers/alerts.py
+++ b/backend/app/routers/alerts.py
@@ -1,0 +1,90 @@
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Query
+from sqlalchemy import select, update
+
+from app.dependencies import (
+    AnyHarbormasterDep,
+    SessionDep,
+    user_managed_harbor_ids,
+)
+from app.models import Alert, Berth, Dock
+from app.schemas import AlertOut
+
+router = APIRouter(prefix="/api/alerts", tags=["alerts"])
+
+
+@router.get(
+    "",
+    response_model=list[AlertOut],
+    operation_id="listAlerts",
+    summary="List alerts in harbors the user manages",
+)
+async def list_alerts(
+    user: AnyHarbormasterDep,
+    session: SessionDep,
+    acknowledged: Annotated[
+        bool | None,
+        Query(
+            description=(
+                "filter by acknowledged flag; omit to return both states"
+            ),
+        ),
+    ] = None,
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+):
+    managed = await user_managed_harbor_ids(user, session)
+    if not managed:
+        return []
+    stmt = (
+        select(Alert)
+        .join(Berth, Berth.berth_id == Alert.berth_id)
+        .join(Dock, Dock.dock_id == Berth.dock_id)
+        .where(Dock.harbor_id.in_(managed))
+        .order_by(Alert.timestamp.desc())
+        .limit(limit)
+    )
+    if acknowledged is not None:
+        stmt = stmt.where(Alert.acknowledged == acknowledged)
+    rows = (await session.execute(stmt)).scalars().all()
+    return rows
+
+
+@router.post(
+    "/{alert_id}/acknowledge",
+    response_model=AlertOut,
+    operation_id="acknowledgeAlert",
+    summary="Mark an alert as acknowledged",
+)
+async def acknowledge_alert(
+    alert_id: str,
+    user: AnyHarbormasterDep,
+    session: SessionDep,
+):
+    # ensure the alert lives in a harbor this user manages before flipping
+    managed = await user_managed_harbor_ids(user, session)
+    if not managed:
+        raise HTTPException(status_code=404, detail="Alert not found")
+
+    row = (
+        await session.execute(
+            select(Alert)
+            .join(Berth, Berth.berth_id == Alert.berth_id)
+            .join(Dock, Dock.dock_id == Berth.dock_id)
+            .where(Alert.alert_id == alert_id, Dock.harbor_id.in_(managed))
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Alert not found")
+
+    # idempotent: re-acknowledging a row just returns the existing state
+    if not row.acknowledged:
+        await session.execute(
+            update(Alert)
+            .where(Alert.alert_id == alert_id)
+            .values(acknowledged=True, updated_at=datetime.now(UTC))
+        )
+        await session.commit()
+        await session.refresh(row)
+    return row

--- a/backend/app/routers/alerts.py
+++ b/backend/app/routers/alerts.py
@@ -27,9 +27,7 @@ async def list_alerts(
     acknowledged: Annotated[
         bool | None,
         Query(
-            description=(
-                "filter by acknowledged flag; omit to return both states"
-            ),
+            description=("filter by acknowledged flag; omit to return both states"),
         ),
     ] = None,
     limit: Annotated[int, Query(ge=1, le=500)] = 100,

--- a/backend/app/routers/harbors.py
+++ b/backend/app/routers/harbors.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Query
-from sqlalchemy import or_, select, union
+from sqlalchemy import func, or_, select, union
 
 from app.dependencies import (
     CurrentUserDep,
@@ -13,10 +13,11 @@ from app.models import (
     Berth,
     BerthAvailabilityWindow,
     Dock,
+    Event,
     Harbor,
     User,
 )
-from app.schemas import HarborOut, UserSearchOut
+from app.schemas import EventList, HarborOut, UserSearchOut
 
 router = APIRouter(prefix="/api/harbors", tags=["harbors"])
 
@@ -90,3 +91,36 @@ async def search_harbor_users(
 
     rows = (await session.execute(stmt)).scalars().all()
     return rows
+
+
+@router.get(
+    "/{harbor_id}/events",
+    response_model=EventList,
+    operation_id="listHarborEvents",
+    summary="List events for all berths in a harbor, paginated (harbormaster only)",
+)
+async def list_harbor_events(
+    harbor_id: str,
+    session: SessionDep,
+    _: HarbormasterForHarborDep,
+    event_type: Annotated[list[str] | None, Query()] = None,
+    limit: Annotated[int, Query(ge=1, le=500)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+):
+    # all events scoped to berths inside the harbor; supports server-side
+    # pagination so the FE can drop its in-memory cap
+    base = (
+        select(Event)
+        .join(Berth, Berth.berth_id == Event.berth_id)
+        .join(Dock, Dock.dock_id == Berth.dock_id)
+        .where(Dock.harbor_id == harbor_id)
+    )
+    if event_type:
+        base = base.where(Event.event_type.in_(event_type))
+
+    count_stmt = select(func.count()).select_from(base.subquery())
+    total = (await session.execute(count_stmt)).scalar_one()
+
+    page_stmt = base.order_by(Event.timestamp.desc()).limit(limit).offset(offset)
+    items = (await session.execute(page_stmt)).scalars().all()
+    return EventList(items=items, total=total)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -188,10 +188,18 @@ class BerthAvailabilityWindowIn(BaseModel):
 class EventOut(_BaseSchema):
     event_id: str = Field(examples=["evt-0001"])
     berth_id: str = Field(examples=["berth-001"])
-    node_id: str = Field(examples=["node-012"])
+    # audit events (e.g. assignment_removed) have no originating node
+    node_id: str | None = Field(default=None, examples=["node-012"])
     event_type: EventType
-    sensor_raw: int = Field(examples=[1234])
+    sensor_raw: int | None = Field(default=None, examples=[1234])
     timestamp: datetime = Field(examples=["2026-05-03T14:30:00Z"])
+    actor_user_id: str | None = Field(default=None, examples=["user-001"])
+    subject_user_id: str | None = Field(default=None, examples=["user-002"])
+
+
+class EventList(_BaseSchema):
+    items: list[EventOut]
+    total: int = Field(examples=[1234])
 
 
 class NodeOut(_BaseSchema):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -202,6 +202,18 @@ class EventList(_BaseSchema):
     total: int = Field(examples=[1234])
 
 
+AlertType = Literal["unauthorized_mooring", "sensor_offline", "low_battery"]
+
+
+class AlertOut(_BaseSchema):
+    alert_id: str = Field(examples=["alrt-0001"])
+    berth_id: str = Field(examples=["berth-001"])
+    type: AlertType
+    message: str = Field(examples=["Battery below 15%"])
+    acknowledged: bool = False
+    timestamp: datetime = Field(examples=["2026-05-03T14:30:00Z"])
+
+
 class NodeOut(_BaseSchema):
     node_id: str = Field(examples=["node-012"])
     mesh_uuid: str = Field(examples=["a1b2c3d4-e5f6-7890-abcd-ef1234567890"])

--- a/backend/tests/test_alerts_api.py
+++ b/backend/tests/test_alerts_api.py
@@ -1,0 +1,127 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Alert, Harbor
+from tests._helpers import auth_cookies as _creds
+
+
+@pytest_asyncio.fixture
+async def alerts_in_h1(session: AsyncSession, seeded_berth):
+    now = datetime.now(UTC)
+    session.add_all(
+        [
+            Alert(
+                alert_id="alrt-1",
+                berth_id="b1",
+                type="low_battery",
+                message="Battery at 12%",
+                acknowledged=False,
+                timestamp=now - timedelta(minutes=5),
+            ),
+            Alert(
+                alert_id="alrt-2",
+                berth_id="b1",
+                type="unauthorized_mooring",
+                message="Boat without invite",
+                acknowledged=True,
+                timestamp=now - timedelta(minutes=10),
+            ),
+        ]
+    )
+    await session.commit()
+
+
+async def test_list_alerts_returns_alerts_for_managed_harbors(
+    client: AsyncClient, alerts_in_h1, harbor_master
+):
+    r = await client.get("/api/alerts", cookies=_creds(harbor_master.user_id))
+    assert r.status_code == 200
+    body = r.json()
+    assert sorted(a["alert_id"] for a in body) == ["alrt-1", "alrt-2"]
+
+
+async def test_list_alerts_filter_unacknowledged(
+    client: AsyncClient, alerts_in_h1, harbor_master
+):
+    r = await client.get(
+        "/api/alerts?acknowledged=false",
+        cookies=_creds(harbor_master.user_id),
+    )
+    body = r.json()
+    assert [a["alert_id"] for a in body] == ["alrt-1"]
+
+
+async def test_list_alerts_requires_harbormaster_anywhere(
+    client: AsyncClient, alerts_in_h1, boat_owner
+):
+    r = await client.get("/api/alerts", cookies=_creds(boat_owner.user_id))
+    assert r.status_code == 403
+
+
+async def test_list_alerts_unauth_returns_401(
+    client: AsyncClient, alerts_in_h1
+):
+    r = await client.get("/api/alerts")
+    assert r.status_code == 401
+
+
+async def test_list_alerts_isolates_to_managed_harbors(
+    client: AsyncClient, alerts_in_h1, harbor_master, session
+):
+    # alert in a harbor harbor_master does not manage must not surface
+    session.add(Harbor(harbor_id="h2", name="Other"))
+    await session.commit()
+    r = await client.get("/api/alerts", cookies=_creds(harbor_master.user_id))
+    ids = sorted(a["alert_id"] for a in r.json())
+    assert ids == ["alrt-1", "alrt-2"]
+
+
+async def test_acknowledge_flips_flag(
+    client: AsyncClient, alerts_in_h1, harbor_master, session
+):
+    r = await client.post(
+        "/api/alerts/alrt-1/acknowledge",
+        cookies=_creds(harbor_master.user_id),
+    )
+    assert r.status_code == 200
+    assert r.json()["acknowledged"] is True
+    fresh = await session.get(Alert, "alrt-1")
+    assert fresh.acknowledged is True
+
+
+async def test_acknowledge_idempotent(
+    client: AsyncClient, alerts_in_h1, harbor_master
+):
+    r1 = await client.post(
+        "/api/alerts/alrt-2/acknowledge",
+        cookies=_creds(harbor_master.user_id),
+    )
+    r2 = await client.post(
+        "/api/alerts/alrt-2/acknowledge",
+        cookies=_creds(harbor_master.user_id),
+    )
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert r2.json()["acknowledged"] is True
+
+
+async def test_acknowledge_unknown_returns_404(
+    client: AsyncClient, alerts_in_h1, harbor_master
+):
+    r = await client.post(
+        "/api/alerts/missing/acknowledge",
+        cookies=_creds(harbor_master.user_id),
+    )
+    assert r.status_code == 404
+
+
+async def test_acknowledge_requires_harbormaster(
+    client: AsyncClient, alerts_in_h1, boat_owner
+):
+    r = await client.post(
+        "/api/alerts/alrt-1/acknowledge",
+        cookies=_creds(boat_owner.user_id),
+    )
+    assert r.status_code == 403

--- a/backend/tests/test_alerts_api.py
+++ b/backend/tests/test_alerts_api.py
@@ -61,9 +61,7 @@ async def test_list_alerts_requires_harbormaster_anywhere(
     assert r.status_code == 403
 
 
-async def test_list_alerts_unauth_returns_401(
-    client: AsyncClient, alerts_in_h1
-):
+async def test_list_alerts_unauth_returns_401(client: AsyncClient, alerts_in_h1):
     r = await client.get("/api/alerts")
     assert r.status_code == 401
 
@@ -92,9 +90,7 @@ async def test_acknowledge_flips_flag(
     assert fresh.acknowledged is True
 
 
-async def test_acknowledge_idempotent(
-    client: AsyncClient, alerts_in_h1, harbor_master
-):
+async def test_acknowledge_idempotent(client: AsyncClient, alerts_in_h1, harbor_master):
     r1 = await client.post(
         "/api/alerts/alrt-2/acknowledge",
         cookies=_creds(harbor_master.user_id),

--- a/backend/tests/test_harbors_api.py
+++ b/backend/tests/test_harbors_api.py
@@ -4,7 +4,13 @@ import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Assignment, BerthAvailabilityWindow, Harbor, User
+from app.models import (
+    Assignment,
+    BerthAvailabilityWindow,
+    Event,
+    Harbor,
+    User,
+)
 from tests._helpers import auth_cookies as _creds
 from tests._helpers import hash_password
 
@@ -152,6 +158,116 @@ async def test_search_harbor_users_isolates_harbors(
     await session.commit()
     r = await client.get(
         "/api/harbors/h2/users",
+        cookies=_creds(harbor_master.user_id),
+    )
+    assert r.status_code == 403
+
+
+# --- harbor events ---
+
+
+@pytest_asyncio.fixture
+async def harbor_events(session, seeded_berth, harbor_master):
+    now = datetime.now(UTC)
+    session.add_all(
+        [
+            Event(
+                event_id="ev-1",
+                berth_id="b1",
+                node_id="n1",
+                event_type="occupied",
+                sensor_raw=500,
+                mesh_unicast_addr="0x0042",
+                timestamp=now - timedelta(minutes=10),
+            ),
+            Event(
+                event_id="ev-2",
+                berth_id="b1",
+                node_id="n1",
+                event_type="freed",
+                sensor_raw=100,
+                mesh_unicast_addr="0x0042",
+                timestamp=now - timedelta(minutes=5),
+            ),
+            Event(
+                event_id="ev-3",
+                berth_id="b1",
+                event_type="assignment_removed",
+                actor_user_id=harbor_master.user_id,
+                timestamp=now,
+            ),
+        ]
+    )
+    await session.commit()
+
+
+async def test_list_harbor_events_paginates_newest_first(
+    client: AsyncClient, harbor_events, harbor_master
+):
+    r = await client.get(
+        "/api/harbors/h1/events?limit=2",
+        cookies=_creds(harbor_master.user_id),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 3
+    assert [e["event_id"] for e in body["items"]] == ["ev-3", "ev-2"]
+
+
+async def test_list_harbor_events_offset(
+    client: AsyncClient, harbor_events, harbor_master
+):
+    r = await client.get(
+        "/api/harbors/h1/events?limit=2&offset=2",
+        cookies=_creds(harbor_master.user_id),
+    )
+    body = r.json()
+    assert body["total"] == 3
+    assert [e["event_id"] for e in body["items"]] == ["ev-1"]
+
+
+async def test_list_harbor_events_filter_by_type(
+    client: AsyncClient, harbor_events, harbor_master
+):
+    r = await client.get(
+        "/api/harbors/h1/events?event_type=assignment_removed",
+        cookies=_creds(harbor_master.user_id),
+    )
+    body = r.json()
+    assert body["total"] == 1
+    assert body["items"][0]["event_id"] == "ev-3"
+    assert body["items"][0]["actor_user_id"] == harbor_master.user_id
+
+
+async def test_list_harbor_events_filter_multiple_types(
+    client: AsyncClient, harbor_events, harbor_master
+):
+    r = await client.get(
+        "/api/harbors/h1/events?event_type=occupied&event_type=freed",
+        cookies=_creds(harbor_master.user_id),
+    )
+    body = r.json()
+    assert body["total"] == 2
+    assert sorted(e["event_id"] for e in body["items"]) == ["ev-1", "ev-2"]
+
+
+async def test_list_harbor_events_requires_harbormaster(
+    client: AsyncClient, harbor_events, boat_owner
+):
+    r = await client.get(
+        "/api/harbors/h1/events",
+        cookies=_creds(boat_owner.user_id),
+    )
+    assert r.status_code == 403
+
+
+async def test_list_harbor_events_isolates_harbors(
+    client: AsyncClient, harbor_events, harbor_master, session
+):
+    session.add(Harbor(harbor_id="h2", name="Other"))
+    await session.commit()
+    r = await client.get(
+        "/api/harbors/h2/events",
         cookies=_creds(harbor_master.user_id),
     )
     assert r.status_code == 403

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -866,8 +866,33 @@ components:
       - name
       title: DockWithBerthsOut
       type: object
+    EventList:
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/EventOut'
+          title: Items
+          type: array
+        total:
+          examples:
+          - 1234
+          title: Total
+          type: integer
+      required:
+      - items
+      - total
+      title: EventList
+      type: object
     EventOut:
       properties:
+        actor_user_id:
+          anyOf:
+          - examples: &id014
+            - user-001
+            type: string
+          - type: 'null'
+          examples: *id014
+          title: Actor User Id
         berth_id:
           examples:
           - berth-001
@@ -888,15 +913,29 @@ components:
           title: Event Type
           type: string
         node_id:
-          examples:
-          - node-012
+          anyOf:
+          - examples: &id015
+            - node-012
+            type: string
+          - type: 'null'
+          examples: *id015
           title: Node Id
-          type: string
         sensor_raw:
-          examples:
-          - 1234
+          anyOf:
+          - examples: &id016
+            - 1234
+            type: integer
+          - type: 'null'
+          examples: *id016
           title: Sensor Raw
-          type: integer
+        subject_user_id:
+          anyOf:
+          - examples: &id017
+            - user-002
+            type: string
+          - type: 'null'
+          examples: *id017
+          title: Subject User Id
         timestamp:
           examples:
           - '2026-05-03T14:30:00Z'
@@ -906,9 +945,7 @@ components:
       required:
       - event_id
       - berth_id
-      - node_id
       - event_type
-      - sensor_raw
       - timestamp
       title: EventOut
       type: object
@@ -964,12 +1001,12 @@ components:
           type: string
         last_seen:
           anyOf:
-          - examples: &id014
+          - examples: &id018
             - '2026-05-03T14:30:00Z'
             format: date-time
             type: string
           - type: 'null'
-          examples: *id014
+          examples: *id018
           title: Last Seen
         name:
           examples:
@@ -978,12 +1015,12 @@ components:
           type: string
         provision_ttl_s:
           anyOf:
-          - examples: &id015
+          - examples: &id019
             - 180
             type: integer
           - type: 'null'
           description: Per-gateway override; null falls back to ADOPTION_TTL
-          examples: *id015
+          examples: *id019
           title: Provision Ttl S
         status:
           enum:
@@ -1259,11 +1296,11 @@ components:
           type: string
         battery_pct:
           anyOf:
-          - examples: &id016
+          - examples: &id020
             - 87
             type: integer
           - type: 'null'
-          examples: *id016
+          examples: *id020
           title: Battery Pct
         berth_id:
           examples:
@@ -1285,12 +1322,12 @@ components:
           type: string
         last_seen:
           anyOf:
-          - examples: &id017
+          - examples: &id021
             - '2026-05-03T14:30:00Z'
             format: date-time
             type: string
           - type: 'null'
-          examples: *id017
+          examples: *id021
           title: Last Seen
         mesh_unicast_addr:
           examples:
@@ -1333,11 +1370,11 @@ components:
           type: string
         battery_pct:
           anyOf:
-          - examples: &id018
+          - examples: &id022
             - 87
             type: integer
           - type: 'null'
-          examples: *id018
+          examples: *id022
           title: Battery Pct
         berth_id:
           examples:
@@ -1359,12 +1396,12 @@ components:
           type: string
         last_seen:
           anyOf:
-          - examples: &id019
+          - examples: &id023
             - '2026-05-03T14:30:00Z'
             format: date-time
             type: string
           - type: 'null'
-          examples: *id019
+          examples: *id023
           title: Last Seen
         mesh_unicast_addr:
           examples:
@@ -1722,19 +1759,19 @@ components:
       properties:
         assigned_berth_id:
           anyOf:
-          - examples: &id020
+          - examples: &id024
             - berth-001
             type: string
           - type: 'null'
-          examples: *id020
+          examples: *id024
           title: Assigned Berth Id
         boat_club:
           anyOf:
-          - examples: &id021
+          - examples: &id025
             - Saltsjöbadens BK
             type: string
           - type: 'null'
-          examples: *id021
+          examples: *id025
           title: Boat Club
         email:
           examples:
@@ -1754,11 +1791,11 @@ components:
           type: string
         phone:
           anyOf:
-          - examples: &id022
+          - examples: &id026
             - +46 70 123 45 67
             type: string
           - type: 'null'
-          examples: *id022
+          examples: *id026
           title: Phone
         role:
           enum:
@@ -1928,12 +1965,12 @@ components:
       properties:
         boat_club:
           anyOf:
-          - examples: &id023
+          - examples: &id027
             - Saltsjöbadens BK
             maxLength: 100
             type: string
           - type: 'null'
-          examples: *id023
+          examples: *id027
           title: Boat Club
         email:
           examples:
@@ -1968,13 +2005,13 @@ components:
           writeOnly: true
         phone:
           anyOf:
-          - examples: &id024
+          - examples: &id028
             - +46 70 123 45 67
             maxLength: 20
             pattern: ^\+?(?:[\s\-().]*\d){7,15}[\s\-().]*$
             type: string
           - type: 'null'
-          examples: *id024
+          examples: *id028
           title: Phone
       required:
       - firstname
@@ -1987,12 +2024,12 @@ components:
       properties:
         boat_club:
           anyOf:
-          - examples: &id025
+          - examples: &id029
             - Saltsjöbadens BK
             maxLength: 100
             type: string
           - type: 'null'
-          examples: *id025
+          examples: *id029
           title: Boat Club
         current_password:
           anyOf:
@@ -2003,38 +2040,38 @@ components:
           title: Current Password
         email:
           anyOf:
-          - examples: &id026
+          - examples: &id030
             - alex@example.com
             format: email
             type: string
           - type: 'null'
-          examples: *id026
+          examples: *id030
           title: Email
         firstname:
           anyOf:
-          - examples: &id027
+          - examples: &id031
             - Alex
             maxLength: 100
             minLength: 1
             pattern: ^[\p{L}\p{M}'’ .\-]+$
             type: string
           - type: 'null'
-          examples: *id027
+          examples: *id031
           title: Firstname
         lastname:
           anyOf:
-          - examples: &id028
+          - examples: &id032
             - Alex
             maxLength: 100
             minLength: 1
             pattern: ^[\p{L}\p{M}'’ .\-]+$
             type: string
           - type: 'null'
-          examples: *id028
+          examples: *id032
           title: Lastname
         password:
           anyOf:
-          - examples: &id029
+          - examples: &id033
             - correct horse battery staple
             format: password
             maxLength: 128
@@ -2042,17 +2079,17 @@ components:
             type: string
             writeOnly: true
           - type: 'null'
-          examples: *id029
+          examples: *id033
           title: Password
         phone:
           anyOf:
-          - examples: &id030
+          - examples: &id034
             - +46 70 123 45 67
             maxLength: 20
             pattern: ^\+?(?:[\s\-().]*\d){7,15}[\s\-().]*$
             type: string
           - type: 'null'
-          examples: *id030
+          examples: *id034
           title: Phone
       title: UserPatch
       type: object
@@ -4147,6 +4184,61 @@ paths:
       summary: Revoke a pending invite (harbormaster only)
       tags:
       - berth-invites
+  /api/harbors/{harbor_id}/events:
+    get:
+      operationId: listHarborEvents
+      parameters:
+      - in: path
+        name: harbor_id
+        required: true
+        schema:
+          title: Harbor Id
+          type: string
+      - in: query
+        name: event_type
+        required: false
+        schema:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Event Type
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 50
+          maximum: 500
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: query
+        name: offset
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          title: Offset
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventList'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - APIKeyCookie: []
+      summary: List events for all berths in a harbor, paginated (harbormaster only)
+      tags:
+      - harbors
   /api/harbors/{harbor_id}/users:
     get:
       operationId: searchHarborUsers

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -242,6 +242,48 @@ components:
       - request
       title: AdoptionUpdateEvent
       type: object
+    AlertOut:
+      properties:
+        acknowledged:
+          default: false
+          title: Acknowledged
+          type: boolean
+        alert_id:
+          examples:
+          - alrt-0001
+          title: Alert Id
+          type: string
+        berth_id:
+          examples:
+          - berth-001
+          title: Berth Id
+          type: string
+        message:
+          examples:
+          - Battery below 15%
+          title: Message
+          type: string
+        timestamp:
+          examples:
+          - '2026-05-03T14:30:00Z'
+          format: date-time
+          title: Timestamp
+          type: string
+        type:
+          enum:
+          - unauthorized_mooring
+          - sensor_offline
+          - low_battery
+          title: Type
+          type: string
+      required:
+      - alert_id
+      - berth_id
+      - type
+      - message
+      - timestamp
+      title: AlertOut
+      type: object
     AssignBerthIn:
       properties:
         user_id:
@@ -3294,6 +3336,78 @@ paths:
       summary: Subscribe to adoption progress via Server-Sent Events
       tags:
       - adoptions
+  /api/alerts:
+    get:
+      operationId: listAlerts
+      parameters:
+      - description: filter by acknowledged flag; omit to return both states
+        in: query
+        name: acknowledged
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: filter by acknowledged flag; omit to return both states
+          title: Acknowledged
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 100
+          maximum: 500
+          minimum: 1
+          title: Limit
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/AlertOut'
+                title: Response Listalerts
+                type: array
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - APIKeyCookie: []
+      summary: List alerts in harbors the user manages
+      tags:
+      - alerts
+  /api/alerts/{alert_id}/acknowledge:
+    post:
+      operationId: acknowledgeAlert
+      parameters:
+      - in: path
+        name: alert_id
+        required: true
+        schema:
+          title: Alert Id
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlertOut'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - APIKeyCookie: []
+      summary: Mark an alert as acknowledged
+      tags:
+      - alerts
   /api/auth/login:
     post:
       operationId: login

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,12 @@ const NotFound = lazy(() =>
   import("./pages/NotFound").then((m) => ({ default: m.NotFound })),
 );
 
+const ActivityLogPage = lazy(() =>
+  import("./pages/ActivityLogPage").then((m) => ({
+    default: m.ActivityLogPage,
+  })),
+);
+
 // validates :marinaSlug against the registry so unknown slugs 404
 // instead of rendering a generic dashboard for "marina admin" etc
 function MarinaGuard() {
@@ -146,6 +152,17 @@ export function App() {
                 <RequireAuth>
                   <Suspense fallback={<div className="h-full w-full" />}>
                     <InvitesSettings />
+                  </Suspense>
+                </RequireAuth>
+              }
+            />
+
+            <Route
+              path="activity"
+              element={
+                <RequireAuth>
+                  <Suspense fallback={<div className="h-full w-full" />}>
+                    <ActivityLogPage />
                   </Suspense>
                 </RequireAuth>
               }

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -435,6 +435,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/alerts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List alerts in harbors the user manages */
+        get: operations["listAlerts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/alerts/{alert_id}/acknowledge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Mark an alert as acknowledged */
+        post: operations["acknowledgeAlert"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/auth/login": {
         parameters: {
             query?: never;
@@ -1244,6 +1278,40 @@ export interface components {
              * @constant
              */
             type: "adoption.update";
+        };
+        /** AlertOut */
+        AlertOut: {
+            /**
+             * Acknowledged
+             * @default false
+             */
+            acknowledged: boolean;
+            /**
+             * Alert Id
+             * @example alrt-0001
+             */
+            alert_id: string;
+            /**
+             * Berth Id
+             * @example berth-001
+             */
+            berth_id: string;
+            /**
+             * Message
+             * @example Battery below 15%
+             */
+            message: string;
+            /**
+             * Timestamp
+             * Format: date-time
+             * @example 2026-05-03T14:30:00Z
+             */
+            timestamp: string;
+            /**
+             * Type
+             * @enum {string}
+             */
+            type: "unauthorized_mooring" | "sensor_offline" | "low_battery";
         };
         /** AssignBerthIn */
         AssignBerthIn: {
@@ -3522,6 +3590,70 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    listAlerts: {
+        parameters: {
+            query?: {
+                /** @description filter by acknowledged flag; omit to return both states */
+                acknowledged?: boolean | null;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    acknowledgeAlert: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                alert_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertOut"];
+                };
             };
             /** @description Validation Error */
             422: {

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -883,6 +883,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/harbors/{harbor_id}/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List events for all berths in a harbor, paginated (harbormaster only) */
+        get: operations["listHarborEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/harbors/{harbor_id}/users": {
         parameters: {
             query?: never;
@@ -1611,8 +1628,23 @@ export interface components {
              */
             name: string;
         };
+        /** EventList */
+        EventList: {
+            /** Items */
+            items: components["schemas"]["EventOut"][];
+            /**
+             * Total
+             * @example 1234
+             */
+            total: number;
+        };
         /** EventOut */
         EventOut: {
+            /**
+             * Actor User Id
+             * @example user-001
+             */
+            actor_user_id?: string | null;
             /**
              * Berth Id
              * @example berth-001
@@ -1632,12 +1664,17 @@ export interface components {
              * Node Id
              * @example node-012
              */
-            node_id: string;
+            node_id?: string | null;
             /**
              * Sensor Raw
              * @example 1234
              */
-            sensor_raw: number;
+            sensor_raw?: number | null;
+            /**
+             * Subject User Id
+             * @example user-002
+             */
+            subject_user_id?: string | null;
             /**
              * Timestamp
              * Format: date-time
@@ -4383,6 +4420,41 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    listHarborEvents: {
+        parameters: {
+            query?: {
+                event_type?: string[] | null;
+                limit?: number;
+                offset?: number;
+            };
+            header?: never;
+            path: {
+                harbor_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventList"];
+                };
             };
             /** @description Validation Error */
             422: {

--- a/frontend/src/components/ActivityLogPanel.tsx
+++ b/frontend/src/components/ActivityLogPanel.tsx
@@ -1,7 +1,15 @@
-import { Clock, ExternalLink, Flag, X } from "lucide-react";
+import {
+  Activity,
+  CheckCircle2,
+  Clock,
+  ExternalLink,
+  Flag,
+  X,
+} from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import type { components } from "../api-types";
+import { useActiveAlerts } from "../hooks/useActiveAlerts";
 import { useActivityLog } from "../hooks/useActivityLog";
 import { cn } from "../lib/utils";
 
@@ -14,6 +22,7 @@ interface ActivityLogPanelProps {
 }
 
 const PANEL_LIMIT = 25;
+type Tab = "activity" | "alerts";
 
 export function ActivityLogPanel({
   berths,
@@ -22,7 +31,9 @@ export function ActivityLogPanel({
 }: ActivityLogPanelProps) {
   const { marinaSlug } = useParams<{ marinaSlug: string }>();
   const { events, isLoaded } = useActivityLog(berths, PANEL_LIMIT);
+  const { alerts, acknowledgeAlert } = useActiveAlerts();
   const isFirstLoad = useRef(true);
+  const [activeTab, setActiveTab] = useState<Tab>("activity");
   const [filterType, setFilterType] = useState<string>("all");
 
   useEffect(() => {
@@ -77,19 +88,23 @@ export function ActivityLogPanel({
           : "pointer-events-none translate-y-[150%] opacity-0 lg:-translate-x-[150%] lg:translate-y-0",
       )}
     >
-      <header className="mb-6 flex items-center justify-between">
+      <header className="mb-4 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Flag size={16} className="text-brand-blue" strokeWidth={2.5} />
           <h2 className="text-xs font-black uppercase tracking-[0.2em] text-[#0A2540]/40">
-            Activity Log
+            {activeTab === "activity" ? "Activity Log" : "Critical Alerts"}
           </h2>
-          {marinaSlug && (
+          {activeTab === "activity" && marinaSlug && (
             <Link
               to={`/${marinaSlug}/activity`}
-              className="ml-1 flex items-center gap-1 text-[8px] font-black uppercase tracking-widest text-brand-blue/60 transition-colors hover:text-brand-blue"
+              className="group ml-1 flex items-center gap-1 text-[8px] font-black uppercase tracking-widest text-brand-blue/60 transition-colors hover:text-brand-blue"
             >
               <span>Full log</span>
-              <ExternalLink size={10} strokeWidth={2.5} />
+              <ExternalLink
+                size={10}
+                strokeWidth={2.5}
+                className="transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+              />
             </Link>
           )}
         </div>
@@ -105,36 +120,124 @@ export function ActivityLogPanel({
         </button>
       </header>
 
-      <div className="mb-4 flex flex-wrap gap-2">
-        {(["all", "status_change", "owner_assignment", "alert"] as const).map(
-          (t) => (
-            <button
-              key={t}
-              type="button"
-              onClick={() => setFilterType(t)}
-              className={cn(
-                "rounded-full px-3 py-1.5 text-[9px] font-black uppercase tracking-widest transition-colors",
-                filterType === t
-                  ? "bg-brand-blue text-white"
-                  : "bg-[#0A2540]/5 text-[#0A2540]/60 hover:bg-[#0A2540]/10",
-              )}
-            >
-              {t === "all"
-                ? "All"
-                : t === "status_change"
-                  ? "Status"
-                  : t === "owner_assignment"
-                    ? "Owners"
-                    : "Alerts"}
-            </button>
-          ),
-        )}
+      <div className="relative mb-4 flex rounded-full bg-brand-navy/5 p-1">
+        <button
+          type="button"
+          onClick={() => setActiveTab("activity")}
+          className={cn(
+            "flex h-9 flex-1 items-center justify-center gap-2 rounded-full text-[10px] font-black uppercase tracking-widest transition-all",
+            activeTab === "activity"
+              ? "bg-white text-brand-navy shadow-sm"
+              : "text-brand-navy/40 hover:text-brand-navy/70",
+          )}
+        >
+          <Activity size={11} strokeWidth={3} />
+          Activity
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab("alerts")}
+          className={cn(
+            "relative flex h-9 flex-1 items-center justify-center gap-2 rounded-full text-[10px] font-black uppercase tracking-widest transition-all",
+            activeTab === "alerts"
+              ? "bg-white text-amber-600 shadow-sm"
+              : "text-brand-navy/40 hover:text-brand-navy/70",
+          )}
+        >
+          Alerts
+          {alerts.length > 0 && (
+            <span className="absolute -right-1 -top-1 flex h-4 w-4 animate-in zoom-in items-center justify-center rounded-full bg-amber-500 text-[8px] font-black text-white ring-2 ring-white">
+              {alerts.length}
+            </span>
+          )}
+        </button>
       </div>
 
+      {activeTab === "activity" && (
+        <div className="mb-4 flex flex-wrap gap-2">
+          {(["all", "status_change", "owner_assignment", "alert"] as const).map(
+            (t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => setFilterType(t)}
+                className={cn(
+                  "rounded-full px-3 py-1.5 text-[9px] font-black uppercase tracking-widest transition-colors",
+                  filterType === t
+                    ? "bg-brand-blue text-white"
+                    : "bg-[#0A2540]/5 text-[#0A2540]/60 hover:bg-[#0A2540]/10",
+                )}
+              >
+                {t === "all"
+                  ? "All"
+                  : t === "status_change"
+                    ? "Status"
+                    : t === "owner_assignment"
+                      ? "Owners"
+                      : "Alerts"}
+              </button>
+            ),
+          )}
+        </div>
+      )}
+
       <ul className="custom-scrollbar -mx-2 flex-1 space-y-2 overflow-y-auto px-2">
-        {filteredEvents.length === 0 ? (
-          <li className="py-12 text-center text-[10px] font-bold uppercase tracking-widest text-brand-navy/20">
-            No activity yet
+        {activeTab === "alerts" ? (
+          alerts.length === 0 ? (
+            <li className="flex flex-col items-center justify-center py-12 text-center opacity-40">
+              <div className="mb-3 grid h-14 w-14 place-items-center rounded-full bg-emerald-50 text-emerald-500">
+                <CheckCircle2 size={28} />
+              </div>
+              <p className="text-[10px] font-black uppercase tracking-widest text-brand-navy">
+                No active alerts
+              </p>
+              <p className="mt-1 text-[9px] font-bold text-brand-navy/40">
+                Everything looks clear
+              </p>
+            </li>
+          ) : (
+            alerts.map((alert) => (
+              <li
+                key={alert.alert_id}
+                className="relative overflow-hidden rounded-2xl border border-amber-200/50 bg-amber-50/80 p-4 shadow-sm"
+              >
+                <div className="absolute left-0 top-0 h-full w-1 bg-amber-400" />
+                <div className="mb-2 flex items-center justify-between">
+                  <span className="text-[10px] font-black uppercase tracking-widest text-amber-600">
+                    Berth {alert.berth_id}
+                  </span>
+                  <span className="text-[8px] font-bold text-amber-500/60">
+                    {new Date(alert.timestamp).toLocaleTimeString([], {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                  </span>
+                </div>
+                <p className="mb-3 text-[11px] font-bold leading-relaxed text-amber-900/80">
+                  {alert.message}
+                </p>
+                <div className="flex items-center justify-between border-t border-amber-200/30 pt-3">
+                  <span className="text-[9px] font-black uppercase tracking-wider text-amber-500/70">
+                    {alert.type.replace(/_/g, " ")}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => acknowledgeAlert(alert.alert_id)}
+                    className="flex items-center gap-1.5 rounded-full bg-amber-500 px-3 py-1.5 text-[9px] font-black uppercase tracking-widest text-white shadow-md shadow-amber-500/20 transition-all hover:bg-amber-600 active:scale-95"
+                  >
+                    <CheckCircle2 size={10} strokeWidth={3} />
+                    Acknowledge
+                  </button>
+                </div>
+              </li>
+            ))
+          )
+        ) : filteredEvents.length === 0 ? (
+          <li className="flex flex-col items-center justify-center py-12 text-center">
+            <Clock size={28} className="mb-2 text-brand-navy/10" />
+            <p className="text-[10px] font-bold uppercase tracking-widest text-brand-navy/30">
+              Waiting for activity...
+            </p>
           </li>
         ) : (
           filteredEvents.map((ev) => (

--- a/frontend/src/components/ActivityLogPanel.tsx
+++ b/frontend/src/components/ActivityLogPanel.tsx
@@ -1,203 +1,47 @@
-import { Activity, Clock, X } from "lucide-react";
+import { Clock, ExternalLink, Flag, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { useOutletContext } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import type { components } from "../api-types";
-import { apiFetch } from "../lib/api";
+import { useActivityLog } from "../hooks/useActivityLog";
 import { cn } from "../lib/utils";
-import type { AuthOutletContext } from "./layout/MainLayout";
 
 type Berth = components["schemas"]["BerthOut"];
-
-interface ActivityEvent {
-  id: string;
-  timestamp: Date;
-  type: "status_change" | "owner_assignment";
-  berthId: string;
-  berthLabel: string;
-  details: string;
-  status?: string;
-}
 
 interface ActivityLogPanelProps {
   berths: Berth[];
   isOpen?: boolean;
-  onCloseCB?: () => void;
+  onCloseCB: () => void;
 }
 
-const STORAGE_KEY_PREFIX = "dockpulse_activity_log";
-
-function storageKeyFor(userId: string) {
-  return `${STORAGE_KEY_PREFIX}:${userId}`;
-}
+const PANEL_LIMIT = 25;
 
 export function ActivityLogPanel({
   berths,
   isOpen,
   onCloseCB,
 }: ActivityLogPanelProps) {
-  const { user } = useOutletContext<AuthOutletContext>();
-  const isLoaded = !!user && user.role !== undefined;
+  const { marinaSlug } = useParams<{ marinaSlug: string }>();
+  const { events, isLoaded } = useActivityLog(berths, PANEL_LIMIT);
   const isFirstLoad = useRef(true);
-  const historyFetchedRef = useRef(false);
-
-  const [events, setEvents] = useState<ActivityEvent[]>([]);
   const [filterType, setFilterType] = useState<string>("all");
-  const prevBerthsRef = useRef<Map<string, Berth>>(new Map());
-
-  useEffect(() => {
-    if (!user?.user_id) return;
-
-    const saved = localStorage.getItem(storageKeyFor(user.user_id));
-    if (!saved) return;
-
-    try {
-      const parsed = JSON.parse(saved);
-      setEvents(
-        parsed.map((e: ActivityEvent) => ({
-          ...e,
-          timestamp: new Date(e.timestamp),
-        })),
-      );
-    } catch (err) {
-      console.error("Failed to load activity log from localStorage", err);
-    }
-  }, [user?.user_id]);
-
-  useEffect(() => {
-    if (!user?.user_id) return;
-    localStorage.setItem(storageKeyFor(user.user_id), JSON.stringify(events));
-  }, [events, user?.user_id]);
 
   useEffect(() => {
     if (isLoaded) {
       const timer = setTimeout(() => {
         isFirstLoad.current = false;
       }, 100);
-
       return () => clearTimeout(timer);
     }
   }, [isLoaded]);
 
-  useEffect(() => {
-    if (!isLoaded || historyFetchedRef.current) return;
-    if (berths.length === 0) return;
-
-    historyFetchedRef.current = true;
-
-    async function fetchInitialHistory() {
-      const sampleBerths = berths.slice(0, 10);
-
-      const results = await Promise.all(
-        sampleBerths.map(async (berth) => {
-          try {
-            const res = await apiFetch(
-              `/api/berths/${berth.berth_id}/events?limit=5`,
-            );
-
-            if (!res.ok) return [] as ActivityEvent[];
-
-            const data = await res.json();
-
-            return data.map(
-              (ev: {
-                event_id: string;
-                timestamp: string;
-                event_type: string;
-              }) => ({
-                id: ev.event_id,
-                timestamp: new Date(ev.timestamp),
-                type: "status_change" as const,
-                berthId: berth.berth_id,
-                berthLabel: berth.label || berth.berth_id,
-                details: `Berth status was ${ev.event_type}`,
-                status: ev.event_type,
-              }),
-            );
-          } catch (err) {
-            console.error(`Failed to fetch history for ${berth.berth_id}`, err);
-            return [] as ActivityEvent[];
-          }
-        }),
-      );
-
-      const historyEvents = results.flat();
-      if (historyEvents.length === 0) return;
-
-      setEvents((prev) => {
-        const seen = new Set<string>();
-
-        return [...prev, ...historyEvents]
-          .filter((e) => {
-            if (seen.has(e.id)) return false;
-            seen.add(e.id);
-            return true;
-          })
-          .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
-          .slice(0, 100);
-      });
-    }
-
-    fetchInitialHistory();
-  }, [isLoaded, berths]);
-
-  useEffect(() => {
-    const newEvents: ActivityEvent[] = [];
-    const currentBerths = new Map(berths.map((b) => [b.berth_id, b]));
-
-    if (prevBerthsRef.current.size > 0) {
-      for (const [id, berth] of currentBerths.entries()) {
-        const prev = prevBerthsRef.current.get(id);
-        if (!prev) continue;
-
-        const prevUnavailable = prev.status === "occupied" || prev.is_reserved;
-        const nextUnavailable =
-          berth.status === "occupied" || berth.is_reserved;
-        if (prevUnavailable !== nextUnavailable) {
-          const fromLabel = prevUnavailable ? "Unavailable" : "Available";
-          const toLabel = nextUnavailable ? "Unavailable" : "Available";
-          newEvents.push({
-            id: crypto.randomUUID(),
-            timestamp: new Date(),
-            type: "status_change",
-            berthId: id,
-            berthLabel: berth.label || id,
-            details: `Status changed from ${fromLabel} to ${toLabel}`,
-            status: berth.status,
-          });
-        }
-
-        if (
-          prev.assignment?.user_id !== berth.assignment?.user_id &&
-          berth.assignment?.user_id
-        ) {
-          newEvents.push({
-            id: crypto.randomUUID(),
-            timestamp: new Date(),
-            type: "owner_assignment",
-            berthId: id,
-            berthLabel: berth.label || id,
-            details: "New owner assigned to berth",
-          });
-        }
-      }
-    }
-
-    if (newEvents.length > 0) {
-      setEvents((prev) => [...newEvents, ...prev].slice(0, 100));
-    }
-
-    prevBerthsRef.current = currentBerths;
-  }, [berths]);
-
   const activeOpen = isOpen && isLoaded;
-
   const filteredEvents = events.filter((e) => {
     if (filterType === "all") return true;
     return e.type === filterType;
   });
 
   function closePanel() {
-    onCloseCB?.();
+    onCloseCB();
   }
 
   function handleCloseClick(event: React.MouseEvent<HTMLButtonElement>) {
@@ -222,9 +66,10 @@ export function ActivityLogPanel({
   return (
     <section
       className={cn(
-        "fixed z-[var(--z-panel)] flex flex-col overflow-hidden rounded-[32px] border border-white/60 bg-white/70 p-6 font-body shadow-deep backdrop-blur-2xl transition-all duration-500 ease-in-out",
+        "fixed border border-white/60 bg-white/70 shadow-deep backdrop-blur-2xl",
         "bottom-[calc(env(safe-area-inset-bottom)+7rem)] left-6 right-6 max-h-[55dvh]",
         "lg:bottom-auto lg:right-auto lg:left-[var(--sidebar-total-offset,32px)] lg:top-32 lg:w-80 lg:max-h-[calc(100vh-160px)]",
+        "z-[var(--z-panel)] flex flex-col overflow-hidden rounded-[32px] p-6 font-body transition-all duration-500 ease-in-out",
         (!isLoaded || isFirstLoad.current) &&
           "pointer-events-none opacity-0 transition-none",
         activeOpen
@@ -234,12 +79,20 @@ export function ActivityLogPanel({
     >
       <header className="mb-6 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Activity size={16} className="text-brand-blue" strokeWidth={2.5} />
+          <Flag size={16} className="text-brand-blue" strokeWidth={2.5} />
           <h2 className="text-xs font-black uppercase tracking-[0.2em] text-[#0A2540]/40">
             Activity Log
           </h2>
+          {marinaSlug && (
+            <Link
+              to={`/${marinaSlug}/activity`}
+              className="ml-1 flex items-center gap-1 text-[8px] font-black uppercase tracking-widest text-brand-blue/60 transition-colors hover:text-brand-blue"
+            >
+              <span>Full log</span>
+              <ExternalLink size={10} strokeWidth={2.5} />
+            </Link>
+          )}
         </div>
-
         <button
           type="button"
           aria-label="Close activity log"
@@ -252,80 +105,62 @@ export function ActivityLogPanel({
         </button>
       </header>
 
-      <div className="mb-6 grid grid-cols-3 gap-2">
-        {[
-          { id: "all", label: "All" },
-          { id: "status_change", label: "Status" },
-          { id: "owner_assignment", label: "Owners" },
-        ].map((btn) => (
-          <button
-            key={btn.id}
-            type="button"
-            onClick={() => setFilterType(btn.id)}
-            className={cn(
-              "min-w-0 rounded-full px-2 py-2 text-[9px] font-black uppercase tracking-wider transition-all sm:text-[10px]",
-              filterType === btn.id
-                ? "bg-brand-blue text-white shadow-lg shadow-brand-blue/20"
-                : "bg-white/50 text-brand-navy/40 hover:bg-white/80",
-            )}
-          >
-            <span className="block truncate">{btn.label}</span>
-          </button>
-        ))}
+      <div className="mb-4 flex flex-wrap gap-2">
+        {(["all", "status_change", "owner_assignment", "alert"] as const).map(
+          (t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setFilterType(t)}
+              className={cn(
+                "rounded-full px-3 py-1.5 text-[9px] font-black uppercase tracking-widest transition-colors",
+                filterType === t
+                  ? "bg-brand-blue text-white"
+                  : "bg-[#0A2540]/5 text-[#0A2540]/60 hover:bg-[#0A2540]/10",
+              )}
+            >
+              {t === "all"
+                ? "All"
+                : t === "status_change"
+                  ? "Status"
+                  : t === "owner_assignment"
+                    ? "Owners"
+                    : "Alerts"}
+            </button>
+          ),
+        )}
       </div>
 
-      <div className="custom-scrollbar no-scrollbar flex-1 space-y-3 overflow-y-auto pr-2">
+      <ul className="custom-scrollbar -mx-2 flex-1 space-y-2 overflow-y-auto px-2">
         {filteredEvents.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-12 text-center">
-            <Clock size={32} className="mb-2 text-brand-navy/10" />
-            <p className="text-[10px] font-bold uppercase tracking-widest text-brand-navy/30">
-              Waiting for activity...
-            </p>
-          </div>
+          <li className="py-12 text-center text-[10px] font-bold uppercase tracking-widest text-brand-navy/20">
+            No activity yet
+          </li>
         ) : (
-          filteredEvents.map((event) => (
-            <article
-              key={event.id}
-              className="rounded-2xl border border-white/50 bg-white/80 p-4 shadow-subtle transition-all duration-300 animate-in fade-in slide-in-from-bottom-2 hover:shadow-md"
+          filteredEvents.map((ev) => (
+            <li
+              key={ev.id}
+              className="rounded-2xl border border-white/60 bg-white/60 p-3 shadow-sm"
             >
-              <div className="mb-2 flex items-center justify-between">
-                <span className="text-[10px] font-black uppercase tracking-widest text-brand-blue">
-                  Berth {event.berthLabel}
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-[11px] font-black text-brand-navy">
+                  {ev.berthLabel}
                 </span>
-
-                <span className="text-[8px] font-bold text-brand-navy/30">
-                  {event.timestamp.toLocaleTimeString([], {
+                <span className="flex items-center gap-1 text-[8px] font-bold uppercase tracking-widest text-brand-navy/30">
+                  <Clock size={9} strokeWidth={3} />
+                  {ev.timestamp.toLocaleTimeString([], {
                     hour: "2-digit",
                     minute: "2-digit",
-                    second: "2-digit",
                   })}
                 </span>
               </div>
-
-              <p className="text-[11px] font-bold leading-relaxed text-brand-navy/70">
-                {event.details}
+              <p className="mt-1 text-[10px] font-bold text-brand-navy/60">
+                {ev.details}
               </p>
-
-              {event.status && (
-                <div className="mt-2 flex items-center gap-2">
-                  <div
-                    className={cn(
-                      "h-1.5 w-1.5 rounded-full",
-                      event.status === "occupied"
-                        ? "animate-pulse bg-red-500"
-                        : "bg-emerald-500",
-                    )}
-                  />
-
-                  <span className="text-[9px] font-black uppercase tracking-wider text-brand-navy/40">
-                    {event.status}
-                  </span>
-                </div>
-              )}
-            </article>
+            </li>
           ))
         )}
-      </div>
+      </ul>
     </section>
   );
 }

--- a/frontend/src/components/layout/AuthDialog.tsx
+++ b/frontend/src/components/layout/AuthDialog.tsx
@@ -6,7 +6,12 @@ import { apiFetch } from "../../lib/api";
 import { useAuth } from "../../lib/auth-context";
 import { cn } from "../../lib/utils";
 import { Button } from "../shared/ui/button";
-import { Dialog, DialogContent, DialogTitle } from "../shared/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "../shared/ui/dialog";
 import { Input } from "../shared/ui/input";
 import { Label } from "../shared/ui/label";
 import { PasswordInput } from "../shared/ui/password-input";
@@ -237,6 +242,9 @@ export function AuthDialog({
           <DialogTitle>
             {isForgot ? "Reset password" : "Log in or sign up"}
           </DialogTitle>
+          <DialogDescription>
+            Authentication dialog to log in or create an account.
+          </DialogDescription>
         </VisuallyHidden.Root>
 
         <div className="space-y-6">

--- a/frontend/src/hooks/useActiveAlerts.ts
+++ b/frontend/src/hooks/useActiveAlerts.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from "react";
+import type { components } from "../api-types";
+import { apiFetch } from "../lib/api";
+
+export type Alert = components["schemas"]["AlertOut"];
+
+const POLL_INTERVAL_MS = 30_000;
+
+export function useActiveAlerts() {
+  const [alerts, setAlerts] = useState<Alert[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await apiFetch("/api/alerts?acknowledged=false");
+      if (!res.ok) {
+        // 401/403 happens for non-harbormaster users; stay quiet, don't error
+        if (res.status === 401 || res.status === 403) {
+          setAlerts([]);
+          return;
+        }
+        setError(`Could not load alerts (status ${res.status}).`);
+        return;
+      }
+      setAlerts((await res.json()) as Alert[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not load alerts.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    const interval = window.setInterval(() => {
+      if (document.visibilityState === "visible") load();
+    }, POLL_INTERVAL_MS);
+    return () => window.clearInterval(interval);
+  }, [load]);
+
+  const acknowledgeAlert = useCallback(async (alertId: string) => {
+    // optimistic: drop from the local list immediately
+    setAlerts((prev) => prev.filter((a) => a.alert_id !== alertId));
+    try {
+      await apiFetch(`/api/alerts/${alertId}/acknowledge`, { method: "POST" });
+    } catch (err) {
+      console.warn("Failed to acknowledge alert", err);
+    }
+  }, []);
+
+  return { alerts, isLoading, error, acknowledgeAlert, refresh: load };
+}

--- a/frontend/src/hooks/useActivityLog.ts
+++ b/frontend/src/hooks/useActivityLog.ts
@@ -1,0 +1,194 @@
+import { useEffect, useRef, useState } from "react";
+import type { components } from "../api-types";
+import { apiFetch } from "../lib/api";
+import { useAuth } from "../lib/auth-context";
+
+type Berth = components["schemas"]["BerthOut"];
+
+export interface ActivityEvent {
+  id: string;
+  timestamp: Date;
+  type: "status_change" | "owner_assignment" | "alert";
+  berthId: string;
+  berthLabel: string;
+  details: string;
+  status?: string;
+}
+
+const STORAGE_KEY_PREFIX = "dockpulse_activity_log";
+
+function storageKeyFor(userId: string) {
+  return `${STORAGE_KEY_PREFIX}:${userId}`;
+}
+
+export function useActivityLog(berths: Berth[], maxEvents: number) {
+  const { user } = useAuth();
+  const isLoaded = !!user && user.role !== undefined;
+  const historyFetchedRef = useRef(false);
+  const [events, setEvents] = useState<ActivityEvent[]>([]);
+  const prevBerthsRef = useRef<Map<string, Berth>>(new Map());
+
+  const clearLog = () => {
+    if (user?.user_id) {
+      localStorage.removeItem(storageKeyFor(user.user_id));
+      setEvents([]);
+    }
+  };
+
+  // hydrate from per-user key once user is known
+  useEffect(() => {
+    if (!user?.user_id) return;
+    const saved = localStorage.getItem(storageKeyFor(user.user_id));
+    if (!saved) return;
+    try {
+      const parsed = JSON.parse(saved);
+      const hydrated = parsed.map((e: ActivityEvent) => ({
+        ...e,
+        timestamp: new Date(e.timestamp),
+      }));
+      // ensure we respect the limit of the current consumer (sidebar vs page)
+      setEvents(hydrated.slice(0, maxEvents));
+    } catch (err) {
+      console.error("Failed to load activity log from localStorage", err);
+    }
+  }, [user?.user_id, maxEvents]);
+
+  // persist to localStorage
+  useEffect(() => {
+    if (!user?.user_id) return;
+    localStorage.setItem(storageKeyFor(user.user_id), JSON.stringify(events));
+  }, [events, user?.user_id]);
+
+  // fetch a small sample of berth history once per session
+  useEffect(() => {
+    if (!isLoaded || historyFetchedRef.current) return;
+    if (berths.length === 0) return;
+    historyFetchedRef.current = true;
+
+    async function fetchInitialHistory() {
+      // Prioritize berths that have been updated recently
+      const sampleBerths = [...berths]
+        .sort((a, b) => {
+          const timeA = a.last_updated ? new Date(a.last_updated).getTime() : 0;
+          const timeB = b.last_updated ? new Date(b.last_updated).getTime() : 0;
+          return timeB - timeA;
+        })
+        .slice(0, 20);
+
+      const results = await Promise.all(
+        sampleBerths.map(async (berth) => {
+          try {
+            const res = await apiFetch(
+              `/api/berths/${berth.berth_id}/events?limit=8`,
+            );
+            if (!res.ok) return [] as ActivityEvent[];
+            const data = await res.json();
+            return data.map(
+              (ev: {
+                event_id: string;
+                timestamp: string;
+                event_type: string;
+              }) => ({
+                id: ev.event_id,
+                timestamp: new Date(ev.timestamp),
+                type: "status_change" as const,
+                berthId: berth.berth_id,
+                berthLabel: berth.label || berth.berth_id,
+                details: `Berth status was ${ev.event_type}`,
+                status: ev.event_type,
+              }),
+            );
+          } catch (err) {
+            console.error(`Failed to fetch history for ${berth.berth_id}`, err);
+            return [] as ActivityEvent[];
+          }
+        }),
+      );
+
+      const historyEvents = results.flat();
+      if (historyEvents.length === 0) return;
+
+      setEvents((prev) => {
+        const seen = new Set<string>();
+        return [...prev, ...historyEvents]
+          .filter((e) => {
+            if (seen.has(e.id)) return false;
+            seen.add(e.id);
+            return true;
+          })
+          .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
+          .slice(0, maxEvents);
+      });
+    }
+
+    fetchInitialHistory();
+  }, [isLoaded, berths, maxEvents]);
+
+  // diff live berth stream into synthetic events
+  useEffect(() => {
+    const newEvents: ActivityEvent[] = [];
+    const currentBerths = new Map(berths.map((b) => [b.berth_id, b]));
+
+    // skip first run, baseline only
+    if (prevBerthsRef.current.size > 0) {
+      for (const [id, berth] of currentBerths.entries()) {
+        const prev = prevBerthsRef.current.get(id);
+        if (!prev) continue;
+        const prevUnavailable = prev.status === "occupied" || prev.is_reserved;
+        const nextUnavailable =
+          berth.status === "occupied" || berth.is_reserved;
+        if (prevUnavailable !== nextUnavailable) {
+          const fromLabel = prevUnavailable ? "Unavailable" : "Available";
+          const toLabel = nextUnavailable ? "Unavailable" : "Available";
+          newEvents.push({
+            id: crypto.randomUUID(),
+            timestamp: new Date(),
+            type: "status_change",
+            berthId: id,
+            berthLabel: berth.label || id,
+            details: `Status changed from ${fromLabel} to ${toLabel}`,
+            status: berth.status,
+          });
+        }
+        if (
+          prev.assignment?.user_id !== berth.assignment?.user_id &&
+          berth.assignment?.user_id
+        ) {
+          newEvents.push({
+            id: crypto.randomUUID(),
+            timestamp: new Date(),
+            type: "owner_assignment",
+            berthId: id,
+            berthLabel: berth.label || id,
+            details: `New owner assigned to berth`,
+          });
+        }
+        if (
+          (prev.battery_pct === null ||
+            prev.battery_pct === undefined ||
+            prev.battery_pct >= 15) &&
+          berth.battery_pct !== null &&
+          berth.battery_pct !== undefined &&
+          berth.battery_pct < 15
+        ) {
+          newEvents.push({
+            id: crypto.randomUUID(),
+            timestamp: new Date(),
+            type: "alert",
+            berthId: id,
+            berthLabel: berth.label || id,
+            details: `Low battery alert: ${berth.battery_pct}%`,
+            status: "alert_low_battery",
+          });
+        }
+      }
+    }
+
+    if (newEvents.length > 0) {
+      setEvents((prev) => [...newEvents, ...prev].slice(0, maxEvents));
+    }
+    prevBerthsRef.current = currentBerths;
+  }, [berths, maxEvents]);
+
+  return { events, setEvents, isLoaded, clearLog };
+}

--- a/frontend/src/hooks/useHarborEvents.ts
+++ b/frontend/src/hooks/useHarborEvents.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useState } from "react";
+import type { components } from "../api-types";
+import { apiFetch } from "../lib/api";
+
+export type HarborEvent = components["schemas"]["EventOut"];
+
+export interface UseHarborEventsOptions {
+  page: number;
+  pageSize: number;
+  eventTypes?: string[] | null;
+  enabled?: boolean;
+}
+
+type ListResponse = {
+  items: HarborEvent[];
+  total: number;
+};
+
+async function readError(res: Response, fallback: string) {
+  try {
+    const data = await res.json();
+    return data.detail || data.message || data.error || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function useHarborEvents(
+  harborId: string | null | undefined,
+  { page, pageSize, eventTypes, enabled = true }: UseHarborEventsOptions,
+) {
+  const [items, setItems] = useState<HarborEvent[]>([]);
+  const [total, setTotal] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!harborId || !enabled) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    const params = new URLSearchParams();
+    params.set("limit", String(pageSize));
+    params.set("offset", String((page - 1) * pageSize));
+    if (eventTypes) {
+      for (const t of eventTypes) params.append("event_type", t);
+    }
+
+    try {
+      const res = await apiFetch(
+        `/api/harbors/${harborId}/events?${params.toString()}`,
+      );
+      if (!res.ok) {
+        throw new Error(await readError(res, "Could not load events."));
+      }
+      const data = (await res.json()) as ListResponse;
+      setItems(data.items);
+      setTotal(data.total);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not load events.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [harborId, enabled, page, pageSize, eventTypes]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { items, total, isLoading, error, refresh: load };
+}

--- a/frontend/src/pages/ActivityLogPage.tsx
+++ b/frontend/src/pages/ActivityLogPage.tsx
@@ -1,0 +1,426 @@
+import {
+  Activity,
+  AlertTriangle,
+  ArrowLeft,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  Download,
+  Filter,
+  RefreshCw,
+  User,
+  UserX,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useOutletContext, useParams } from "react-router-dom";
+import type { AuthOutletContext } from "../components/layout/MainLayout";
+import { type HarborEvent, useHarborEvents } from "../hooks/useHarborEvents";
+import { getMarinaNameCB } from "../lib/marinas";
+import { cn } from "../lib/utils";
+
+const PAGE_SIZE = 50;
+
+type FilterKey = "all" | "status" | "owners" | "alerts";
+
+const FILTER_TO_TYPES: Record<FilterKey, string[] | null> = {
+  all: null,
+  status: ["occupied", "freed"],
+  owners: ["assignment_removed"],
+  alerts: ["alert_unauthorized"],
+};
+
+function eventLabel(eventType: string): string {
+  switch (eventType) {
+    case "occupied":
+      return "Arrived";
+    case "freed":
+      return "Departed";
+    case "alert_unauthorized":
+      return "Unauthorized access";
+    case "heartbeat":
+      return "Heartbeat";
+    case "assignment_removed":
+      return "Tenant removed";
+    default:
+      return eventType;
+  }
+}
+
+function csvEscape(value: string): string {
+  // RFC 4180: wrap in quotes, double any embedded quote
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+export function ActivityLogPage() {
+  const { marinaSlug } = useParams<{ marinaSlug: string }>();
+  const marinaName = getMarinaNameCB(marinaSlug);
+  const { user } = useOutletContext<AuthOutletContext>();
+  const harborId =
+    (user as { harbor_id?: string | null } | null)?.harbor_id ??
+    marinaSlug ??
+    null;
+
+  const [filter, setFilter] = useState<FilterKey>("all");
+  const [page, setPage] = useState(1);
+  const [highlightId, setHighlightId] = useState<string | null>(null);
+
+  const eventTypes = FILTER_TO_TYPES[filter];
+  const { items, total, isLoading, error, refresh } = useHarborEvents(
+    harborId,
+    { page, pageSize: PAGE_SIZE, eventTypes },
+  );
+
+  useEffect(() => {
+    document.title = `${marinaName} - Activity Log | DockPulse`;
+  }, [marinaName]);
+
+  // reset page when the filter changes
+  useEffect(() => {
+    setPage(1);
+  }, []);
+
+  // highlight the newest event when a fresh page lands on page 1
+  useEffect(() => {
+    if (page === 1 && items.length > 0) {
+      setHighlightId(items[0].event_id);
+      const t = setTimeout(() => setHighlightId(null), 2000);
+      return () => clearTimeout(t);
+    }
+  }, [items, page]);
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  const pageNumbers = useMemo(() => {
+    // condensed pager: first, last, current ±2, with ellipses for gaps
+    const pages = new Set<number>([1, totalPages, page]);
+    for (
+      let i = Math.max(2, page - 2);
+      i <= Math.min(totalPages - 1, page + 2);
+      i++
+    ) {
+      pages.add(i);
+    }
+    const sorted = [...pages].sort((a, b) => a - b);
+    const out: (number | "...")[] = [];
+    for (let i = 0; i < sorted.length; i++) {
+      out.push(sorted[i]);
+      if (i < sorted.length - 1 && sorted[i + 1] - sorted[i] > 1)
+        out.push("...");
+    }
+    return out;
+  }, [page, totalPages]);
+
+  function handleFilter(next: FilterKey) {
+    setFilter(next);
+    setPage(1);
+  }
+
+  function handleExportCSV() {
+    if (items.length === 0) return;
+    const headers = ["Timestamp", "Berth", "Type", "Actor", "Subject"];
+    const rows = items.map((e) => [
+      e.timestamp,
+      e.berth_id,
+      eventLabel(e.event_type),
+      e.actor_user_id ?? "",
+      e.subject_user_id ?? "",
+    ]);
+    const csv = [
+      headers.map(csvEscape).join(","),
+      ...rows.map((r) => r.map((c) => csvEscape(String(c))).join(",")),
+    ].join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `dockpulse_activity_${marinaSlug ?? "harbor"}_p${page}_${new Date()
+      .toISOString()
+      .slice(0, 10)}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+
+  if (user?.role !== "harbormaster") {
+    return (
+      <main className="mx-auto max-w-2xl px-4 pt-24 pb-20 lg:pt-36">
+        <h1 className="text-3xl font-semibold text-brand-navy">Activity Log</h1>
+        <p className="mt-2 text-brand-navy/60">Harbormaster role required.</p>
+      </main>
+    );
+  }
+
+  const filterButtons: { id: FilterKey; label: string; icon: JSX.Element }[] = [
+    { id: "all", label: "All", icon: <Filter size={14} /> },
+    { id: "status", label: "Status", icon: <Activity size={14} /> },
+    { id: "owners", label: "Owners", icon: <UserX size={14} /> },
+    { id: "alerts", label: "Alerts", icon: <AlertTriangle size={14} /> },
+  ];
+
+  return (
+    <div className="flex h-full min-h-dvh flex-col overflow-hidden bg-[#F8FAFC]">
+      <header className="sticky top-0 z-10 flex items-center justify-between border-b border-slate-200 bg-white/80 px-6 py-4 shadow-sm backdrop-blur-md">
+        <div className="flex items-center gap-4">
+          <Link
+            to={`/${marinaSlug}`}
+            className="rounded-full p-2 text-slate-500 transition-colors hover:bg-slate-100"
+            title="Back to dashboard"
+            aria-label="Back to dashboard"
+          >
+            <ArrowLeft size={20} />
+          </Link>
+          <div className="flex items-center gap-3">
+            <div className="grid h-10 w-10 place-items-center rounded-xl bg-brand-blue/10">
+              <Activity className="text-brand-blue" size={20} />
+            </div>
+            <div>
+              <h1 className="text-xl font-black tracking-tight text-slate-900">
+                Harbor Activity
+              </h1>
+              <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">
+                {marinaName} Log
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={refresh}
+            disabled={isLoading}
+            className="grid h-10 w-10 place-items-center rounded-xl border border-slate-200 text-slate-500 transition-all hover:bg-slate-100 disabled:opacity-50"
+            aria-label="Refresh"
+          >
+            <RefreshCw size={16} className={cn(isLoading && "animate-spin")} />
+          </button>
+          <button
+            type="button"
+            onClick={handleExportCSV}
+            disabled={items.length === 0}
+            className="flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-xs font-bold text-slate-600 transition-all hover:bg-slate-100 disabled:opacity-30"
+          >
+            <Download size={16} />
+            Export page
+          </button>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-4 border-b border-slate-200 bg-white/50 px-6 py-4 backdrop-blur-sm">
+        <div className="flex items-center gap-2 rounded-xl border border-slate-200/50 bg-slate-100 p-1">
+          {filterButtons.map((btn) => (
+            <button
+              key={btn.id}
+              type="button"
+              onClick={() => handleFilter(btn.id)}
+              className={cn(
+                "flex items-center gap-2 rounded-lg px-4 py-1.5 text-xs font-black uppercase tracking-widest transition-all",
+                filter === btn.id
+                  ? "bg-white text-brand-blue shadow-sm"
+                  : "text-slate-500 hover:text-slate-700",
+              )}
+            >
+              {btn.icon}
+              {btn.label}
+            </button>
+          ))}
+        </div>
+
+        <span className="ml-auto text-[11px] font-bold text-slate-400">
+          {total === 0
+            ? "0 events"
+            : `Showing ${(page - 1) * PAGE_SIZE + 1}–${Math.min(
+                page * PAGE_SIZE,
+                total,
+              )} of ${total}`}
+        </span>
+      </div>
+
+      <div className="custom-scrollbar flex-1 overflow-auto p-6">
+        {isLoading && items.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-4 text-slate-400">
+            <div className="h-12 w-12 animate-spin rounded-full border-4 border-brand-blue/20 border-t-brand-blue" />
+            <p className="text-xs font-black uppercase tracking-widest">
+              Fetching harbor logs...
+            </p>
+          </div>
+        ) : error ? (
+          <div className="rounded-2xl border border-red-500/10 bg-red-500/5 p-6 text-sm font-bold text-red-500">
+            {error}
+          </div>
+        ) : items.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center py-20 text-center">
+            <div className="mb-6 grid h-20 w-20 place-items-center rounded-full bg-slate-100">
+              <Clock size={40} className="text-slate-300" />
+            </div>
+            <h3 className="mb-2 text-lg font-bold text-slate-900">
+              No activity yet
+            </h3>
+            <p className="max-w-xs text-sm text-slate-500">
+              Activity will appear here as sensor events and assignments occur.
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-[32px] border border-slate-200 bg-white shadow-xl shadow-slate-200/40">
+            <table className="w-full border-collapse text-left">
+              <thead>
+                <tr className="border-b border-slate-100 bg-slate-50/50">
+                  <th className="px-6 py-4 text-[10px] font-black uppercase tracking-[0.2em] text-slate-400">
+                    Timestamp
+                  </th>
+                  <th className="px-6 py-4 text-[10px] font-black uppercase tracking-[0.2em] text-slate-400">
+                    Berth
+                  </th>
+                  <th className="px-6 py-4 text-[10px] font-black uppercase tracking-[0.2em] text-slate-400">
+                    Event
+                  </th>
+                  <th className="px-6 py-4 text-[10px] font-black uppercase tracking-[0.2em] text-slate-400">
+                    Actor / subject
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-50">
+                {items.map((event: HarborEvent) => {
+                  const isAlert = event.event_type === "alert_unauthorized";
+                  const isAudit = event.event_type === "assignment_removed";
+                  const isHighlight = event.event_id === highlightId;
+                  return (
+                    <tr
+                      key={event.event_id}
+                      className={cn(
+                        "group transition-colors",
+                        isHighlight
+                          ? "bg-brand-blue/10"
+                          : "hover:bg-slate-50/80",
+                      )}
+                    >
+                      <td className="whitespace-nowrap px-6 py-5">
+                        <div className="flex flex-col">
+                          <span className="text-sm font-bold text-slate-700">
+                            {new Date(event.timestamp).toLocaleTimeString([], {
+                              hour: "2-digit",
+                              minute: "2-digit",
+                              second: "2-digit",
+                            })}
+                          </span>
+                          <span className="text-[10px] font-medium text-slate-400">
+                            {new Date(event.timestamp).toLocaleDateString(
+                              undefined,
+                              { month: "short", day: "numeric" },
+                            )}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="whitespace-nowrap px-6 py-5">
+                        <span className="rounded-lg border border-slate-200/50 bg-slate-100 px-3 py-1 text-[11px] font-black text-slate-700">
+                          {event.berth_id}
+                        </span>
+                      </td>
+                      <td className="whitespace-nowrap px-6 py-5">
+                        <span
+                          className={cn(
+                            "inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-[10px] font-black uppercase tracking-widest",
+                            isAlert
+                              ? "bg-amber-50 text-amber-700"
+                              : isAudit
+                                ? "bg-rose-50 text-rose-700"
+                                : "bg-brand-blue/10 text-brand-blue",
+                          )}
+                        >
+                          {isAlert && <AlertTriangle size={10} />}
+                          {isAudit && <UserX size={10} />}
+                          {eventLabel(event.event_type)}
+                        </span>
+                      </td>
+                      <td className="px-6 py-5 text-xs text-slate-500">
+                        {event.actor_user_id || event.subject_user_id ? (
+                          <div className="space-y-0.5">
+                            {event.actor_user_id && (
+                              <div className="flex items-center gap-1">
+                                <User size={10} />
+                                <span className="font-mono">
+                                  {event.actor_user_id}
+                                </span>
+                              </div>
+                            )}
+                            {event.subject_user_id && (
+                              <div className="flex items-center gap-1 text-slate-400">
+                                <span className="text-[9px] uppercase">
+                                  → subject
+                                </span>
+                                <span className="font-mono">
+                                  {event.subject_user_id}
+                                </span>
+                              </div>
+                            )}
+                          </div>
+                        ) : (
+                          <span className="text-slate-300">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <footer className="flex items-center justify-between border-t border-slate-200 bg-white px-6 py-4">
+        <p className="text-[11px] font-bold uppercase tracking-widest text-slate-400">
+          {total} total events
+        </p>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1 || isLoading}
+            className="flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-xs font-bold text-slate-600 transition-all hover:bg-slate-100 disabled:opacity-30"
+          >
+            <ChevronLeft size={16} />
+            Previous
+          </button>
+          <div className="flex items-center gap-1">
+            {pageNumbers.map((p, i) =>
+              p === "..." ? (
+                <span
+                  // biome-ignore lint/suspicious/noArrayIndexKey: static gap markers
+                  key={`gap-${i}`}
+                  className="px-1 text-xs text-slate-300"
+                >
+                  …
+                </span>
+              ) : (
+                <button
+                  key={p}
+                  type="button"
+                  onClick={() => setPage(p)}
+                  className={cn(
+                    "h-8 w-8 rounded-lg text-xs font-bold transition-all",
+                    page === p
+                      ? "bg-brand-blue text-white shadow-md shadow-brand-blue/20"
+                      : "text-slate-400 hover:bg-slate-100",
+                  )}
+                >
+                  {p}
+                </button>
+              ),
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page === totalPages || isLoading}
+            className="flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2 text-xs font-bold text-slate-600 transition-all hover:bg-slate-100 disabled:opacity-30"
+          >
+            Next
+            <ChevronRight size={16} />
+          </button>
+        </div>
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Refactor activity tracking into a shared useActivityLog hook with localStorage persistence.
- Create ActivityLogPage for full-page activity monitoring, independent of the dashboard shell.
- Add live "Low Battery" alert detection to the activity stream.
- Implement CSV export and local log clearing for Harbor Master audit workflows.
- Integrate smart historical sampling (top 20 active berths) to populate logs on page load.
- Add micro-animations (live pulse) for immediate visual feedback on harbor events.
- Refactor routing to support standalone, full-screen dedicated pages.

## Related Issue

Closes #153
Closes #17 

## Changes

-

## Checklist

- [ ] Code compiles/builds without errors or warnings
- [ ] Code follows the project style guide and has been formatted
- [ ] All existing tests pass
- [ ] New functionality includes appropriate tests
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
