### PR TITLE
fix(backend): booking totals, invite revoke audit, role filter, resolved_by rename

### DIFF
--- a/backend/alembic/versions/a9c3f1d8e502_rename_berth_invite_accepted_to_resolved.py
+++ b/backend/alembic/versions/a9c3f1d8e502_rename_berth_invite_accepted_to_resolved.py
@@ -1,0 +1,26 @@
+"""rename berth_invites accepted_by/at to resolved_by/at
+
+Revision ID: a9c3f1d8e502
+Revises: b6f12e9c8d44
+Create Date: 2026-05-15 00:00:00.000000
+
+accepted_by and accepted_at were reused for reject flows, making the column
+names misleading. resolved_by/resolved_at cover accept, reject, and revoke.
+"""
+
+from alembic import op
+
+revision = "a9c3f1d8e502"
+down_revision = "b6f12e9c8d44"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("berth_invites", "accepted_by", new_column_name="resolved_by")
+    op.alter_column("berth_invites", "accepted_at", new_column_name="resolved_at")
+
+
+def downgrade() -> None:
+    op.alter_column("berth_invites", "resolved_by", new_column_name="accepted_by")
+    op.alter_column("berth_invites", "resolved_at", new_column_name="accepted_at")

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -63,7 +63,8 @@ async def user_managed_harbor_ids(user: User, session: AsyncSession) -> set[str]
 async def user_is_harbormaster(user: User, session: AsyncSession) -> bool:
     row = await session.execute(
         select(UserHarborRole.user_id)
-        .where(UserHarborRole.user_id == user.user_id, UserHarborRole.role == "harbormaster")
+        .where(UserHarborRole.user_id == user.user_id,
+        UserHarborRole.role == "harbormaster")
         .limit(1)
     )
     return row.scalar_one_or_none() is not None

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -63,8 +63,10 @@ async def user_managed_harbor_ids(user: User, session: AsyncSession) -> set[str]
 async def user_is_harbormaster(user: User, session: AsyncSession) -> bool:
     row = await session.execute(
         select(UserHarborRole.user_id)
-        .where(UserHarborRole.user_id == user.user_id,
-        UserHarborRole.role == "harbormaster")
+        .where(
+            UserHarborRole.user_id == user.user_id,
+            UserHarborRole.role == "harbormaster",
+        )
         .limit(1)
     )
     return row.scalar_one_or_none() is not None

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -63,7 +63,7 @@ async def user_managed_harbor_ids(user: User, session: AsyncSession) -> set[str]
 async def user_is_harbormaster(user: User, session: AsyncSession) -> bool:
     row = await session.execute(
         select(UserHarborRole.user_id)
-        .where(UserHarborRole.user_id == user.user_id)
+        .where(UserHarborRole.user_id == user.user_id, UserHarborRole.role == "harbormaster")
         .limit(1)
     )
     return row.scalar_one_or_none() is not None

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -87,9 +87,9 @@ class User(Base):
         cascade="all, delete-orphan",
         foreign_keys="[BerthInvite.created_by]",
     )
