### PR TITLE
feat(frontend): qr and tenant

### DIFF
--- a/backend/app/routers/harbors.py
+++ b/backend/app/routers/harbors.py
@@ -1,9 +1,22 @@
-from fastapi import APIRouter
-from sqlalchemy import select
+from typing import Annotated
 
-from app.dependencies import CurrentUserDep, SessionDep
-from app.models import Harbor
-from app.schemas import HarborOut
+from fastapi import APIRouter, Query
+from sqlalchemy import or_, select, union
+
+from app.dependencies import (
+    CurrentUserDep,
+    HarbormasterForHarborDep,
+    SessionDep,
+)
+from app.models import (
+    Assignment,
+    Berth,
+    BerthAvailabilityWindow,
+    Dock,
+    Harbor,
+    User,
+)
+from app.schemas import HarborOut, UserSearchOut
 
 router = APIRouter(prefix="/api/harbors", tags=["harbors"])
 
@@ -21,3 +34,59 @@ async def list_harbors(
     stmt = select(Harbor).order_by(Harbor.name)
     result = await session.execute(stmt)
     return result.scalars().all()
+
+
+@router.get(
+    "/{harbor_id}/users",
+    response_model=list[UserSearchOut],
+    operation_id="searchHarborUsers",
+    summary="Search users known to this harbor (harbormaster only)",
+)
+async def search_harbor_users(
+    harbor_id: str,
+    session: SessionDep,
+    _: HarbormasterForHarborDep,
+    q: Annotated[
+        str | None,
+        Query(
+            description="email or name prefix, case-insensitive",
+            max_length=120,
+        ),
+    ] = None,
+    limit: Annotated[int, Query(ge=1, le=50)] = 20,
+):
+    # users "known to the harbor" = anyone with a current assignment to a
+    # berth in this harbor or an availability window scheduled here. avoids
+    # global email enumeration while still surfacing realistic invite targets
+    assignment_user_ids = (
+        select(Assignment.user_id)
+        .join(Berth, Berth.berth_id == Assignment.berth_id)
+        .join(Dock, Dock.dock_id == Berth.dock_id)
+        .where(Dock.harbor_id == harbor_id)
+    )
+    window_user_ids = (
+        select(BerthAvailabilityWindow.user_id)
+        .join(Berth, Berth.berth_id == BerthAvailabilityWindow.berth_id)
+        .join(Dock, Dock.dock_id == Berth.dock_id)
+        .where(Dock.harbor_id == harbor_id)
+    )
+    known_user_ids = union(assignment_user_ids, window_user_ids).subquery()
+
+    stmt = (
+        select(User)
+        .join(known_user_ids, known_user_ids.c.user_id == User.user_id)
+        .order_by(User.email)
+        .limit(limit)
+    )
+    if q:
+        prefix = f"{q.strip().lower()}%"
+        stmt = stmt.where(
+            or_(
+                User.email.ilike(prefix),
+                User.firstname.ilike(prefix),
+                User.lastname.ilike(prefix),
+            )
+        )
+
+    rows = (await session.execute(stmt)).scalars().all()
+    return rows

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -264,6 +264,13 @@ class UserOut(_BaseSchema):
     assigned_berth_id: str | None = Field(default=None, examples=["berth-001"])
 
 
+class UserSearchOut(_BaseSchema):
+    user_id: str = Field(examples=["user-001"])
+    firstname: str = Field(examples=["Alex"])
+    lastname: str = Field(examples=["Lindgren"])
+    email: EmailField
+
+
 class UserPatch(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 

--- a/backend/tests/test_harbors_api.py
+++ b/backend/tests/test_harbors_api.py
@@ -1,9 +1,12 @@
+from datetime import UTC, datetime, timedelta
+
 import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Harbor, User
+from app.models import Assignment, BerthAvailabilityWindow, Harbor, User
 from tests._helpers import auth_cookies as _creds
+from tests._helpers import hash_password
 
 
 @pytest_asyncio.fixture
@@ -43,3 +46,112 @@ async def test_list_harbors_returns_all_for_harbormaster(
     )
     assert r.status_code == 200
     assert [h["harbor_id"] for h in r.json()] == ["h1", "h2"]
+
+
+# --- harbor user search ---
+
+
+@pytest_asyncio.fixture
+async def harbor_known_users(
+    session: AsyncSession, seeded_berth, harbor_master, boat_owner
+):
+    # tenant linked via Assignment
+    session.add(Assignment(berth_id="b1", user_id=boat_owner.user_id))
+    # visitor linked via availability window
+    visitor = User(
+        user_id="v1",
+        firstname="Vera",
+        lastname="Visitor",
+        email="vera@example.com",
+        password_hash=hash_password("secret"),
+    )
+    # outsider not linked to h1 in any way
+    outsider = User(
+        user_id="x1",
+        firstname="Xander",
+        lastname="Outside",
+        email="xander@example.com",
+        password_hash=hash_password("secret"),
+    )
+    session.add_all([visitor, outsider])
+    await session.flush()
+    now = datetime.now(UTC)
+    session.add(
+        BerthAvailabilityWindow(
+            window_id="w-search-1",
+            berth_id="b1",
+            user_id=visitor.user_id,
+            from_date=now - timedelta(days=1),
+            return_date=now + timedelta(days=1),
+        )
+    )
+    await session.commit()
+    return {"tenant": boat_owner, "visitor": visitor, "outsider": outsider}
+
+
+async def test_search_harbor_users_returns_tenants_and_visitors(
+    client: AsyncClient, harbor_known_users, harbor_master
+):
+    r = await client.get(
+        "/api/harbors/h1/users",
+        cookies=_creds(harbor_master.user_id),
+    )
+    assert r.status_code == 200
+    emails = sorted(u["email"] for u in r.json())
+    assert harbor_known_users["tenant"].email in emails
+    assert harbor_known_users["visitor"].email in emails
+    assert harbor_known_users["outsider"].email not in emails
+
+
+async def test_search_harbor_users_filters_by_q(
+    client: AsyncClient, harbor_known_users, harbor_master
+):
+    r = await client.get(
+        "/api/harbors/h1/users?q=ver",
+        cookies=_creds(harbor_master.user_id),
+    )
+    assert r.status_code == 200
+    emails = [u["email"] for u in r.json()]
+    assert emails == [harbor_known_users["visitor"].email]
+
+
+async def test_search_harbor_users_q_matches_name_prefix(
+    client: AsyncClient, harbor_known_users, harbor_master
+):
+    r = await client.get(
+        "/api/harbors/h1/users?q=Olle",
+        cookies=_creds(harbor_master.user_id),
+    )
+    assert r.status_code == 200
+    emails = [u["email"] for u in r.json()]
+    assert emails == [harbor_known_users["tenant"].email]
+
+
+async def test_search_harbor_users_requires_harbormaster(
+    client: AsyncClient, harbor_known_users, boat_owner
+):
+    r = await client.get(
+        "/api/harbors/h1/users",
+        cookies=_creds(boat_owner.user_id),
+    )
+    assert r.status_code == 403
+
+
+async def test_search_harbor_users_unauth_returns_401(
+    client: AsyncClient, harbor_known_users
+):
+    r = await client.get("/api/harbors/h1/users")
+    assert r.status_code == 401
+
+
+async def test_search_harbor_users_isolates_harbors(
+    client: AsyncClient, harbor_known_users, harbor_master, session
+):
+    # harbor_master only manages h1, so /h2/users must 403 even though h2 exists
+    session.add(Harbor(harbor_id="h2", name="Other"))
+    await session.commit()
+    r = await client.get(
+        "/api/harbors/h2/users",
+        cookies=_creds(harbor_master.user_id),
+    )
+    assert r.status_code == 403

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -1796,6 +1796,36 @@ components:
       - role
       title: UserPatchOut
       type: object
+    UserSearchOut:
+      properties:
+        email:
+          examples:
+          - alex@example.com
+          format: email
+          title: Email
+          type: string
+        firstname:
+          examples:
+          - Alex
+          title: Firstname
+          type: string
+        lastname:
+          examples:
+          - Lindgren
+          title: Lastname
+          type: string
+        user_id:
+          examples:
+          - user-001
+          title: User Id
+          type: string
+      required:
+      - user_id
+      - firstname
+      - lastname
+      - email
+      title: UserSearchOut
+      type: object
     ValidationError:
       properties:
         ctx:
@@ -4117,6 +4147,57 @@ paths:
       summary: Revoke a pending invite (harbormaster only)
       tags:
       - berth-invites
+  /api/harbors/{harbor_id}/users:
+    get:
+      operationId: searchHarborUsers
+      parameters:
+      - in: path
+        name: harbor_id
+        required: true
+        schema:
+          title: Harbor Id
+          type: string
+      - description: email or name prefix, case-insensitive
+        in: query
+        name: q
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 120
+            type: string
+          - type: 'null'
+          description: email or name prefix, case-insensitive
+          title: Q
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 20
+          maximum: 50
+          minimum: 1
+          title: Limit
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/UserSearchOut'
+                title: Response Searchharborusers
+                type: array
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - APIKeyCookie: []
+      summary: Search users known to this harbor (harbormaster only)
+      tags:
+      - harbors
   /api/health:
     get:
       operationId: getHealth

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,8 +19,20 @@ const Settings = lazy(() =>
   import("./pages/Settings").then((m) => ({ default: m.Settings })),
 );
 
+const InvitesSettings = lazy(() =>
+  import("./pages/InvitesSettings").then((m) => ({
+    default: m.InvitesSettings,
+  })),
+);
+
 const ResetPassword = lazy(() =>
   import("./pages/ResetPassword").then((m) => ({ default: m.ResetPassword })),
+);
+
+const AcceptBerthPage = lazy(() =>
+  import("./pages/AcceptBerthPage").then((m) => ({
+    default: m.AcceptBerthPage,
+  })),
 );
 
 const NotFound = lazy(() =>
@@ -94,6 +106,19 @@ export function App() {
             }
           />
 
+          {/* public berth invite accept page, wrapped in MainLayout so the
+              shared AuthDialog opens with prefilled email */}
+          <Route element={<MainLayout />}>
+            <Route
+              path="/accept-berth"
+              element={
+                <Suspense fallback={<div className="h-full w-full" />}>
+                  <AcceptBerthPage />
+                </Suspense>
+              }
+            />
+          </Route>
+
           <Route path="/:marinaSlug" element={<MarinaGuard />}>
             <Route
               index
@@ -110,6 +135,17 @@ export function App() {
                 <RequireAuth>
                   <Suspense fallback={<div className="h-full w-full" />}>
                     <Settings />
+                  </Suspense>
+                </RequireAuth>
+              }
+            />
+
+            <Route
+              path="settings/invites"
+              element={
+                <RequireAuth>
+                  <Suspense fallback={<div className="h-full w-full" />}>
+                    <InvitesSettings />
                   </Suspense>
                 </RequireAuth>
               }

--- a/frontend/src/HarborMap.tsx
+++ b/frontend/src/HarborMap.tsx
@@ -43,14 +43,14 @@ export function HarborMap() {
     [berths, selectedBerthId],
   );
 
-  const canShowDashboardPanels = !selectedBerthId;
-  const overviewIsVisible = isOverviewOpen && canShowDashboardPanels;
-  const activityLogIsVisible = isActivityLogOpen && canShowDashboardPanels;
+  const overviewIsVisible = isOverviewOpen;
+  const activityLogIsVisible = isActivityLogOpen;
 
-  const isAnyPanelOpen =
-    !!selectedBerthId || overviewIsVisible || activityLogIsVisible;
+  // berth detail sits in the gutter so the map stays interactive behind it.
+  // only overview/activity occupy enough surface to warrant blocking map drag
+  const isMapBlocked = overviewIsVisible || activityLogIsVisible;
 
-  const shouldShowMapLegend = !isAnyPanelOpen;
+  const shouldShowMapLegend = !isMapBlocked && !selectedBerthId;
 
   useEffect(() => {
     const contentElement = contentRef.current;
@@ -91,12 +91,12 @@ export function HarborMap() {
     const instance = panzoomRef.current;
     if (!instance) return;
 
-    if (isAnyPanelOpen) {
+    if (isMapBlocked) {
       instance.pause();
     } else {
       instance.resume();
     }
-  }, [isAnyPanelOpen]);
+  }, [isMapBlocked]);
 
   useEffect(() => {
     if (!isLoading) setShowInitialSpinner(false);
@@ -131,7 +131,7 @@ export function HarborMap() {
         className={cn(
           "absolute inset-0 z-10 h-full w-full cursor-grab active:cursor-grabbing",
           "md:touch-none",
-          isAnyPanelOpen && "pointer-events-none",
+          isMapBlocked && "pointer-events-none",
         )}
       >
         <SvgMap

--- a/frontend/src/HarborMap.tsx
+++ b/frontend/src/HarborMap.tsx
@@ -43,8 +43,14 @@ export function HarborMap() {
     [berths, selectedBerthId],
   );
 
-  const shouldShowMapLegend =
-    !selectedBerthId && !isOverviewOpen && !isActivityLogOpen;
+  const canShowDashboardPanels = !selectedBerthId;
+  const overviewIsVisible = isOverviewOpen && canShowDashboardPanels;
+  const activityLogIsVisible = isActivityLogOpen && canShowDashboardPanels;
+
+  const isAnyPanelOpen =
+    !!selectedBerthId || overviewIsVisible || activityLogIsVisible;
+
+  const shouldShowMapLegend = !isAnyPanelOpen;
 
   useEffect(() => {
     const contentElement = contentRef.current;
@@ -85,20 +91,25 @@ export function HarborMap() {
     const instance = panzoomRef.current;
     if (!instance) return;
 
-    if (selectedBerthId || isOverviewOpen || isActivityLogOpen) {
+    if (isAnyPanelOpen) {
       instance.pause();
     } else {
       instance.resume();
     }
-  }, [selectedBerthId, isOverviewOpen, isActivityLogOpen]);
+  }, [isAnyPanelOpen]);
 
   useEffect(() => {
     if (!isLoading) setShowInitialSpinner(false);
   }, [isLoading]);
 
-  const handleBerthClick = useCallback((berthId: string) => {
-    setSelectedBerthId(berthId);
-  }, []);
+  const handleBerthClick = useCallback(
+    (berthId: string) => {
+      setIsOverviewOpen(false);
+      setIsActivityLogOpen(false);
+      setSelectedBerthId(berthId);
+    },
+    [setIsOverviewOpen, setIsActivityLogOpen],
+  );
 
   const handleCloseBerthPanel = useCallback(() => {
     setSelectedBerthId(null);
@@ -108,6 +119,10 @@ export function HarborMap() {
     setIsOverviewOpen(false);
   }, [setIsOverviewOpen]);
 
+  const handleCloseActivityLog = useCallback(() => {
+    setIsActivityLogOpen(false);
+  }, [setIsActivityLogOpen]);
+
   return (
     <div className="relative h-full w-full overflow-hidden border-4 border-white/70 bg-sky-50/20 font-body shadow-inner">
       <section
@@ -116,8 +131,7 @@ export function HarborMap() {
         className={cn(
           "absolute inset-0 z-10 h-full w-full cursor-grab active:cursor-grabbing",
           "md:touch-none",
-          (selectedBerthId || isOverviewOpen || isActivityLogOpen) &&
-            "pointer-events-none",
+          isAnyPanelOpen && "pointer-events-none",
         )}
       >
         <SvgMap
@@ -158,14 +172,14 @@ export function HarborMap() {
         <HarborMasterOverview
           key="master-overview"
           berths={berths}
-          isOpen={isOverviewOpen}
+          isOpen={overviewIsVisible}
           onCloseCB={handleCloseOverview}
         />
       ) : (
         <HarborOverview
           key="public-overview"
           berths={berths}
-          isOpen={isOverviewOpen}
+          isOpen={overviewIsVisible}
           onCloseCB={handleCloseOverview}
         />
       )}
@@ -173,8 +187,8 @@ export function HarborMap() {
       <ActivityLogPanel
         key="activity-log"
         berths={berths}
-        isOpen={isActivityLogOpen}
-        onCloseCB={() => setIsActivityLogOpen(false)}
+        isOpen={activityLogIsVisible}
+        onCloseCB={handleCloseActivityLog}
       />
 
       {shouldShowMapLegend && <MapLegend />}

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -520,6 +520,91 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/auth/resend-verification": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Resend verification email */
+        post: operations["resendVerification"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/verify-email": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Verify email address using token from email link */
+        get: operations["verifyEmail"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/berth-invites/by-token/{token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Look up an invite by its token (public) */
+        get: operations["getBerthInviteByToken"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/berth-invites/by-token/{token}/accept": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Accept an invite (authed, must match invite email) */
+        post: operations["acceptBerthInvite"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/berth-invites/by-token/{token}/reject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reject an invite (authed, must match invite email) */
+        post: operations["rejectBerthInvite"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/berths": {
         parameters: {
             query?: never;
@@ -763,6 +848,58 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/harbors/{harbor_id}/berth-invites": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List invites for a harbor, paginated (harbormaster only) */
+        get: operations["listBerthInvites"];
+        put?: never;
+        /** Create a berth invite (harbormaster only) */
+        post: operations["createBerthInvite"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/harbors/{harbor_id}/berth-invites/{invite_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Revoke a pending invite (harbormaster only) */
+        delete: operations["deleteBerthInvite"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/harbors/{harbor_id}/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Search users known to this harbor (harbormaster only) */
+        get: operations["searchHarborUsers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/health": {
         parameters: {
             query?: never;
@@ -883,6 +1020,40 @@ export interface paths {
         head?: never;
         /** Update notification preferences for the current user */
         patch: operations["updateNotificationPrefs"];
+        trace?: never;
+    };
+    "/api/users/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Send a password reset email if the address is registered */
+        post: operations["requestPasswordReset"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/resetpassword": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Apply a new password using a reset token */
+        post: operations["confirmPasswordReset"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
 }
@@ -1175,6 +1346,74 @@ export interface components {
             /** Label */
             label?: string | null;
         };
+        /** BerthInviteCreate */
+        BerthInviteCreate: {
+            /**
+             * Berth Id
+             * @example berth-001
+             */
+            berth_id: string;
+            /**
+             * Email
+             * Format: email
+             * @example alex@example.com
+             */
+            email: string;
+        };
+        /** BerthInviteList */
+        BerthInviteList: {
+            /** Items */
+            items: components["schemas"]["BerthInviteOut"][];
+            /**
+             * Total
+             * @example 42
+             */
+            total: number;
+        };
+        /** BerthInviteOut */
+        BerthInviteOut: {
+            /**
+             * Berth Id
+             * @example berth-001
+             */
+            berth_id: string;
+            /**
+             * Berth Label
+             * @example A-12
+             */
+            berth_label?: string | null;
+            /**
+             * Email
+             * Format: email
+             * @example alex@example.com
+             */
+            email: string;
+            /**
+             * Expires At
+             * Format: date-time
+             */
+            expires_at: string;
+            /**
+             * Harbor Id
+             * @example harbor-001
+             */
+            harbor_id: string;
+            /**
+             * Harbor Name
+             * @example Saltsjöbaden
+             */
+            harbor_name?: string | null;
+            /**
+             * Invite Id
+             * @example inv-001
+             */
+            invite_id: string;
+            /**
+             * Status
+             * @example pending
+             */
+            status: string;
+        };
         /** BerthOut */
         BerthOut: {
             assignment?: components["schemas"]["AssignmentOut"] | null;
@@ -1388,7 +1627,7 @@ export interface components {
              * Event Type
              * @enum {string}
              */
-            event_type: "occupied" | "freed" | "alert_unauthorized" | "heartbeat";
+            event_type: "occupied" | "freed" | "alert_unauthorized" | "heartbeat" | "assignment_removed";
             /**
              * Node Id
              * @example node-012
@@ -1717,6 +1956,35 @@ export interface components {
             /** Notify Departure */
             notify_departure?: boolean | null;
         };
+        /** PasswordResetConfirm */
+        PasswordResetConfirm: {
+            /** Invite Token */
+            invite_token?: string | null;
+            /**
+             * Password
+             * Format: password
+             * @example correct horse battery staple
+             */
+            password: string;
+            /** Token */
+            token: string;
+        };
+        /** PasswordResetOut */
+        PasswordResetOut: {
+            /** Invite Token */
+            invite_token?: string | null;
+            /** Message */
+            message: string;
+        };
+        /** PasswordResetRequest */
+        PasswordResetRequest: {
+            /**
+             * Email
+             * Format: email
+             * @example alex@example.com
+             */
+            email: string;
+        };
         /** PendingGatewayOut */
         PendingGatewayOut: {
             /**
@@ -1748,6 +2016,15 @@ export interface components {
             node_id: string;
             /** Request Id */
             request_id: string;
+        };
+        /** ResendVerificationIn */
+        ResendVerificationIn: {
+            /**
+             * Email
+             * Format: email
+             * @example alex@example.com
+             */
+            email: string;
         };
         /** SnapshotAdoption */
         SnapshotAdoption: {
@@ -1906,6 +2183,30 @@ export interface components {
             /** User Id */
             user_id: string;
         };
+        /** UserSearchOut */
+        UserSearchOut: {
+            /**
+             * Email
+             * Format: email
+             * @example alex@example.com
+             */
+            email: string;
+            /**
+             * Firstname
+             * @example Alex
+             */
+            firstname: string;
+            /**
+             * Lastname
+             * @example Lindgren
+             */
+            lastname: string;
+            /**
+             * User Id
+             * @example user-001
+             */
+            user_id: string;
+        };
         /** ValidationError */
         ValidationError: {
             /** Context */
@@ -1939,12 +2240,6 @@ export interface components {
             password: string;
             /** Phone */
             phone?: string | null;
-            /**
-             * Role
-             * @default boat_owner
-             * @enum {string}
-             */
-            role: "harbormaster" | "boat_owner";
         };
         /** UserPatch */
         app__routers__admin__users__UserPatch: {
@@ -1956,8 +2251,6 @@ export interface components {
             lastname?: string | null;
             /** Phone */
             phone?: string | null;
-            /** Role */
-            role?: ("harbormaster" | "boat_owner") | null;
         };
         /** UserCreate */
         app__schemas__UserCreate: {
@@ -3226,6 +3519,20 @@ export interface operations {
                     "application/json": components["schemas"]["UserOut"];
                 };
             };
+            /** @description Invalid credentials */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Email not verified */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -3323,7 +3630,171 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["UserOut"];
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resendVerification: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ResendVerificationIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    verifyEmail: {
+        parameters: {
+            query: {
+                token: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Invalid or expired token */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    getBerthInviteByToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BerthInviteOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    acceptBerthInvite: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BerthInviteOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    rejectBerthInvite: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BerthInviteOut"];
                 };
             };
             /** @description Validation Error */
@@ -3824,6 +4295,141 @@ export interface operations {
             };
         };
     };
+    listBerthInvites: {
+        parameters: {
+            query?: {
+                status?: string | null;
+                limit?: number;
+                offset?: number;
+            };
+            header?: never;
+            path: {
+                harbor_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BerthInviteList"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    createBerthInvite: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                harbor_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BerthInviteCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BerthInviteOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    deleteBerthInvite: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                harbor_id: string;
+                invite_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    searchHarborUsers: {
+        parameters: {
+            query?: {
+                /** @description email or name prefix, case-insensitive */
+                q?: string | null;
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                harbor_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserSearchOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     getHealth: {
         parameters: {
             query?: never;
@@ -4095,6 +4701,70 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["NotificationPrefsOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    requestPasswordReset: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PasswordResetRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    confirmPasswordReset: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PasswordResetConfirm"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PasswordResetOut"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/components/BerthDetailPanel.tsx
+++ b/frontend/src/components/BerthDetailPanel.tsx
@@ -10,8 +10,14 @@ import {
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Link, useOutletContext, useParams } from "react-router-dom";
+import { toast } from "sonner";
 import type { components } from "../api-types";
 import { useBerthDetail } from "../hooks/useBerthDetail";
+import {
+  type BerthInvite,
+  revokeInvite,
+  useBerthInvites,
+} from "../hooks/useBerthInvites";
 import { apiFetch } from "../lib/api";
 import { cn } from "../lib/utils";
 import { InviteOwnerModal } from "./InviteOwnerModal";
@@ -69,6 +75,19 @@ export function BerthDetailPanel({
     null,
   );
 
+  const [tenantEmail, setTenantEmail] = useState<string | null>(null);
+  const [isRevokingInvite, setIsRevokingInvite] = useState(false);
+
+  const { invites: pendingInvites, loadInvites: reloadInvites } =
+    useBerthInvites(harborId, {
+      enabled: isHarborMaster && Boolean(harborId),
+      status: "pending",
+    });
+
+  const pendingInviteForBerth: BerthInvite | undefined = pendingInvites.find(
+    (inv) => inv.berth_id === berthId,
+  );
+
   const closeTimeoutRef = useRef<number | null>(null);
 
   const canInviteOwner =
@@ -116,6 +135,39 @@ export function BerthDetailPanel({
       }
     };
   }, []);
+
+  // tenant email shown in the remove dialog, fetched on demand because
+  // BerthOut.assignment carries only user_id
+  useEffect(() => {
+    if (!isHarborMaster || !berth?.assignment) {
+      setTenantEmail(null);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    async function fetchTenant() {
+      try {
+        const res = await apiFetch(
+          `/api/users?berth_id=${encodeURIComponent(berthId)}`,
+          { signal: controller.signal },
+        );
+
+        if (res.ok) {
+          const data = (await res.json()) as { email?: string };
+          setTenantEmail(data.email ?? null);
+        }
+      } catch (err) {
+        if ((err as Error).name !== "AbortError") {
+          console.error("Failed to fetch tenant", err);
+        }
+      }
+    }
+
+    fetchTenant();
+
+    return () => controller.abort();
+  }, [berthId, isHarborMaster, berth?.assignment]);
 
   function closePanel() {
     if (isClosing) return;
@@ -182,6 +234,27 @@ export function BerthDetailPanel({
     } finally {
       setIsRemovingTenant(false);
     }
+  }
+
+  async function handleRevokeInvite() {
+    if (!harborId || !pendingInviteForBerth || isRevokingInvite) return;
+
+    setIsRevokingInvite(true);
+
+    const result = await revokeInvite(
+      harborId,
+      pendingInviteForBerth.invite_id,
+    );
+
+    setIsRevokingInvite(false);
+
+    if (!result.ok) {
+      toast.error(result.error);
+      return;
+    }
+
+    toast.success("Invite revoked.");
+    await reloadInvites();
   }
 
   return (
@@ -455,11 +528,38 @@ export function BerthDetailPanel({
         </div>
 
         <div className="animate-in fade-in slide-in-from-top-4 border-t border-black/5 bg-white/20 p-6 duration-500 delay-700 fill-mode-both">
+          {isHarborMaster && pendingInviteForBerth && (
+            <div className="mb-4 flex items-start justify-between gap-4 rounded-2xl border border-amber-500/20 bg-amber-50 p-4">
+              <div className="min-w-0 space-y-1.5">
+                <p className="text-[9px] font-black uppercase tracking-widest text-amber-700/70">
+                  Pending invite
+                </p>
+                <p className="truncate text-xs font-bold text-amber-900">
+                  {pendingInviteForBerth.email}
+                </p>
+                <p className="text-[9px] font-bold uppercase tracking-widest text-amber-700/60">
+                  Expires{" "}
+                  {new Date(
+                    pendingInviteForBerth.expires_at,
+                  ).toLocaleDateString()}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={handleRevokeInvite}
+                disabled={isRevokingInvite}
+                className="shrink-0 rounded-full bg-amber-500/10 px-4 py-2 text-[9px] font-black uppercase tracking-widest text-amber-700 transition-colors hover:bg-amber-500/20 disabled:opacity-50"
+              >
+                {isRevokingInvite ? "..." : "Revoke"}
+              </button>
+            </div>
+          )}
+
           {canInviteOwner ? (
             <button
               type="button"
               onClick={() => setIsInviteOpen(true)}
-              disabled={!harborId}
+              disabled={!harborId || Boolean(pendingInviteForBerth)}
               className="flex w-full items-center justify-center gap-3 rounded-2xl bg-gradient-to-r from-brand-blue to-brand-cyan py-4 text-[10px] font-black uppercase tracking-widest text-white shadow-lg shadow-brand-blue/20 transition-all hover:-translate-y-0.5 hover:shadow-xl hover:shadow-brand-blue/40 active:translate-y-0 disabled:grayscale disabled:opacity-50"
             >
               <Mail size={16} strokeWidth={3} />
@@ -484,19 +584,20 @@ export function BerthDetailPanel({
           berth={berth}
           harborId={harborId}
           onClose={() => setIsInviteOpen(false)}
+          onCreated={reloadInvites}
         />
       )}
 
       {berth?.assignment && isRemoveTenantOpen && (
         <div className="fixed inset-0 z-[220] grid place-items-center bg-brand-navy/30 p-4 backdrop-blur-sm">
-          <div className="w-full max-w-md rounded-[32px] border border-white/60 bg-white p-6 shadow-deep">
-            <div className="mb-6 flex items-start justify-between gap-4">
+          <div className="w-full max-w-md rounded-[32px] border border-white/60 bg-white p-7 shadow-deep sm:p-8">
+            <div className="mb-8 flex items-start justify-between gap-4">
               <div>
                 <h2 className="text-lg font-black uppercase tracking-tight text-brand-navy">
                   Remove Tenant?
                 </h2>
 
-                <p className="mt-1 text-xs font-bold uppercase tracking-widest text-brand-navy/40">
+                <p className="mt-1.5 text-xs font-bold uppercase tracking-widest text-brand-navy/40">
                   Berth {berth.label || berth.berth_id}
                 </p>
               </div>
@@ -520,28 +621,28 @@ export function BerthDetailPanel({
               . The berth will become free after the update is pushed.
             </p>
 
-            <div className="mt-4 rounded-2xl bg-slate-50 p-4">
+            <div className="mt-6 rounded-2xl bg-slate-50 p-5">
               <p className="text-[10px] font-black uppercase tracking-widest text-brand-navy/40">
                 Tenant
               </p>
 
-              <p className="mt-1 break-all text-xs font-bold text-brand-navy/70">
-                {berth.assignment.user_id}
+              <p className="mt-2 break-all text-xs font-bold text-brand-navy/70">
+                {tenantEmail ?? berth.assignment.user_id}
               </p>
             </div>
 
             {removeTenantError && (
-              <p className="mt-4 rounded-xl bg-red-50 p-3 text-xs font-bold text-red-600">
+              <p className="mt-6 rounded-xl bg-red-50 p-4 text-xs font-bold text-red-600">
                 {removeTenantError}
               </p>
             )}
 
-            <div className="mt-6 grid gap-3 sm:grid-cols-2">
+            <div className="mt-8 grid gap-4 sm:grid-cols-2">
               <button
                 type="button"
                 disabled={isRemovingTenant}
                 onClick={closeRemoveTenantDialog}
-                className="rounded-2xl border border-slate-200 px-6 py-4 text-xs font-black uppercase tracking-widest text-brand-navy/60 transition-all hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                className="h-14 rounded-2xl border border-slate-200 px-6 text-xs font-black uppercase tracking-widest text-brand-navy/60 transition-all hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Cancel
               </button>
@@ -550,7 +651,7 @@ export function BerthDetailPanel({
                 type="button"
                 disabled={isRemovingTenant}
                 onClick={handleRemoveTenant}
-                className="rounded-2xl bg-red-500 px-6 py-4 text-xs font-black uppercase tracking-widest text-white transition-all hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-50"
+                className="h-14 rounded-2xl bg-red-500 px-6 text-xs font-black uppercase tracking-widest text-white transition-all hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isRemovingTenant ? "Removing..." : "Remove"}
               </button>

--- a/frontend/src/components/BerthDetailPanel.tsx
+++ b/frontend/src/components/BerthDetailPanel.tsx
@@ -1,9 +1,11 @@
 import {
   Battery,
   Clock,
+  Mail,
   Ruler,
   ShieldCheck,
   Thermometer,
+  Trash2,
   X,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
@@ -12,6 +14,7 @@ import type { components } from "../api-types";
 import { useBerthDetail } from "../hooks/useBerthDetail";
 import { apiFetch } from "../lib/api";
 import { cn } from "../lib/utils";
+import { InviteOwnerModal } from "./InviteOwnerModal";
 import type { AuthOutletContext } from "./layout/MainLayout";
 
 type Event = components["schemas"]["EventOut"];
@@ -21,6 +24,20 @@ interface BerthDetailPanelProps {
   berthId: string;
   onCloseCB: () => void;
   berth?: Berth;
+}
+
+async function getErrorMessage(res: Response, fallback: string) {
+  try {
+    const data = await res.json();
+
+    if (typeof data.detail === "string") return data.detail;
+    if (typeof data.message === "string") return data.message;
+    if (typeof data.error === "string") return data.error;
+
+    return `${fallback} Status: ${res.status}`;
+  } catch {
+    return `${fallback} Status: ${res.status}`;
+  }
 }
 
 export function BerthDetailPanel({
@@ -33,14 +50,31 @@ export function BerthDetailPanel({
 
   const isHarborMaster = currentUser?.role === "harbormaster";
 
+  const harborId =
+    (currentUser as { harbor_id?: string | null })?.harbor_id ??
+    marinaSlug ??
+    null;
+
   const { berth: fetchedBerth, isLoading, error } = useBerthDetail(berthId);
   const berth = liveBerth || fetchedBerth;
 
   const [events, setEvents] = useState<Event[]>([]);
   const [isEventsLoading, setIsEventsLoading] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
+  const [isInviteOpen, setIsInviteOpen] = useState(false);
+
+  const [isRemoveTenantOpen, setIsRemoveTenantOpen] = useState(false);
+  const [isRemovingTenant, setIsRemovingTenant] = useState(false);
+  const [removeTenantError, setRemoveTenantError] = useState<string | null>(
+    null,
+  );
 
   const closeTimeoutRef = useRef<number | null>(null);
+
+  const canInviteOwner =
+    isHarborMaster && berth?.status === "free" && !berth.assignment;
+
+  const canRemoveTenant = isHarborMaster && Boolean(berth?.assignment);
 
   useEffect(() => {
     if (!isHarborMaster) return;
@@ -112,271 +146,418 @@ export function BerthDetailPanel({
     closePanel();
   }
 
-  return (
-    <aside
-      className={cn(
-        "pointer-events-auto fixed z-[110] flex flex-col overflow-hidden transition-all duration-300",
-        "border border-white/40 bg-white/40 shadow-deep backdrop-blur-xl",
-        "rounded-[32px] p-0 font-body",
-        "bottom-28 left-6 right-6 max-h-[calc(100vh-220px)]",
-        "md:left-auto md:right-8 md:max-w-md",
-        "lg:top-32 lg:right-8 lg:bottom-auto lg:w-80",
-        "animate-in fade-in slide-in-from-bottom-6 duration-500 fill-mode-both lg:slide-in-from-right-8",
-        isClosing && [
-          "animate-out fade-out duration-300 fill-mode-both",
-          "slide-out-to-bottom-6 lg:slide-out-to-right-8",
-        ],
-      )}
-    >
-      <div className="flex items-center justify-between border-b border-black/5 p-6 animate-in fade-in slide-in-from-bottom-4 duration-500 delay-100 fill-mode-both">
-        <div>
-          <h2 className="text-sm font-black uppercase tracking-tight text-brand-navy">
-            Berth Detail
-          </h2>
+  function openRemoveTenantDialog() {
+    setRemoveTenantError(null);
+    setIsRemoveTenantOpen(true);
+  }
 
-          <p className="text-[9px] font-bold uppercase tracking-widest text-brand-navy/40">
-            Live Telemetry
-          </p>
+  function closeRemoveTenantDialog() {
+    if (isRemovingTenant) return;
+
+    setRemoveTenantError(null);
+    setIsRemoveTenantOpen(false);
+  }
+
+  async function handleRemoveTenant() {
+    if (!berth || isRemovingTenant) return;
+
+    setIsRemovingTenant(true);
+    setRemoveTenantError(null);
+
+    try {
+      const res = await apiFetch(`/api/berths/${berth.berth_id}/assignment`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        setRemoveTenantError(
+          await getErrorMessage(res, "Could not remove tenant."),
+        );
+        return;
+      }
+
+      setIsRemoveTenantOpen(false);
+    } catch {
+      setRemoveTenantError("Could not remove tenant. Please try again.");
+    } finally {
+      setIsRemovingTenant(false);
+    }
+  }
+
+  return (
+    <>
+      <aside
+        className={cn(
+          "pointer-events-auto fixed z-[110] flex flex-col overflow-hidden transition-all duration-300",
+          "border border-white/40 bg-white/40 shadow-deep backdrop-blur-xl",
+          "rounded-[32px] p-0 font-body",
+          "bottom-28 left-6 right-6 max-h-[calc(100vh-220px)]",
+          "md:left-auto md:right-8 md:max-w-md",
+          "lg:top-32 lg:right-8 lg:bottom-auto lg:w-80",
+          "animate-in fade-in slide-in-from-bottom-6 duration-500 fill-mode-both lg:slide-in-from-right-8",
+          isClosing && [
+            "animate-out fade-out duration-300 fill-mode-both",
+            "slide-out-to-bottom-6 lg:slide-out-to-right-8",
+          ],
+        )}
+      >
+        <div className="flex items-center justify-between border-b border-black/5 p-6 animate-in fade-in slide-in-from-bottom-4 duration-500 delay-100 fill-mode-both">
+          <div>
+            <h2 className="text-sm font-black uppercase tracking-tight text-brand-navy">
+              Berth Detail
+            </h2>
+
+            <p className="text-[9px] font-bold uppercase tracking-widest text-brand-navy/40">
+              Live Telemetry
+            </p>
+          </div>
+
+          <button
+            type="button"
+            aria-label="Close berth details"
+            onPointerDown={handleClosePointerDown}
+            onPointerUp={handleClosePointerUp}
+            onClick={handleCloseClick}
+            className="pointer-events-auto relative z-[130] flex h-14 w-14 shrink-0 touch-manipulation items-center justify-center rounded-full bg-brand-navy/5 text-brand-navy/60 transition-all hover:scale-110 hover:bg-brand-navy/10 active:scale-95"
+          >
+            <X size={22} strokeWidth={3} />
+          </button>
         </div>
 
-        <button
-          type="button"
-          aria-label="Close berth details"
-          onPointerDown={handleClosePointerDown}
-          onPointerUp={handleClosePointerUp}
-          onClick={handleCloseClick}
-          className="pointer-events-auto relative z-[130] flex h-14 w-14 shrink-0 touch-manipulation items-center justify-center rounded-full bg-brand-navy/5 text-brand-navy/60 transition-all hover:scale-110 hover:bg-brand-navy/10 active:scale-95"
-        >
-          <X size={22} strokeWidth={3} />
-        </button>
-      </div>
+        <div className="custom-scrollbar flex-1 overflow-y-auto p-6">
+          {isLoading ? (
+            <div className="space-y-6">
+              <div className="h-20 w-full animate-pulse rounded-2xl bg-slate-100" />
+              <div className="h-10 w-24 animate-pulse rounded-full bg-slate-100" />
 
-      <div className="custom-scrollbar flex-1 overflow-y-auto p-6">
-        {isLoading ? (
-          <div className="space-y-6">
-            <div className="h-20 w-full animate-pulse rounded-2xl bg-slate-100" />
-            <div className="h-10 w-24 animate-pulse rounded-full bg-slate-100" />
-
-            <div className="grid grid-cols-3 gap-3">
-              <div className="h-12 animate-pulse rounded-xl bg-slate-100" />
-              <div className="h-12 animate-pulse rounded-xl bg-slate-100" />
-              <div className="h-12 animate-pulse rounded-xl bg-slate-100" />
-            </div>
-          </div>
-        ) : error ? (
-          <div className="animate-in zoom-in-95 rounded-2xl border border-red-500/10 bg-red-500/5 p-4 text-xs font-bold text-red-500 duration-300">
-            Error: {error}
-          </div>
-        ) : berth ? (
-          <div className="space-y-6" key={berth.berth_id}>
-            <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 delay-200 fill-mode-both">
-              <span className="mb-1 block text-[9px] font-bold uppercase tracking-widest text-brand-navy/40">
-                Identification
-              </span>
-
-              <span className="text-4xl font-black tracking-tighter text-brand-blue">
-                {berth.label || berth.berth_id}
-              </span>
-            </div>
-
-            <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 delay-300 fill-mode-both">
-              <span className="mb-2 block text-[9px] font-bold uppercase tracking-widest text-brand-navy/40">
-                Current Status
-              </span>
-
-              <div
-                className={cn(
-                  "inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-[10px] font-bold uppercase tracking-wider",
-                  berth.status === "occupied"
-                    ? "border-red-500/20 bg-red-500/10 text-red-500"
-                    : "border-emerald-500/20 bg-emerald-500/10 text-emerald-600",
-                )}
-              >
-                <span
-                  className={cn(
-                    "h-2 w-2 rounded-full",
-                    berth.status === "occupied"
-                      ? "animate-pulse bg-red-500 drop-shadow-[0_0_4px_rgba(239,68,68,0.5)]"
-                      : "bg-emerald-500 glow-emerald",
-                  )}
-                />
-
-                {berth.status}
+              <div className="grid grid-cols-3 gap-3">
+                <div className="h-12 animate-pulse rounded-xl bg-slate-100" />
+                <div className="h-12 animate-pulse rounded-xl bg-slate-100" />
+                <div className="h-12 animate-pulse rounded-xl bg-slate-100" />
               </div>
             </div>
-
-            <div className="grid grid-cols-3 gap-3 animate-in fade-in slide-in-from-bottom-4 duration-500 delay-400 fill-mode-both">
-              {[
-                {
-                  label: "Length",
-                  value: berth.length_m,
-                  unit: "m",
-                  icon: Ruler,
-                },
-                {
-                  label: "Width",
-                  value: berth.width_m,
-                  unit: "m",
-                  icon: Ruler,
-                },
-                {
-                  label: "Depth",
-                  value: berth.depth_m,
-                  unit: "m",
-                  icon: Thermometer,
-                },
-              ].map((item) => (
-                <div
-                  key={item.label}
-                  className="rounded-[20px] border border-white/50 bg-white/80 p-3 shadow-subtle"
-                >
-                  <span className="mb-1 block text-[8px] font-bold uppercase tracking-widest text-brand-navy/40">
-                    {item.label}
-                  </span>
-
-                  <span className="text-xs font-black tracking-tight text-brand-navy">
-                    {item.value ? `${item.value}${item.unit}` : "N/A"}
-                  </span>
-                </div>
-              ))}
+          ) : error ? (
+            <div className="animate-in zoom-in-95 rounded-2xl border border-red-500/10 bg-red-500/5 p-4 text-xs font-bold text-red-500 duration-300">
+              Error: {error}
             </div>
-
-            <div className="animate-in fade-in slide-in-from-bottom-4 rounded-[24px] border border-brand-blue/10 bg-brand-blue/5 p-5 duration-500 delay-500 fill-mode-both">
-              <div className="mb-3 flex items-center gap-2 text-[9px] font-bold uppercase tracking-widest text-brand-blue/60">
-                <Clock size={12} strokeWidth={3} />
-                Node Check-in
-              </div>
-
-              <span className="block w-fit rounded-xl border border-brand-blue/10 bg-white/60 px-3 py-1.5 font-mono text-[10px] font-bold text-brand-navy shadow-sm">
-                {berth.last_updated
-                  ? new Date(berth.last_updated).toLocaleString()
-                  : "Never"}
-              </span>
-            </div>
-
-            {isHarborMaster && berth.assignment && marinaSlug && (
-              <div className="animate-in fade-in slide-in-from-bottom-4 mt-6 border-t border-black/5 pt-6 duration-500 delay-550 fill-mode-both">
-                <span className="mb-3 block text-[9px] font-bold uppercase tracking-widest text-brand-navy/40">
-                  Ownership Details
+          ) : berth ? (
+            <div className="space-y-6" key={berth.berth_id}>
+              <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 delay-200 fill-mode-both">
+                <span className="mb-1 block text-[9px] font-bold uppercase tracking-widest text-brand-navy/40">
+                  Identification
                 </span>
 
-                <Link
-                  to={`/${marinaSlug}/profile/${berth.assignment.user_id}`}
-                  className="group flex items-center gap-4 rounded-2xl border border-white/60 bg-white/60 p-4 shadow-sm transition-all hover:bg-brand-blue/5 hover:shadow-md"
+                <span className="text-4xl font-black tracking-tighter text-brand-blue">
+                  {berth.label || berth.berth_id}
+                </span>
+              </div>
+
+              <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 delay-300 fill-mode-both">
+                <span className="mb-2 block text-[9px] font-bold uppercase tracking-widest text-brand-navy/40">
+                  Current Status
+                </span>
+
+                <div
+                  className={cn(
+                    "inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-[10px] font-bold uppercase tracking-wider",
+                    berth.status === "occupied"
+                      ? "border-red-500/20 bg-red-500/10 text-red-500"
+                      : "border-emerald-500/20 bg-emerald-500/10 text-emerald-600",
+                  )}
                 >
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-blue/10 text-brand-blue transition-transform group-hover:scale-110">
-                    <span className="text-xs font-black">
-                      {berth.assignment.user_id.slice(0, 2).toUpperCase()}
+                  <span
+                    className={cn(
+                      "h-2 w-2 rounded-full",
+                      berth.status === "occupied"
+                        ? "animate-pulse bg-red-500 drop-shadow-[0_0_4px_rgba(239,68,68,0.5)]"
+                        : "bg-emerald-500 glow-emerald",
+                    )}
+                  />
+
+                  {berth.status}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-3 gap-3 animate-in fade-in slide-in-from-bottom-4 duration-500 delay-400 fill-mode-both">
+                {[
+                  {
+                    label: "Length",
+                    value: berth.length_m,
+                    unit: "m",
+                    icon: Ruler,
+                  },
+                  {
+                    label: "Width",
+                    value: berth.width_m,
+                    unit: "m",
+                    icon: Ruler,
+                  },
+                  {
+                    label: "Depth",
+                    value: berth.depth_m,
+                    unit: "m",
+                    icon: Thermometer,
+                  },
+                ].map((item) => (
+                  <div
+                    key={item.label}
+                    className="rounded-[20px] border border-white/50 bg-white/80 p-3 shadow-subtle"
+                  >
+                    <span className="mb-1 block text-[8px] font-bold uppercase tracking-widest text-brand-navy/40">
+                      {item.label}
+                    </span>
+
+                    <span className="text-xs font-black tracking-tight text-brand-navy">
+                      {item.value ? `${item.value}${item.unit}` : "N/A"}
+                    </span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="animate-in fade-in slide-in-from-bottom-4 rounded-[24px] border border-brand-blue/10 bg-brand-blue/5 p-5 duration-500 delay-500 fill-mode-both">
+                <div className="mb-3 flex items-center gap-2 text-[9px] font-bold uppercase tracking-widest text-brand-blue/60">
+                  <Clock size={12} strokeWidth={3} />
+                  Node Check-in
+                </div>
+
+                <span className="block w-fit rounded-xl border border-brand-blue/10 bg-white/60 px-3 py-1.5 font-mono text-[10px] font-bold text-brand-navy shadow-sm">
+                  {berth.last_updated
+                    ? new Date(berth.last_updated).toLocaleString()
+                    : "Never"}
+                </span>
+              </div>
+
+              {isHarborMaster && berth.assignment && marinaSlug && (
+                <div className="animate-in fade-in slide-in-from-bottom-4 mt-6 border-t border-black/5 pt-6 duration-500 delay-550 fill-mode-both">
+                  <span className="mb-3 block text-[9px] font-bold uppercase tracking-widest text-brand-navy/40">
+                    Ownership Details
+                  </span>
+
+                  <Link
+                    to={`/${marinaSlug}/profile/${berth.assignment.user_id}`}
+                    className="group flex items-center gap-4 rounded-2xl border border-white/60 bg-white/60 p-4 shadow-sm transition-all hover:bg-brand-blue/5 hover:shadow-md"
+                  >
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-blue/10 text-brand-blue transition-transform group-hover:scale-110">
+                      <span className="text-xs font-black">
+                        {berth.assignment.user_id.slice(0, 2).toUpperCase()}
+                      </span>
+                    </div>
+
+                    <div className="min-w-0">
+                      <p className="text-[10px] font-black uppercase tracking-widest text-brand-navy transition-colors group-hover:text-brand-blue">
+                        Owner Profile
+                      </p>
+
+                      <p className="truncate text-[9px] font-bold text-brand-navy/40">
+                        ID: {berth.assignment.user_id}
+                      </p>
+                    </div>
+                  </Link>
+
+                  {canRemoveTenant && (
+                    <button
+                      type="button"
+                      onClick={openRemoveTenantDialog}
+                      className="mt-3 flex w-full items-center justify-center gap-2 rounded-2xl border border-red-500/15 bg-red-500/5 px-4 py-3 text-[10px] font-black uppercase tracking-widest text-red-500 transition-all hover:bg-red-500/10 active:scale-[0.98]"
+                    >
+                      <Trash2 size={14} strokeWidth={3} />
+                      Remove Tenant
+                    </button>
+                  )}
+                </div>
+              )}
+
+              {berth.battery_pct != null && (
+                <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 delay-600 fill-mode-both">
+                  <div className="mb-3 flex items-center justify-between">
+                    <span className="flex items-center gap-1 text-[9px] font-bold uppercase tracking-widest text-brand-navy/50">
+                      <Battery size={12} strokeWidth={3} />
+                      Node Battery
+                    </span>
+
+                    <span className="text-[10px] font-black tracking-tighter text-brand-navy">
+                      {berth.battery_pct}%
                     </span>
                   </div>
 
-                  <div className="min-w-0">
-                    <p className="text-[10px] font-black uppercase tracking-widest text-brand-navy transition-colors group-hover:text-brand-blue">
-                      Owner Profile
-                    </p>
-
-                    <p className="truncate text-[9px] font-bold text-brand-navy/40">
-                      ID: {berth.assignment.user_id}
-                    </p>
+                  <div className="h-3 overflow-hidden rounded-full border border-black/5 bg-slate-100 p-0.5">
+                    <div
+                      className={cn(
+                        "h-full rounded-full transition-all duration-1000 ease-out",
+                        berth.battery_pct < 20
+                          ? "bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.4)]"
+                          : "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.4)]",
+                      )}
+                      style={{ width: `${berth.battery_pct}%` }}
+                    />
                   </div>
-                </Link>
-              </div>
-            )}
+                </div>
+              )}
 
-            {berth.battery_pct != null && (
-              <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 delay-600 fill-mode-both">
-                <div className="mb-3 flex items-center justify-between">
-                  <span className="flex items-center gap-1 text-[9px] font-bold uppercase tracking-widest text-brand-navy/50">
-                    <Battery size={12} strokeWidth={3} />
-                    Node Battery
+              {isHarborMaster && (
+                <div className="animate-in fade-in slide-in-from-bottom-4 mt-6 border-t border-black/5 pt-6 duration-500 delay-750 fill-mode-both">
+                  <span className="mb-4 block text-[9px] font-bold uppercase tracking-widest text-brand-navy/40">
+                    Recent Activity
                   </span>
 
-                  <span className="text-[10px] font-black tracking-tighter text-brand-navy">
-                    {berth.battery_pct}%
-                  </span>
-                </div>
-
-                <div className="h-3 overflow-hidden rounded-full border border-black/5 bg-slate-100 p-0.5">
-                  <div
-                    className={cn(
-                      "h-full rounded-full transition-all duration-1000 ease-out",
-                      berth.battery_pct < 20
-                        ? "bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.4)]"
-                        : "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.4)]",
-                    )}
-                    style={{ width: `${berth.battery_pct}%` }}
-                  />
-                </div>
-              </div>
-            )}
-
-            {isHarborMaster && (
-              <div className="animate-in fade-in slide-in-from-bottom-4 mt-6 border-t border-black/5 pt-6 duration-500 delay-750 fill-mode-both">
-                <span className="mb-4 block text-[9px] font-bold uppercase tracking-widest text-brand-navy/40">
-                  Recent Activity
-                </span>
-
-                {isEventsLoading ? (
-                  <div className="flex justify-center py-4">
-                    <div className="h-4 w-4 animate-spin rounded-full border-2 border-brand-blue/30 border-t-brand-blue" />
-                  </div>
-                ) : events.length === 0 ? (
-                  <p className="py-4 text-center text-[10px] font-bold uppercase tracking-widest text-brand-navy/20">
-                    No recent events
-                  </p>
-                ) : (
-                  <div className="space-y-3">
-                    {events.slice(0, 5).map((ev) => (
-                      <div key={ev.event_id} className="flex items-start gap-3">
+                  {isEventsLoading ? (
+                    <div className="flex justify-center py-4">
+                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-brand-blue/30 border-t-brand-blue" />
+                    </div>
+                  ) : events.length === 0 ? (
+                    <p className="py-4 text-center text-[10px] font-bold uppercase tracking-widest text-brand-navy/20">
+                      No recent events
+                    </p>
+                  ) : (
+                    <div className="space-y-3">
+                      {events.slice(0, 5).map((ev) => (
                         <div
-                          className={cn(
-                            "mt-1.5 h-1.5 w-1.5 rounded-full",
-                            ev.event_type === "occupied"
-                              ? "bg-red-500"
-                              : ev.event_type === "freed"
-                                ? "bg-emerald-500"
-                                : "bg-slate-300",
-                          )}
-                        />
+                          key={ev.event_id}
+                          className="flex items-start gap-3"
+                        >
+                          <div
+                            className={cn(
+                              "mt-1.5 h-1.5 w-1.5 rounded-full",
+                              ev.event_type === "occupied"
+                                ? "bg-red-500"
+                                : ev.event_type === "freed"
+                                  ? "bg-emerald-500"
+                                  : "bg-slate-300",
+                            )}
+                          />
 
-                        <div className="flex-1">
-                          <p className="text-[11px] font-bold capitalize text-brand-navy/70">
-                            {ev.event_type}
-                          </p>
+                          <div className="flex-1">
+                            <p className="text-[11px] font-bold capitalize text-brand-navy/70">
+                              {ev.event_type}
+                            </p>
 
-                          <p className="text-[8px] font-bold uppercase tracking-widest text-brand-navy/30">
-                            {new Date(ev.timestamp).toLocaleString([], {
-                              month: "short",
-                              day: "numeric",
-                              hour: "2-digit",
-                              minute: "2-digit",
-                            })}
-                          </p>
+                            <p className="text-[8px] font-bold uppercase tracking-widest text-brand-navy/30">
+                              {new Date(ev.timestamp).toLocaleString([], {
+                                month: "short",
+                                day: "numeric",
+                                hour: "2-digit",
+                                minute: "2-digit",
+                              })}
+                            </p>
+                          </div>
                         </div>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-        ) : (
-          <div className="py-12 text-center text-[10px] font-bold uppercase tracking-widest text-brand-navy/20">
-            No berth found
-          </div>
-        )}
-      </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="py-12 text-center text-[10px] font-bold uppercase tracking-widest text-brand-navy/20">
+              No berth found
+            </div>
+          )}
+        </div>
 
-      <div className="animate-in fade-in slide-in-from-top-4 border-t border-black/5 bg-white/20 p-6 duration-500 delay-700 fill-mode-both">
-        <button
-          type="button"
-          disabled
-          className="flex w-full items-center justify-center gap-3 rounded-2xl bg-gradient-to-r from-brand-blue to-brand-cyan py-4 text-[10px] font-black uppercase tracking-widest text-white shadow-lg shadow-brand-blue/20 transition-all hover:-translate-y-0.5 hover:shadow-xl hover:shadow-brand-blue/40 active:translate-y-0 disabled:grayscale disabled:opacity-50"
-        >
-          <ShieldCheck size={16} strokeWidth={3} />
-          Book Berth
-        </button>
-      </div>
-    </aside>
+        <div className="animate-in fade-in slide-in-from-top-4 border-t border-black/5 bg-white/20 p-6 duration-500 delay-700 fill-mode-both">
+          {canInviteOwner ? (
+            <button
+              type="button"
+              onClick={() => setIsInviteOpen(true)}
+              disabled={!harborId}
+              className="flex w-full items-center justify-center gap-3 rounded-2xl bg-gradient-to-r from-brand-blue to-brand-cyan py-4 text-[10px] font-black uppercase tracking-widest text-white shadow-lg shadow-brand-blue/20 transition-all hover:-translate-y-0.5 hover:shadow-xl hover:shadow-brand-blue/40 active:translate-y-0 disabled:grayscale disabled:opacity-50"
+            >
+              <Mail size={16} strokeWidth={3} />
+              Invite Owner
+            </button>
+          ) : (
+            <button
+              type="button"
+              disabled
+              className="flex w-full items-center justify-center gap-3 rounded-2xl bg-gradient-to-r from-brand-blue to-brand-cyan py-4 text-[10px] font-black uppercase tracking-widest text-white shadow-lg shadow-brand-blue/20 transition-all disabled:grayscale disabled:opacity-50"
+            >
+              <ShieldCheck size={16} strokeWidth={3} />
+              Book Berth
+            </button>
+          )}
+        </div>
+      </aside>
+
+      {berth && harborId && (
+        <InviteOwnerModal
+          open={isInviteOpen}
+          berth={berth}
+          harborId={harborId}
+          onClose={() => setIsInviteOpen(false)}
+        />
+      )}
+
+      {berth?.assignment && isRemoveTenantOpen && (
+        <div className="fixed inset-0 z-[220] grid place-items-center bg-brand-navy/30 p-4 backdrop-blur-sm">
+          <div className="w-full max-w-md rounded-[32px] border border-white/60 bg-white p-6 shadow-deep">
+            <div className="mb-6 flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-black uppercase tracking-tight text-brand-navy">
+                  Remove Tenant?
+                </h2>
+
+                <p className="mt-1 text-xs font-bold uppercase tracking-widest text-brand-navy/40">
+                  Berth {berth.label || berth.berth_id}
+                </p>
+              </div>
+
+              <button
+                type="button"
+                onClick={closeRemoveTenantDialog}
+                disabled={isRemovingTenant}
+                className="grid h-10 w-10 place-items-center rounded-full bg-brand-navy/5 text-brand-navy/60 transition-colors hover:bg-brand-navy/10 disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label="Close remove tenant dialog"
+              >
+                <X size={16} strokeWidth={3} />
+              </button>
+            </div>
+
+            <p className="text-sm font-bold leading-relaxed text-brand-navy/60">
+              This will remove the tenant from berth{" "}
+              <span className="text-brand-navy">
+                {berth.label || berth.berth_id}
+              </span>
+              . The berth will become free after the update is pushed.
+            </p>
+
+            <div className="mt-4 rounded-2xl bg-slate-50 p-4">
+              <p className="text-[10px] font-black uppercase tracking-widest text-brand-navy/40">
+                Tenant
+              </p>
+
+              <p className="mt-1 break-all text-xs font-bold text-brand-navy/70">
+                {berth.assignment.user_id}
+              </p>
+            </div>
+
+            {removeTenantError && (
+              <p className="mt-4 rounded-xl bg-red-50 p-3 text-xs font-bold text-red-600">
+                {removeTenantError}
+              </p>
+            )}
+
+            <div className="mt-6 grid gap-3 sm:grid-cols-2">
+              <button
+                type="button"
+                disabled={isRemovingTenant}
+                onClick={closeRemoveTenantDialog}
+                className="rounded-2xl border border-slate-200 px-6 py-4 text-xs font-black uppercase tracking-widest text-brand-navy/60 transition-all hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Cancel
+              </button>
+
+              <button
+                type="button"
+                disabled={isRemovingTenant}
+                onClick={handleRemoveTenant}
+                className="rounded-2xl bg-red-500 px-6 py-4 text-xs font-black uppercase tracking-widest text-white transition-all hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isRemovingTenant ? "Removing..." : "Remove"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/frontend/src/components/BerthDetailPanel.tsx
+++ b/frontend/src/components/BerthDetailPanel.tsx
@@ -3,7 +3,6 @@ import {
   Clock,
   Mail,
   Ruler,
-  ShieldCheck,
   Thermometer,
   Trash2,
   X,
@@ -90,8 +89,9 @@ export function BerthDetailPanel({
 
   const closeTimeoutRef = useRef<number | null>(null);
 
-  const canInviteOwner =
-    isHarborMaster && berth?.status === "free" && !berth.assignment;
+  // booking is scrapped, so invite is the only owner-facing action;
+  // status doesn't gate it — occupied + unassigned still needs an owner
+  const canInviteOwner = isHarborMaster && Boolean(berth) && !berth?.assignment;
 
   const canRemoveTenant = isHarborMaster && Boolean(berth?.assignment);
 
@@ -527,35 +527,35 @@ export function BerthDetailPanel({
           )}
         </div>
 
-        <div className="animate-in fade-in slide-in-from-top-4 border-t border-black/5 bg-white/20 p-6 duration-500 delay-700 fill-mode-both">
-          {isHarborMaster && pendingInviteForBerth && (
-            <div className="mb-4 flex items-start justify-between gap-4 rounded-2xl border border-amber-500/20 bg-amber-50 p-4">
-              <div className="min-w-0 space-y-1.5">
-                <p className="text-[9px] font-black uppercase tracking-widest text-amber-700/70">
-                  Pending invite
-                </p>
-                <p className="truncate text-xs font-bold text-amber-900">
-                  {pendingInviteForBerth.email}
-                </p>
-                <p className="text-[9px] font-bold uppercase tracking-widest text-amber-700/60">
-                  Expires{" "}
-                  {new Date(
-                    pendingInviteForBerth.expires_at,
-                  ).toLocaleDateString()}
-                </p>
+        {canInviteOwner && (
+          <div className="animate-in fade-in slide-in-from-top-4 border-t border-black/5 bg-white/20 p-6 duration-500 delay-700 fill-mode-both">
+            {pendingInviteForBerth && (
+              <div className="mb-4 flex items-start justify-between gap-4 rounded-2xl border border-amber-500/20 bg-amber-50 p-4">
+                <div className="min-w-0 space-y-1.5">
+                  <p className="text-[9px] font-black uppercase tracking-widest text-amber-700/70">
+                    Pending invite
+                  </p>
+                  <p className="truncate text-xs font-bold text-amber-900">
+                    {pendingInviteForBerth.email}
+                  </p>
+                  <p className="text-[9px] font-bold uppercase tracking-widest text-amber-700/60">
+                    Expires{" "}
+                    {new Date(
+                      pendingInviteForBerth.expires_at,
+                    ).toLocaleDateString()}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={handleRevokeInvite}
+                  disabled={isRevokingInvite}
+                  className="shrink-0 rounded-full bg-amber-500/10 px-4 py-2 text-[9px] font-black uppercase tracking-widest text-amber-700 transition-colors hover:bg-amber-500/20 disabled:opacity-50"
+                >
+                  {isRevokingInvite ? "..." : "Revoke"}
+                </button>
               </div>
-              <button
-                type="button"
-                onClick={handleRevokeInvite}
-                disabled={isRevokingInvite}
-                className="shrink-0 rounded-full bg-amber-500/10 px-4 py-2 text-[9px] font-black uppercase tracking-widest text-amber-700 transition-colors hover:bg-amber-500/20 disabled:opacity-50"
-              >
-                {isRevokingInvite ? "..." : "Revoke"}
-              </button>
-            </div>
-          )}
+            )}
 
-          {canInviteOwner ? (
             <button
               type="button"
               onClick={() => setIsInviteOpen(true)}
@@ -565,17 +565,8 @@ export function BerthDetailPanel({
               <Mail size={16} strokeWidth={3} />
               Invite Owner
             </button>
-          ) : (
-            <button
-              type="button"
-              disabled
-              className="flex w-full items-center justify-center gap-3 rounded-2xl bg-gradient-to-r from-brand-blue to-brand-cyan py-4 text-[10px] font-black uppercase tracking-widest text-white shadow-lg shadow-brand-blue/20 transition-all disabled:grayscale disabled:opacity-50"
-            >
-              <ShieldCheck size={16} strokeWidth={3} />
-              Book Berth
-            </button>
-          )}
-        </div>
+          </div>
+        )}
       </aside>
 
       {berth && harborId && (

--- a/frontend/src/components/InviteOwnerModal.tsx
+++ b/frontend/src/components/InviteOwnerModal.tsx
@@ -1,8 +1,12 @@
 import { Loader2, Mail, X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { components } from "../api-types";
-import { useBerthInvites } from "../hooks/useBerthInvites";
+import {
+  createInvite,
+  type HarborUser,
+  searchHarborUsers,
+} from "../hooks/useBerthInvites";
 import { cn } from "../lib/utils";
 
 type Berth = components["schemas"]["BerthOut"];
@@ -26,19 +30,59 @@ export function InviteOwnerModal({
   onClose,
   onCreated,
 }: InviteOwnerModalProps) {
-  const { createInvite } = useBerthInvites(harborId);
-
   const [email, setEmail] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  const [suggestions, setSuggestions] = useState<HarborUser[]>([]);
+  const [isSuggesting, setIsSuggesting] = useState(false);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const debounceRef = useRef<number | null>(null);
+
+  // debounced lookup of users known to this harbor; aborts on each keystroke
+  // so racing responses can't overwrite a fresher result
+  useEffect(() => {
+    if (!open) return;
+    if (debounceRef.current) {
+      window.clearTimeout(debounceRef.current);
+    }
+    const trimmed = email.trim();
+    if (trimmed.length < 2) {
+      setSuggestions([]);
+      setIsSuggesting(false);
+      return;
+    }
+    setIsSuggesting(true);
+    debounceRef.current = window.setTimeout(async () => {
+      const rows = await searchHarborUsers(harborId, trimmed);
+      // drop the suggestion if it's the only match and equals the typed email,
+      // saves a "pick yourself" click
+      const filtered = rows.filter(
+        (u) => u.email.toLowerCase() !== trimmed.toLowerCase(),
+      );
+      setSuggestions(filtered);
+      setIsSuggesting(false);
+    }, 250);
+    return () => {
+      if (debounceRef.current) window.clearTimeout(debounceRef.current);
+    };
+  }, [email, harborId, open]);
+
   if (!open) return null;
+
+  function pickUser(user: HarborUser) {
+    setEmail(user.email);
+    setShowSuggestions(false);
+    setSuggestions([]);
+  }
 
   function handleClose() {
     if (isSubmitting) return;
 
     setEmail("");
     setError(null);
+    setSuggestions([]);
+    setShowSuggestions(false);
     onClose();
   }
 
@@ -58,7 +102,7 @@ export function InviteOwnerModal({
     setIsSubmitting(true);
 
     try {
-      const result = await createInvite(berth.berth_id, trimmedEmail);
+      const result = await createInvite(harborId, berth.berth_id, trimmedEmail);
 
       if (!result.ok) {
         setError(result.error);
@@ -67,6 +111,7 @@ export function InviteOwnerModal({
 
       toast.success("Invite sent.");
       setEmail("");
+      setSuggestions([]);
       onCreated?.();
       onClose();
     } finally {
@@ -74,16 +119,19 @@ export function InviteOwnerModal({
     }
   }
 
+  const suggestionsVisible =
+    showSuggestions && (suggestions.length > 0 || isSuggesting);
+
   return (
     <div className="fixed inset-0 z-[200] grid place-items-center bg-brand-navy/30 p-4 backdrop-blur-sm">
-      <div className="w-full max-w-md rounded-[32px] border border-white/60 bg-white p-6 shadow-deep">
-        <header className="mb-6 flex items-start justify-between gap-4">
+      <div className="w-full max-w-md rounded-[32px] border border-white/60 bg-white p-7 shadow-deep sm:p-8">
+        <header className="mb-8 flex items-start justify-between gap-4">
           <div>
             <h2 className="text-lg font-black uppercase tracking-tight text-brand-navy">
               Invite Owner
             </h2>
 
-            <p className="mt-1 text-xs font-bold uppercase tracking-widest text-brand-navy/40">
+            <p className="mt-1.5 text-xs font-bold uppercase tracking-widest text-brand-navy/40">
               Berth {berth.label || berth.berth_id}
             </p>
           </div>
@@ -99,17 +147,17 @@ export function InviteOwnerModal({
           </button>
         </header>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-6">
           <fieldset
             disabled={isSubmitting}
-            className="m-0 space-y-4 border-0 p-0 disabled:opacity-60"
+            className="m-0 space-y-6 border-0 p-0 disabled:opacity-60"
           >
             <div>
               <label
                 htmlFor="invite-email"
-                className="mb-2 block text-[10px] font-black uppercase tracking-widest text-brand-navy/50"
+                className="mb-3 block text-[10px] font-black uppercase tracking-widest text-brand-navy/50"
               >
-                Invitee email
+                Invitee — search known users or type any email
               </label>
 
               <div className="relative">
@@ -125,10 +173,45 @@ export function InviteOwnerModal({
                   onChange={(e) => {
                     setEmail(e.target.value);
                     setError(null);
+                    setShowSuggestions(true);
                   }}
+                  onFocus={() => setShowSuggestions(true)}
+                  onBlur={() =>
+                    // delay so a click on a suggestion still registers
+                    window.setTimeout(() => setShowSuggestions(false), 150)
+                  }
                   placeholder="owner@example.com"
-                  className="h-12 w-full rounded-2xl border border-black/5 bg-slate-50 pl-11 pr-4 text-sm font-bold text-brand-navy outline-none transition-all focus:border-brand-blue focus:ring-2 focus:ring-brand-blue/20"
+                  autoComplete="off"
+                  className="h-14 w-full rounded-2xl border border-black/5 bg-slate-50 pl-12 pr-4 text-sm font-bold text-brand-navy outline-none transition-all focus:border-brand-blue focus:ring-2 focus:ring-brand-blue/20"
                 />
+
+                {suggestionsVisible && (
+                  <ul className="absolute left-0 right-0 top-full z-10 mt-2 max-h-60 overflow-y-auto rounded-2xl border border-black/5 bg-white shadow-lg">
+                    {isSuggesting && suggestions.length === 0 ? (
+                      <li className="px-4 py-3 text-xs font-bold text-brand-navy/40">
+                        Searching...
+                      </li>
+                    ) : (
+                      suggestions.map((u) => (
+                        <li key={u.user_id}>
+                          <button
+                            type="button"
+                            onMouseDown={(e) => e.preventDefault()}
+                            onClick={() => pickUser(u)}
+                            className="block w-full px-4 py-3 text-left transition-colors hover:bg-brand-blue/5"
+                          >
+                            <p className="text-sm font-bold text-brand-navy">
+                              {u.firstname} {u.lastname}
+                            </p>
+                            <p className="text-xs text-brand-navy/50">
+                              {u.email}
+                            </p>
+                          </button>
+                        </li>
+                      ))
+                    )}
+                  </ul>
+                )}
               </div>
             </div>
           </fieldset>
@@ -139,12 +222,12 @@ export function InviteOwnerModal({
             </p>
           )}
 
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid gap-4 pt-2 sm:grid-cols-2">
             <button
               type="button"
               disabled={isSubmitting}
               onClick={handleClose}
-              className="h-12 rounded-2xl border border-slate-200 px-4 text-[10px] font-black uppercase tracking-widest text-brand-navy/60 transition-all hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+              className="h-14 rounded-2xl border border-slate-200 px-4 text-[10px] font-black uppercase tracking-widest text-brand-navy/60 transition-all hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
             >
               Cancel
             </button>
@@ -153,7 +236,7 @@ export function InviteOwnerModal({
               type="submit"
               disabled={isSubmitting || !email.trim()}
               className={cn(
-                "flex h-12 items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-brand-blue to-brand-cyan px-4 text-[10px] font-black uppercase tracking-widest text-white shadow-lg shadow-brand-blue/20 transition-all",
+                "flex h-14 items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-brand-blue to-brand-cyan px-4 text-[10px] font-black uppercase tracking-widest text-white shadow-lg shadow-brand-blue/20 transition-all",
                 "disabled:cursor-not-allowed disabled:opacity-50",
               )}
             >

--- a/frontend/src/components/InviteOwnerModal.tsx
+++ b/frontend/src/components/InviteOwnerModal.tsx
@@ -1,0 +1,168 @@
+import { Loader2, Mail, X } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import type { components } from "../api-types";
+import { useBerthInvites } from "../hooks/useBerthInvites";
+import { cn } from "../lib/utils";
+
+type Berth = components["schemas"]["BerthOut"];
+
+interface InviteOwnerModalProps {
+  open: boolean;
+  berth: Berth;
+  harborId: string;
+  onClose: () => void;
+  onCreated?: () => void;
+}
+
+function isValidEmail(email: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+}
+
+export function InviteOwnerModal({
+  open,
+  berth,
+  harborId,
+  onClose,
+  onCreated,
+}: InviteOwnerModalProps) {
+  const { createInvite } = useBerthInvites(harborId);
+
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (!open) return null;
+
+  function handleClose() {
+    if (isSubmitting) return;
+
+    setEmail("");
+    setError(null);
+    onClose();
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    if (isSubmitting) return;
+
+    const trimmedEmail = email.trim().toLowerCase();
+
+    if (!isValidEmail(trimmedEmail)) {
+      setError("Enter a valid email address.");
+      return;
+    }
+
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const result = await createInvite(berth.berth_id, trimmedEmail);
+
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+
+      toast.success("Invite sent.");
+      setEmail("");
+      onCreated?.();
+      onClose();
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[200] grid place-items-center bg-brand-navy/30 p-4 backdrop-blur-sm">
+      <div className="w-full max-w-md rounded-[32px] border border-white/60 bg-white p-6 shadow-deep">
+        <header className="mb-6 flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-black uppercase tracking-tight text-brand-navy">
+              Invite Owner
+            </h2>
+
+            <p className="mt-1 text-xs font-bold uppercase tracking-widest text-brand-navy/40">
+              Berth {berth.label || berth.berth_id}
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={isSubmitting}
+            className="grid h-10 w-10 place-items-center rounded-full bg-brand-navy/5 text-brand-navy/60 transition-colors hover:bg-brand-navy/10 disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Close invite modal"
+          >
+            <X size={16} strokeWidth={3} />
+          </button>
+        </header>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <fieldset
+            disabled={isSubmitting}
+            className="m-0 space-y-4 border-0 p-0 disabled:opacity-60"
+          >
+            <div>
+              <label
+                htmlFor="invite-email"
+                className="mb-2 block text-[10px] font-black uppercase tracking-widest text-brand-navy/50"
+              >
+                Invitee email
+              </label>
+
+              <div className="relative">
+                <Mail
+                  size={16}
+                  className="absolute left-4 top-1/2 -translate-y-1/2 text-brand-navy/30"
+                />
+
+                <input
+                  id="invite-email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => {
+                    setEmail(e.target.value);
+                    setError(null);
+                  }}
+                  placeholder="owner@example.com"
+                  className="h-12 w-full rounded-2xl border border-black/5 bg-slate-50 pl-11 pr-4 text-sm font-bold text-brand-navy outline-none transition-all focus:border-brand-blue focus:ring-2 focus:ring-brand-blue/20"
+                />
+              </div>
+            </div>
+          </fieldset>
+
+          {error && (
+            <p className="rounded-xl bg-red-50 p-3 text-xs font-bold text-red-600">
+              {error}
+            </p>
+          )}
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <button
+              type="button"
+              disabled={isSubmitting}
+              onClick={handleClose}
+              className="h-12 rounded-2xl border border-slate-200 px-4 text-[10px] font-black uppercase tracking-widest text-brand-navy/60 transition-all hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Cancel
+            </button>
+
+            <button
+              type="submit"
+              disabled={isSubmitting || !email.trim()}
+              className={cn(
+                "flex h-12 items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-brand-blue to-brand-cyan px-4 text-[10px] font-black uppercase tracking-widest text-white shadow-lg shadow-brand-blue/20 transition-all",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+              )}
+            >
+              {isSubmitting && <Loader2 size={16} className="animate-spin" />}
+              {isSubmitting ? "Sending..." : "Send Invite"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/AuthDialog.tsx
+++ b/frontend/src/components/layout/AuthDialog.tsx
@@ -1,6 +1,6 @@
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { Loader2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { apiFetch } from "../../lib/api";
 import { useAuth } from "../../lib/auth-context";
@@ -67,9 +67,18 @@ async function getErrorMessage(
 interface AuthDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  prefillEmail?: string;
+  lockEmail?: boolean;
+  defaultTab?: "login" | "signup";
 }
 
-export function AuthDialog({ open, onOpenChange }: AuthDialogProps) {
+export function AuthDialog({
+  open,
+  onOpenChange,
+  prefillEmail,
+  lockEmail = false,
+  defaultTab = "login",
+}: AuthDialogProps) {
   const { refresh } = useAuth();
 
   const [authTab, setAuthTab] = useState<AuthTab>("login");
@@ -98,6 +107,21 @@ export function AuthDialog({ open, onOpenChange }: AuthDialogProps) {
     passwordValid &&
     signupForm.confirmPassword.length > 0 &&
     !passwordMismatch;
+
+  useEffect(() => {
+    if (!open) return;
+
+    setAuthTab(defaultTab);
+    setError(null);
+
+    if (prefillEmail) {
+      setLoginEmail(prefillEmail);
+      setSignupForm((prev) => ({
+        ...prev,
+        email: prefillEmail,
+      }));
+    }
+  }, [open, prefillEmail, defaultTab]);
 
   function updateSignupField<K extends keyof SignupForm>(
     field: K,
@@ -194,6 +218,9 @@ export function AuthDialog({ open, onOpenChange }: AuthDialogProps) {
     }
   }
 
+  const lockedEmailClass =
+    lockEmail && "cursor-not-allowed bg-slate-100 text-brand-navy/60";
+
   return (
     <Dialog
       open={open}
@@ -284,12 +311,15 @@ export function AuthDialog({ open, onOpenChange }: AuthDialogProps) {
                     autoComplete="email"
                     placeholder="name@marina.com"
                     required
+                    readOnly={lockEmail}
+                    aria-readonly={lockEmail}
                     value={loginEmail}
                     onChange={(e) => {
+                      if (lockEmail) return;
                       setLoginEmail(e.target.value);
                       setError(null);
                     }}
-                    className={fieldInputClass}
+                    className={cn(fieldInputClass, lockedEmailClass)}
                   />
                 </div>
 
@@ -363,9 +393,14 @@ export function AuthDialog({ open, onOpenChange }: AuthDialogProps) {
                     autoComplete="email"
                     placeholder="name@marina.com"
                     required
+                    readOnly={lockEmail}
+                    aria-readonly={lockEmail}
                     value={signupForm.email}
-                    onChange={(e) => updateSignupField("email", e.target.value)}
-                    className={fieldInputClass}
+                    onChange={(e) => {
+                      if (lockEmail) return;
+                      updateSignupField("email", e.target.value);
+                    }}
+                    className={cn(fieldInputClass, lockedEmailClass)}
                   />
                 </div>
 

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -14,20 +14,31 @@ import { SideMenu } from "./SideMenu";
 
 export type { AuthUser } from "../../lib/auth-context";
 
+export type AuthDialogOptions = {
+  prefillEmail?: string;
+  lockEmail?: boolean;
+  defaultTab?: "login" | "signup";
+};
+
 export type AuthOutletContext = {
   user: AuthUser | null;
   isLoginOpen: boolean;
   setIsLoginOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  openAuthDialog: (options?: AuthDialogOptions) => void;
 };
 
 interface MainLayoutContentProps {
   isLoginOpen: boolean;
   setIsLoginOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  authDialogOptions: AuthDialogOptions;
+  openAuthDialog: (options?: AuthDialogOptions) => void;
 }
 
 function MainLayoutContent({
   isLoginOpen,
   setIsLoginOpen,
+  authDialogOptions,
+  openAuthDialog,
 }: MainLayoutContentProps) {
   const navigate = useNavigate();
   const { user, logout } = useAuth();
@@ -47,7 +58,9 @@ function MainLayoutContent({
 
   async function handleLogout() {
     if (isLoggingOut) return;
+
     setIsLoggingOut(true);
+
     try {
       await logout();
       setIsLoginOpen(false);
@@ -55,6 +68,10 @@ function MainLayoutContent({
     } finally {
       setIsLoggingOut(false);
     }
+  }
+
+  function handleAuthDialogOpenChange(nextOpen: boolean) {
+    setIsLoginOpen(nextOpen);
   }
 
   const userInitials =
@@ -68,7 +85,7 @@ function MainLayoutContent({
         isLoggedIn={Boolean(user)}
         isLoggingOut={isLoggingOut}
         userInitials={userInitials}
-        onLoginClickCB={() => setIsLoginOpen(true)}
+        onLoginClickCB={() => openAuthDialog()}
         onLogoutClickCB={handleLogout}
       />
 
@@ -95,14 +112,20 @@ function MainLayoutContent({
               user,
               isLoginOpen,
               setIsLoginOpen,
+              openAuthDialog,
             } satisfies AuthOutletContext
           }
         />
       </main>
 
-      <AuthDialog open={isLoginOpen} onOpenChange={setIsLoginOpen} />
+      <AuthDialog
+        open={isLoginOpen}
+        onOpenChange={handleAuthDialogOpenChange}
+        prefillEmail={authDialogOptions.prefillEmail}
+        lockEmail={authDialogOptions.lockEmail}
+        defaultTab={authDialogOptions.defaultTab}
+      />
 
-      {/* mobile harbormaster has bottom dock, footer would clash */}
       {!isDesktop && isHarborMaster ? null : <Footer />}
 
       <Toaster position="top-center" richColors />
@@ -112,13 +135,24 @@ function MainLayoutContent({
 
 function MainLayout() {
   const [isLoginOpen, setIsLoginOpen] = useState(false);
+  const [authDialogOptions, setAuthDialogOptions] = useState<AuthDialogOptions>(
+    {},
+  );
+
   const { user } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
+
+  function openAuthDialog(options?: AuthDialogOptions) {
+    setAuthDialogOptions(options ?? {});
+    setIsLoginOpen(true);
+  }
 
   // route guard redirect lands here with ?login=1, open the dialog and consume the flag
   useEffect(() => {
     if (searchParams.get("login") === "1") {
+      setAuthDialogOptions({});
       setIsLoginOpen(true);
+
       const next = new URLSearchParams(searchParams);
       next.delete("login");
       setSearchParams(next, { replace: true });
@@ -130,6 +164,8 @@ function MainLayout() {
       <MainLayoutContent
         isLoginOpen={isLoginOpen}
         setIsLoginOpen={setIsLoginOpen}
+        authDialogOptions={authDialogOptions}
+        openAuthDialog={openAuthDialog}
       />
     </DashboardLayoutProvider>
   );

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Outlet, useNavigate, useSearchParams } from "react-router-dom";
 import { Toaster } from "sonner";
 import { type AuthUser, useAuth } from "../../lib/auth-context";
@@ -142,10 +142,10 @@ function MainLayout() {
   const { user } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  function openAuthDialog(options?: AuthDialogOptions) {
+  const openAuthDialog = useCallback((options?: AuthDialogOptions) => {
     setAuthDialogOptions(options ?? {});
     setIsLoginOpen(true);
-  }
+  }, []);
 
   // route guard redirect lands here with ?login=1, open the dialog and consume the flag
   useEffect(() => {

--- a/frontend/src/hooks/useBerthInvites.ts
+++ b/frontend/src/hooks/useBerthInvites.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiFetch } from "../lib/api";
+
+export type BerthInviteStatus =
+  | "pending"
+  | "accepted"
+  | "expired"
+  | "revoked"
+  | "rejected";
+
+export type BerthInvite = {
+  invite_id: string;
+  berth_id: string;
+  harbor_id: string;
+  email: string;
+  status: BerthInviteStatus;
+  created_at: string;
+  expires_at: string;
+  accepted_at?: string | null;
+};
+
+export type InviteByToken = {
+  invite_id: string;
+  berth_id: string;
+  berth_label: string;
+  harbor_id: string;
+  harbor_name: string;
+  email: string;
+  status: BerthInviteStatus;
+  expires_at: string;
+};
+
+async function readError(res: Response, fallback: string) {
+  try {
+    const data = await res.json();
+    return data.detail || data.message || data.error || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function useBerthInvites(harborId?: string | null) {
+  const [invites, setInvites] = useState<BerthInvite[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadInvites = useCallback(async () => {
+    if (!harborId) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const res = await apiFetch(
+        `/api/harbors/${harborId}/berth-invites?status=pending`,
+      );
+
+      if (!res.ok) {
+        throw new Error(await readError(res, "Could not load invites."));
+      }
+
+      setInvites(await res.json());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not load invites.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [harborId]);
+
+  useEffect(() => {
+    loadInvites();
+  }, [loadInvites]);
+
+  async function createInvite(berthId: string, email: string) {
+    if (!harborId) {
+      return { ok: false as const, error: "Missing harbor id." };
+    }
+
+    const res = await apiFetch(`/api/harbors/${harborId}/berth-invites`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ berth_id: berthId, email }),
+    });
+
+    if (!res.ok) {
+      return {
+        ok: false as const,
+        error: await readError(res, "Could not create invite."),
+      };
+    }
+
+    await loadInvites();
+    return { ok: true as const, invite: await res.json() };
+  }
+
+  async function revokeInvite(inviteId: string) {
+    if (!harborId) {
+      return { ok: false as const, error: "Missing harbor id." };
+    }
+
+    const res = await apiFetch(
+      `/api/harbors/${harborId}/berth-invites/${inviteId}`,
+      { method: "DELETE" },
+    );
+
+    if (!res.ok) {
+      return {
+        ok: false as const,
+        error: await readError(res, "Could not revoke invite."),
+      };
+    }
+
+    await loadInvites();
+    return { ok: true as const };
+  }
+
+  return {
+    invites,
+    isLoading,
+    error,
+    loadInvites,
+    createInvite,
+    revokeInvite,
+  };
+}
+
+export async function getInviteByToken(token: string) {
+  const res = await apiFetch(`/api/berth-invites/by-token/${token}`);
+
+  if (!res.ok) {
+    return {
+      ok: false as const,
+      status: res.status,
+      error: await readError(res, "Could not load invite."),
+    };
+  }
+
+  return { ok: true as const, invite: (await res.json()) as InviteByToken };
+}
+
+export async function acceptInviteByToken(token: string) {
+  const res = await apiFetch(`/api/berth-invites/by-token/${token}/accept`, {
+    method: "POST",
+  });
+
+  if (!res.ok) {
+    return {
+      ok: false as const,
+      status: res.status,
+      error: await readError(res, "Could not accept invite."),
+    };
+  }
+
+  return { ok: true as const, data: await res.json() };
+}
+
+export async function rejectInviteByToken(token: string) {
+  const res = await apiFetch(`/api/berth-invites/by-token/${token}/reject`, {
+    method: "POST",
+  });
+
+  if (!res.ok) {
+    return {
+      ok: false as const,
+      status: res.status,
+      error: await readError(res, "Could not reject invite."),
+    };
+  }
+
+  return { ok: true as const, data: await res.json() };
+}

--- a/frontend/src/hooks/useBerthInvites.ts
+++ b/frontend/src/hooks/useBerthInvites.ts
@@ -11,23 +11,19 @@ export type BerthInviteStatus =
 export type BerthInvite = {
   invite_id: string;
   berth_id: string;
+  berth_label?: string | null;
   harbor_id: string;
+  harbor_name?: string | null;
   email: string;
   status: BerthInviteStatus;
-  created_at: string;
   expires_at: string;
-  accepted_at?: string | null;
 };
 
-export type InviteByToken = {
-  invite_id: string;
-  berth_id: string;
-  berth_label: string;
-  harbor_id: string;
-  harbor_name: string;
-  email: string;
-  status: BerthInviteStatus;
-  expires_at: string;
+export type InviteByToken = BerthInvite;
+
+type ListResponse = {
+  items: BerthInvite[];
+  total: number;
 };
 
 async function readError(res: Response, fallback: string) {
@@ -39,8 +35,18 @@ async function readError(res: Response, fallback: string) {
   }
 }
 
-export function useBerthInvites(harborId?: string | null) {
+interface UseBerthInvitesOptions {
+  enabled?: boolean;
+  status?: BerthInviteStatus;
+}
+
+export function useBerthInvites(
+  harborId?: string | null,
+  options: UseBerthInvitesOptions = {},
+) {
+  const { enabled = true, status } = options;
   const [invites, setInvites] = useState<BerthInvite[]>([]);
+  const [total, setTotal] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -50,78 +56,80 @@ export function useBerthInvites(harborId?: string | null) {
     setIsLoading(true);
     setError(null);
 
+    const params = new URLSearchParams();
+    if (status) params.set("status", status);
+    const qs = params.toString();
+    const url = `/api/harbors/${harborId}/berth-invites${qs ? `?${qs}` : ""}`;
+
     try {
-      const res = await apiFetch(
-        `/api/harbors/${harborId}/berth-invites?status=pending`,
-      );
+      const res = await apiFetch(url);
 
       if (!res.ok) {
         throw new Error(await readError(res, "Could not load invites."));
       }
 
-      setInvites(await res.json());
+      const data = (await res.json()) as ListResponse;
+      setInvites(data.items);
+      setTotal(data.total);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not load invites.");
     } finally {
       setIsLoading(false);
     }
-  }, [harborId]);
+  }, [harborId, status]);
 
   useEffect(() => {
+    if (!enabled) return;
     loadInvites();
-  }, [loadInvites]);
-
-  async function createInvite(berthId: string, email: string) {
-    if (!harborId) {
-      return { ok: false as const, error: "Missing harbor id." };
-    }
-
-    const res = await apiFetch(`/api/harbors/${harborId}/berth-invites`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ berth_id: berthId, email }),
-    });
-
-    if (!res.ok) {
-      return {
-        ok: false as const,
-        error: await readError(res, "Could not create invite."),
-      };
-    }
-
-    await loadInvites();
-    return { ok: true as const, invite: await res.json() };
-  }
-
-  async function revokeInvite(inviteId: string) {
-    if (!harborId) {
-      return { ok: false as const, error: "Missing harbor id." };
-    }
-
-    const res = await apiFetch(
-      `/api/harbors/${harborId}/berth-invites/${inviteId}`,
-      { method: "DELETE" },
-    );
-
-    if (!res.ok) {
-      return {
-        ok: false as const,
-        error: await readError(res, "Could not revoke invite."),
-      };
-    }
-
-    await loadInvites();
-    return { ok: true as const };
-  }
+  }, [enabled, loadInvites]);
 
   return {
     invites,
+    total,
     isLoading,
     error,
     loadInvites,
-    createInvite,
-    revokeInvite,
   };
+}
+
+export async function createInvite(
+  harborId: string,
+  berthId: string,
+  email: string,
+) {
+  const res = await apiFetch(`/api/harbors/${harborId}/berth-invites`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ berth_id: berthId, email }),
+  });
+
+  if (!res.ok) {
+    return {
+      ok: false as const,
+      error: await readError(res, "Could not create invite."),
+    };
+  }
+
+  return {
+    ok: true as const,
+    invite: (await res.json()) as BerthInvite,
+  };
+}
+
+export async function revokeInvite(harborId: string, inviteId: string) {
+  const res = await apiFetch(
+    `/api/harbors/${harborId}/berth-invites/${inviteId}`,
+    { method: "DELETE" },
+  );
+
+  if (!res.ok) {
+    return {
+      ok: false as const,
+      error: await readError(res, "Could not revoke invite."),
+    };
+  }
+
+  return { ok: true as const };
 }
 
 export async function getInviteByToken(token: string) {
@@ -152,6 +160,28 @@ export async function acceptInviteByToken(token: string) {
   }
 
   return { ok: true as const, data: await res.json() };
+}
+
+export type HarborUser = {
+  user_id: string;
+  firstname: string;
+  lastname: string;
+  email: string;
+};
+
+export async function searchHarborUsers(
+  harborId: string,
+  query: string,
+  limit = 8,
+): Promise<HarborUser[]> {
+  const params = new URLSearchParams();
+  if (query) params.set("q", query);
+  params.set("limit", String(limit));
+  const res = await apiFetch(
+    `/api/harbors/${harborId}/users?${params.toString()}`,
+  );
+  if (!res.ok) return [];
+  return (await res.json()) as HarborUser[];
 }
 
 export async function rejectInviteByToken(token: string) {

--- a/frontend/src/pages/AcceptBerthPage.tsx
+++ b/frontend/src/pages/AcceptBerthPage.tsx
@@ -76,8 +76,7 @@ export function AcceptBerthPage() {
   async function handleAccept() {
     if (!token || !invite) return;
 
-    const assignedBerthId = (user as { assigned_berth_id?: string | null })
-      ?.assigned_berth_id;
+    const assignedBerthId = user?.assigned_berth_id;
 
     if (
       assignedBerthId &&
@@ -101,7 +100,8 @@ export function AcceptBerthPage() {
 
     await refresh();
     toast.success("Berth invite accepted.");
-    navigate(`/${invite.harbor_id}`, { replace: true });
+    // root redirects to the configured marina dashboard via App.tsx
+    navigate("/", { replace: true });
   }
 
   async function handleReject() {
@@ -248,7 +248,11 @@ export function AcceptBerthPage() {
                     onClick={handleAccept}
                     className="rounded-2xl bg-gradient-to-r from-brand-blue to-brand-cyan px-6 py-4 text-xs font-black uppercase tracking-widest text-white"
                   >
-                    {isSubmitting ? "Working..." : "Accept"}
+                    {isSubmitting
+                      ? "Working..."
+                      : confirmRelease
+                        ? "Confirm release"
+                        : "Accept"}
                   </button>
                 </div>
               </div>

--- a/frontend/src/pages/AcceptBerthPage.tsx
+++ b/frontend/src/pages/AcceptBerthPage.tsx
@@ -1,0 +1,261 @@
+import { AlertTriangle, CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+  useNavigate,
+  useOutletContext,
+  useSearchParams,
+} from "react-router-dom";
+import { toast } from "sonner";
+import type { AuthOutletContext } from "../components/layout/MainLayout";
+import {
+  acceptInviteByToken,
+  getInviteByToken,
+  type InviteByToken,
+  rejectInviteByToken,
+} from "../hooks/useBerthInvites";
+import { useAuth } from "../lib/auth-context";
+
+function sameEmail(a?: string | null, b?: string | null) {
+  return (a ?? "").trim().toLowerCase() === (b ?? "").trim().toLowerCase();
+}
+
+export function AcceptBerthPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token");
+
+  const { user, openAuthDialog } = useOutletContext<AuthOutletContext>();
+  const { logout, refresh } = useAuth();
+
+  const [invite, setInvite] = useState<InviteByToken | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [confirmRelease, setConfirmRelease] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      if (!token) {
+        setError("Missing invite token.");
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      const result = await getInviteByToken(token);
+
+      if (!result.ok) {
+        setError(
+          result.status === 404
+            ? "This invite link does not exist."
+            : result.status === 410
+              ? "This invite is expired, revoked, rejected, or already used."
+              : result.error,
+        );
+        setIsLoading(false);
+        return;
+      }
+
+      setInvite(result.invite);
+      setIsLoading(false);
+    }
+
+    load();
+  }, [token]);
+
+  useEffect(() => {
+    if (!invite || user) return;
+
+    openAuthDialog({
+      prefillEmail: invite.email,
+      lockEmail: true,
+      defaultTab: "signup",
+    });
+  }, [invite, user, openAuthDialog]);
+
+  async function handleAccept() {
+    if (!token || !invite) return;
+
+    const assignedBerthId = (user as { assigned_berth_id?: string | null })
+      ?.assigned_berth_id;
+
+    if (
+      assignedBerthId &&
+      assignedBerthId !== invite.berth_id &&
+      !confirmRelease
+    ) {
+      setConfirmRelease(true);
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    const result = await acceptInviteByToken(token);
+
+    setIsSubmitting(false);
+
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    await refresh();
+    toast.success("Berth invite accepted.");
+    navigate(`/${invite.harbor_id}`, { replace: true });
+  }
+
+  async function handleReject() {
+    if (!token) return;
+
+    setIsSubmitting(true);
+    const result = await rejectInviteByToken(token);
+    setIsSubmitting(false);
+
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    toast.success("Invite rejected.");
+    navigate("/", { replace: true });
+  }
+
+  async function signOutAndContinue() {
+    await logout();
+    openAuthDialog({
+      prefillEmail: invite?.email,
+      lockEmail: true,
+      defaultTab: "signup",
+    });
+  }
+
+  return (
+    <div className="min-h-dvh bg-slate-50 px-4 py-16 font-body">
+      <div className="mx-auto max-w-xl rounded-[32px] border border-white bg-white/90 p-8 shadow-deep">
+        {isLoading ? (
+          <div className="flex flex-col items-center gap-4 py-12 text-brand-navy/50">
+            <Loader2 className="animate-spin" size={32} />
+            <p className="text-xs font-black uppercase tracking-widest">
+              Loading invite...
+            </p>
+          </div>
+        ) : error ? (
+          <div className="text-center">
+            <div className="mx-auto mb-4 grid h-16 w-16 place-items-center rounded-full bg-red-50 text-red-500">
+              <XCircle size={32} />
+            </div>
+            <h1 className="text-xl font-black text-brand-navy">
+              Invite unavailable
+            </h1>
+            <p className="mt-3 text-sm font-medium text-brand-navy/60">
+              {error}
+            </p>
+          </div>
+        ) : invite ? (
+          <div>
+            <div className="mb-6 text-center">
+              <div className="mx-auto mb-4 grid h-16 w-16 place-items-center rounded-full bg-brand-blue/10 text-brand-blue">
+                <CheckCircle2 size={32} />
+              </div>
+
+              <h1 className="text-2xl font-black uppercase tracking-tight text-brand-navy">
+                Berth Invitation
+              </h1>
+
+              <p className="mt-2 text-sm font-bold text-brand-navy/50">
+                You have been invited to claim a berth.
+              </p>
+            </div>
+
+            <div className="space-y-3 rounded-3xl bg-slate-50 p-5 text-sm">
+              <p>
+                <span className="font-black text-brand-navy">Harbor:</span>{" "}
+                {invite.harbor_name}
+              </p>
+              <p>
+                <span className="font-black text-brand-navy">Berth:</span>{" "}
+                {invite.berth_label}
+              </p>
+              <p>
+                <span className="font-black text-brand-navy">Invitee:</span>{" "}
+                {invite.email}
+              </p>
+              <p>
+                <span className="font-black text-brand-navy">Expires:</span>{" "}
+                {new Date(invite.expires_at).toLocaleString()}
+              </p>
+            </div>
+
+            {!user ? (
+              <div className="mt-6 rounded-2xl bg-brand-blue/5 p-4 text-center">
+                <p className="text-sm font-bold text-brand-navy/70">
+                  Sign up or log in with {invite.email} to continue.
+                </p>
+                <button
+                  type="button"
+                  onClick={() =>
+                    openAuthDialog({
+                      prefillEmail: invite.email,
+                      lockEmail: true,
+                      defaultTab: "signup",
+                    })
+                  }
+                  className="mt-4 rounded-full bg-brand-blue px-6 py-3 text-xs font-black uppercase tracking-widest text-white"
+                >
+                  Continue
+                </button>
+              </div>
+            ) : !sameEmail(user.email, invite.email) ? (
+              <div className="mt-6 rounded-2xl bg-yellow-50 p-4">
+                <p className="text-sm font-bold text-yellow-800">
+                  This invite is for {invite.email}, but you are signed in as{" "}
+                  {user.email}.
+                </p>
+
+                <button
+                  type="button"
+                  onClick={signOutAndContinue}
+                  className="mt-4 rounded-full bg-yellow-500 px-6 py-3 text-xs font-black uppercase tracking-widest text-white"
+                >
+                  Sign out and continue
+                </button>
+              </div>
+            ) : (
+              <div className="mt-6 space-y-4">
+                {confirmRelease && (
+                  <div className="flex gap-3 rounded-2xl bg-red-50 p-4 text-red-700">
+                    <AlertTriangle size={20} className="shrink-0" />
+                    <p className="text-sm font-bold">
+                      Accepting this invite will release your current berth.
+                      Press Accept again to confirm.
+                    </p>
+                  </div>
+                )}
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <button
+                    type="button"
+                    disabled={isSubmitting}
+                    onClick={handleReject}
+                    className="rounded-2xl border border-slate-200 px-6 py-4 text-xs font-black uppercase tracking-widest text-brand-navy/60"
+                  >
+                    Reject
+                  </button>
+
+                  <button
+                    type="button"
+                    disabled={isSubmitting}
+                    onClick={handleAccept}
+                    className="rounded-2xl bg-gradient-to-r from-brand-blue to-brand-cyan px-6 py-4 text-xs font-black uppercase tracking-widest text-white"
+                  >
+                    {isSubmitting ? "Working..." : "Accept"}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/InvitesSettings.tsx
+++ b/frontend/src/pages/InvitesSettings.tsx
@@ -1,0 +1,197 @@
+import { Loader2, RefreshCw, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useOutletContext, useParams } from "react-router-dom";
+import { toast } from "sonner";
+import type { AuthOutletContext } from "../components/layout/MainLayout";
+import {
+  type BerthInvite,
+  createInvite,
+  revokeInvite,
+  useBerthInvites,
+} from "../hooks/useBerthInvites";
+
+function statusBadgeClass(status: BerthInvite["status"]) {
+  switch (status) {
+    case "pending":
+      return "bg-amber-100 text-amber-700";
+    case "accepted":
+      return "bg-emerald-100 text-emerald-700";
+    case "rejected":
+    case "revoked":
+      return "bg-slate-100 text-slate-600";
+    case "expired":
+      return "bg-red-50 text-red-600";
+  }
+}
+
+function InvitesSettings() {
+  const { user } = useOutletContext<AuthOutletContext>();
+  const { marinaSlug } = useParams<{ marinaSlug: string }>();
+  // BerthDetailPanel uses the same fallback so we stay consistent
+  const harborId =
+    (user as { harbor_id?: string | null } | null)?.harbor_id ??
+    marinaSlug ??
+    null;
+
+  const { invites, isLoading, error, loadInvites } = useBerthInvites(harborId, {
+    enabled: Boolean(harborId),
+  });
+
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  useEffect(() => {
+    document.title = "Berth invites | DockPulse";
+  }, []);
+
+  if (!user || user.role !== "harbormaster") {
+    return (
+      <main className="mx-auto max-w-2xl px-4 pt-24 pb-20 lg:pt-36">
+        <h1 className="text-3xl font-semibold text-brand-navy">
+          Berth invites
+        </h1>
+        <p className="mt-2 text-brand-navy/60">Harbormaster role required.</p>
+      </main>
+    );
+  }
+
+  async function handleRevoke(invite: BerthInvite) {
+    if (!harborId) return;
+    setBusyId(invite.invite_id);
+    const result = await revokeInvite(harborId, invite.invite_id);
+    setBusyId(null);
+    if (!result.ok) {
+      toast.error(result.error);
+      return;
+    }
+    toast.success("Invite revoked.");
+    await loadInvites();
+  }
+
+  async function handleResend(invite: BerthInvite) {
+    if (!harborId) return;
+    setBusyId(invite.invite_id);
+    // resend = revoke prior + create new with same email/berth
+    const revoked = await revokeInvite(harborId, invite.invite_id);
+    if (!revoked.ok) {
+      setBusyId(null);
+      toast.error(revoked.error);
+      return;
+    }
+    const created = await createInvite(harborId, invite.berth_id, invite.email);
+    setBusyId(null);
+    if (!created.ok) {
+      toast.error(created.error);
+      return;
+    }
+    toast.success("Invite resent.");
+    await loadInvites();
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 pt-24 pb-20 lg:pt-36">
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold text-brand-navy">
+            Berth invites
+          </h1>
+          <p className="mt-1 text-brand-navy/60">
+            Track outstanding invitations to claim berths.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => loadInvites()}
+          className="rounded-full bg-brand-navy/5 p-2 text-brand-navy/60 transition-colors hover:bg-brand-navy/10"
+          aria-label="Refresh invites"
+        >
+          <RefreshCw size={16} />
+        </button>
+      </div>
+
+      {isLoading && invites.length === 0 ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="animate-spin text-brand-navy/40" size={24} />
+        </div>
+      ) : error ? (
+        <p className="rounded-xl bg-red-50 p-4 text-sm font-bold text-red-600">
+          {error}
+        </p>
+      ) : invites.length === 0 ? (
+        <p className="rounded-2xl border border-slate-200 bg-white p-12 text-center text-sm font-bold text-brand-navy/40">
+          No invites yet.
+        </p>
+      ) : (
+        <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-slate-50 text-[10px] font-black uppercase tracking-widest text-brand-navy/60">
+              <tr>
+                <th className="px-4 py-3">Berth</th>
+                <th className="px-4 py-3">Invitee</th>
+                <th className="px-4 py-3">Expires</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {invites.map((invite) => {
+                const isBusy = busyId === invite.invite_id;
+                const canAct = invite.status === "pending";
+                return (
+                  <tr key={invite.invite_id}>
+                    <td className="px-4 py-3 font-bold text-brand-navy">
+                      {invite.berth_label || invite.berth_id}
+                    </td>
+                    <td className="px-4 py-3 text-brand-navy/70">
+                      {invite.email}
+                    </td>
+                    <td className="px-4 py-3 text-brand-navy/70">
+                      {new Date(invite.expires_at).toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`rounded-full px-2 py-1 text-[10px] font-black uppercase tracking-widest ${statusBadgeClass(
+                          invite.status,
+                        )}`}
+                      >
+                        {invite.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      {canAct ? (
+                        <div className="flex justify-end gap-2">
+                          <button
+                            type="button"
+                            disabled={isBusy}
+                            onClick={() => handleResend(invite)}
+                            className="rounded-full bg-brand-blue/10 px-3 py-1.5 text-[10px] font-black uppercase tracking-widest text-brand-blue transition-colors hover:bg-brand-blue/20 disabled:opacity-50"
+                          >
+                            Resend
+                          </button>
+                          <button
+                            type="button"
+                            disabled={isBusy}
+                            onClick={() => handleRevoke(invite)}
+                            className="grid h-7 w-7 place-items-center rounded-full bg-red-500/10 text-red-500 transition-colors hover:bg-red-500/20 disabled:opacity-50"
+                            aria-label="Revoke invite"
+                          >
+                            <Trash2 size={12} />
+                          </button>
+                        </div>
+                      ) : (
+                        <span className="text-[10px] font-bold text-brand-navy/30">
+                          —
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </main>
+  );
+}
+
+export { InvitesSettings };

--- a/frontend/src/test/Dashboard.test.tsx
+++ b/frontend/src/test/Dashboard.test.tsx
@@ -11,6 +11,7 @@ const anonymousOutletContext: AuthOutletContext = {
   user: null,
   isLoginOpen: false,
   setIsLoginOpen: () => {},
+  openAuthDialog: () => {},
 };
 
 function OutletShell() {


### PR DESCRIPTION
## Summary

This PR deals with Harbor Master sending ownership invites to users, they can also remove ownership.

## Related Issue

Closes #73 
Closes #174 
Closes #176 

## Changes

- Harbor master can send ownerships to users via writing their emails in a new modal
- Harbor Master can also remove ownership of a berth by pressing the ownership information on berth details
- QR code works
- Menus don't stack over each other

## Checklist

- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [x] All existing tests pass
- [x] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