-    accepted_invites: Mapped[list["BerthInvite"]] = relationship(
-        back_populates="acceptor",
-        foreign_keys="[BerthInvite.accepted_by]",
+    resolved_invites: Mapped[list["BerthInvite"]] = relationship(
+        back_populates="resolver",
+        foreign_keys="[BerthInvite.resolved_by]",
     )
     bookings: Mapped[list["Booking"]] = relationship(
         back_populates="user",
@@ -163,10 +163,10 @@ class BerthInvite(Base):
     status: Mapped[str] = mapped_column(
         berth_invite_status_enum, nullable=False, default="pending"
     )
-    accepted_by: Mapped[str | None] = mapped_column(
+    resolved_by: Mapped[str | None] = mapped_column(
         ForeignKey("users.user_id", ondelete="SET NULL"), nullable=True
     )
-    accepted_at: Mapped[datetime | None] = mapped_column(
+    resolved_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
 
@@ -174,8 +174,8 @@ class BerthInvite(Base):
     creator: Mapped["User"] = relationship(
         back_populates="created_invites", foreign_keys=[created_by]
     )
-    acceptor: Mapped["User | None"] = relationship(
-        back_populates="accepted_invites", foreign_keys=[accepted_by]
+    resolver: Mapped["User | None"] = relationship(
+        back_populates="resolved_invites", foreign_keys=[resolved_by]
     )
 
 

--- a/backend/app/routers/bookings.py
+++ b/backend/app/routers/bookings.py
@@ -361,15 +361,12 @@ async def list_my_bookings(
         stmt = stmt.where(Booking.to_date > from_date)
     if to_date is not None:
         stmt = stmt.where(Booking.from_date < to_date)
-    stmt = stmt.order_by(Booking.from_date.desc())
 
-    items = list((await session.execute(stmt)).scalars().all())
+    items = list(
+        (await session.execute(stmt.order_by(Booking.from_date.desc()))).scalars().all()
+    )
     total = (
-        await session.scalar(
-            select(func.count(Booking.booking_id)).where(
-                Booking.user_id == current_user.user_id
-            )
-        )
+        await session.scalar(stmt.with_only_columns(func.count(Booking.booking_id)))
     ) or 0
     return BookingList(items=items, total=total)
 
@@ -457,13 +454,12 @@ async def list_berth_bookings(
         stmt = stmt.where(Booking.to_date > from_date)
     if to_date is not None:
         stmt = stmt.where(Booking.from_date < to_date)
-    stmt = stmt.order_by(Booking.from_date.desc())
-    items = list((await session.execute(stmt)).scalars().all())
 
+    items = list(
+        (await session.execute(stmt.order_by(Booking.from_date.desc()))).scalars().all()
+    )
     total = (
-        await session.scalar(
-            select(func.count(Booking.booking_id)).where(Booking.berth_id == berth_id)
-        )
+        await session.scalar(stmt.with_only_columns(func.count(Booking.booking_id)))
     ) or 0
     return BookingList(items=items, total=total)
 
@@ -499,17 +495,13 @@ async def list_harbor_bookings(
         stmt = stmt.where(Booking.to_date > from_date)
     if to_date is not None:
         stmt = stmt.where(Booking.from_date < to_date)
-    stmt = stmt.order_by(Booking.from_date.desc())
 
-    items = list((await session.execute(stmt)).scalars().all())
-
-    total_stmt = (
-        select(func.count(Booking.booking_id))
-        .join(Berth, Berth.berth_id == Booking.berth_id)
-        .join(Dock, Dock.dock_id == Berth.dock_id)
-        .where(Dock.harbor_id == harbor_id)
+    items = list(
+        (await session.execute(stmt.order_by(Booking.from_date.desc()))).scalars().all()
     )
-    total = (await session.scalar(total_stmt)) or 0
+    total = (
+        await session.scalar(stmt.with_only_columns(func.count(Booking.booking_id)))
+    ) or 0
     return BookingList(items=items, total=total)
 
 

--- a/backend/app/routers/invites.py
+++ b/backend/app/routers/invites.py
@@ -280,8 +280,8 @@ async def accept_berth_invite(
         )
         .values(
             status="accepted",
-            accepted_by=current_user.user_id,
-            accepted_at=now,
+            resolved_by=current_user.user_id,
+            resolved_at=now,
         )
         .returning(BerthInvite)
     )

--- a/backend/app/routers/invites.py
+++ b/backend/app/routers/invites.py
@@ -346,7 +346,7 @@ async def reject_berth_invite(
             BerthInvite.invite_id == invite.invite_id,
             BerthInvite.status == "pending",
         )
-        .values(status="rejected", accepted_by=current_user.user_id, accepted_at=now)
+        .values(status="rejected", resolved_by=current_user.user_id, resolved_at=now)
         .returning(BerthInvite)
     )
     rejected = result.scalar_one_or_none()
@@ -380,7 +380,9 @@ async def delete_berth_invite(
     if invite is None:
         raise HTTPException(status_code=404, detail="Invite not found")
     if invite.status != "pending":
-        raise HTTPException(status_code=409, detail="Only pending invites can be revoked")
+        raise HTTPException(
+            status_code=409, detail="Only pending invites can be revoked"
+        )
     invite.status = "revoked"
     await session.commit()
 

--- a/backend/app/routers/invites.py
+++ b/backend/app/routers/invites.py
@@ -379,7 +379,9 @@ async def delete_berth_invite(
     ).scalar_one_or_none()
     if invite is None:
         raise HTTPException(status_code=404, detail="Invite not found")
-    await session.delete(invite)
+    if invite.status != "pending":
+        raise HTTPException(status_code=409, detail="Only pending invites can be revoked")
+    invite.status = "revoked"
     await session.commit()
 
 

--- a/backend/tests/test_berth_invites.py
+++ b/backend/tests/test_berth_invites.py
@@ -284,7 +284,7 @@ async def test_list_invites_requires_harbormaster(
     assert r.status_code == 403
 
 
-async def test_delete_invite_removes_row(
+async def test_delete_invite_sets_revoked(
     client: AsyncClient, seeded_berth, harbor_master, captured_emails, session
 ):
     await _create_invite(client, harbor_master)
@@ -294,8 +294,8 @@ async def test_delete_invite_removes_row(
         cookies=_hm_cookies(harbor_master),
     )
     assert r.status_code == 204
-    remaining = (await session.execute(select(BerthInvite))).scalars().all()
-    assert remaining == []
+    await session.refresh(invite)
+    assert invite.status == "revoked"
 
 
 async def test_delete_invite_unknown_returns_404(


### PR DESCRIPTION
## Summary

### Backend suggested fixes/improvements found during code review:
- Invite revoke now soft-deletes (status="revoked") instead of hard-deleting the row. Preserves audit history. Guards with 409 if invite is not pending.

- Booking list endpoints (me, berth, harbor) returned a total that ignored applied filters. Now uses the same statement via with_only_columns. (with_only_columns swaps the SELECT clause to count(booking_id) on already filtered statement, so that the total is guaranteed to reflect the same WHERE conditions as the returned items.)

- user_is_harbormaster was missing role="harbormaster" in WHERE clause.  Fixed to match the intent of the function and guard against future role additions.

## Checklist
- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [x] All existing tests pass
- [x] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
